### PR TITLE
Docs: chain verification commands for single-line copy-paste

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -71,16 +71,7 @@ This is a high-performance library. Optimize aggressively.
 All must pass without warnings:
 
 ```bash
-# Test async mode (default)
-cargo build -p llm-coding-tools-core && cargo build -p llm-coding-tools-rig --quiet
-cargo test -p llm-coding-tools-core && cargo test -p llm-coding-tools-rig --quiet
-cargo clippy -p llm-coding-tools-core && cargo clippy -p llm-coding-tools-rig --quiet -- -D warnings
-
-# Test blocking mode (llm-coding-tools-core only, rig is inherently async)
-cargo test -p llm-coding-tools-core --no-default-features --features blocking --quiet
-
-cargo doc --workspace --no-deps --quiet
-cargo fmt --all --quiet
+cargo build -p llm-coding-tools-core && cargo build -p llm-coding-tools-rig --quiet && cargo test -p llm-coding-tools-core && cargo test -p llm-coding-tools-rig --quiet && cargo clippy -p llm-coding-tools-core && cargo clippy -p llm-coding-tools-rig --quiet -- -D warnings && cargo test -p llm-coding-tools-core --no-default-features --features blocking --quiet && cargo doc --workspace --no-deps --quiet && cargo fmt --all --quiet
 ```
 
 Note: `llm-coding-tools-rig` is async-only (implements rig's async `Tool` trait).
@@ -88,6 +79,5 @@ The `blocking` feature only applies to `llm-coding-tools-core`.
 
 For individual crates:
 ```bash
-cargo publish --dry-run -p llm-coding-tools-core --quiet
-cargo publish --dry-run -p llm-coding-tools-rig --quiet
+cargo publish --dry-run -p llm-coding-tools-core --quiet && cargo publish --dry-run -p llm-coding-tools-rig --quiet
 ```


### PR DESCRIPTION
## Summary
- Merged all verification commands into single `&&`-chained lines
- Reduces tool calls for LLM agents running verification