### PR TITLE
Docs: treat clippy warnings as errors for both crates

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -71,7 +71,7 @@ This is a high-performance library. Optimize aggressively.
 All must pass without warnings:
 
 ```bash
-cargo build -p llm-coding-tools-core && cargo build -p llm-coding-tools-rig --quiet && cargo test -p llm-coding-tools-core && cargo test -p llm-coding-tools-rig --quiet && cargo clippy -p llm-coding-tools-core && cargo clippy -p llm-coding-tools-rig --quiet -- -D warnings && cargo test -p llm-coding-tools-core --no-default-features --features blocking --quiet && cargo doc --workspace --no-deps --quiet && cargo fmt --all --quiet
+cargo build -p llm-coding-tools-core && cargo build -p llm-coding-tools-rig --quiet && cargo test -p llm-coding-tools-core && cargo test -p llm-coding-tools-rig --quiet && cargo clippy -p llm-coding-tools-core -- -D warnings && cargo clippy -p llm-coding-tools-rig --quiet -- -D warnings && cargo test -p llm-coding-tools-core --no-default-features --features blocking --quiet && cargo doc --workspace --no-deps --quiet && cargo fmt --all
 ```
 
 Note: `llm-coding-tools-rig` is async-only (implements rig's async `Tool` trait).


### PR DESCRIPTION
## Summary
- Add `-D warnings` to `cargo clippy -p llm-coding-tools-core` so both crates treat warnings as errors