### PR TITLE
Added: tool_names module with constants for all tool names

### DIFF
--- a/src/llm-coding-tools-core/src/lib.rs
+++ b/src/llm-coding-tools-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod operations;
 pub mod output;
 pub mod path;
 pub mod preamble;
+pub mod tool_names;
 pub mod util;
 
 pub use context::ToolContext;

--- a/src/llm-coding-tools-core/src/tool_names.rs
+++ b/src/llm-coding-tools-core/src/tool_names.rs
@@ -1,0 +1,22 @@
+//! Canonical tool name constants for consistent naming across crates.
+
+/// The "Read" tool name constant.
+pub const READ: &str = "Read";
+/// The "Write" tool name constant.
+pub const WRITE: &str = "Write";
+/// The "Edit" tool name constant.
+pub const EDIT: &str = "Edit";
+/// The "Glob" tool name constant.
+pub const GLOB: &str = "Glob";
+/// The "Grep" tool name constant.
+pub const GREP: &str = "Grep";
+/// The "Bash" tool name constant.
+pub const BASH: &str = "Bash";
+/// The "WebFetch" tool name constant.
+pub const WEBFETCH: &str = "WebFetch";
+/// The "Task" tool name constant.
+pub const TASK: &str = "Task";
+/// The "TodoWrite" tool name constant.
+pub const TODO_WRITE: &str = "TodoWrite";
+/// The "TodoRead" tool name constant.
+pub const TODO_READ: &str = "TodoRead";

--- a/src/llm-coding-tools-rig/src/absolute/edit.rs
+++ b/src/llm-coding-tools-rig/src/absolute/edit.rs
@@ -2,6 +2,7 @@
 
 use llm_coding_tools_core::operations::edit_file;
 use llm_coding_tools_core::path::AbsolutePathResolver;
+use llm_coding_tools_core::tool_names;
 pub use llm_coding_tools_core::EditError;
 use llm_coding_tools_core::ToolContext;
 use rig::completion::ToolDefinition;
@@ -36,7 +37,7 @@ impl EditTool {
 }
 
 impl Tool for EditTool {
-    const NAME: &'static str = "Edit";
+    const NAME: &'static str = tool_names::EDIT;
 
     type Error = EditError;
     type Args = EditArgs;
@@ -67,7 +68,7 @@ impl Tool for EditTool {
 }
 
 impl ToolContext for EditTool {
-    const NAME: &'static str = "Edit";
+    const NAME: &'static str = tool_names::EDIT;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::EDIT_ABSOLUTE

--- a/src/llm-coding-tools-rig/src/absolute/glob.rs
+++ b/src/llm-coding-tools-rig/src/absolute/glob.rs
@@ -2,6 +2,7 @@
 
 use llm_coding_tools_core::operations::glob_files;
 use llm_coding_tools_core::path::AbsolutePathResolver;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{GlobOutput, ToolContext, ToolError};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
@@ -30,7 +31,7 @@ impl GlobTool {
 }
 
 impl Tool for GlobTool {
-    const NAME: &'static str = "Glob";
+    const NAME: &'static str = tool_names::GLOB;
 
     type Error = ToolError;
     type Args = GlobArgs;
@@ -54,7 +55,7 @@ impl Tool for GlobTool {
 }
 
 impl ToolContext for GlobTool {
-    const NAME: &'static str = "Glob";
+    const NAME: &'static str = tool_names::GLOB;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::GLOB_ABSOLUTE

--- a/src/llm-coding-tools-rig/src/absolute/grep.rs
+++ b/src/llm-coding-tools-rig/src/absolute/grep.rs
@@ -2,6 +2,7 @@
 
 use llm_coding_tools_core::operations::{grep_search, DEFAULT_MAX_LINE_LENGTH};
 use llm_coding_tools_core::path::AbsolutePathResolver;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolContext, ToolError, ToolOutput};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
@@ -43,7 +44,7 @@ impl<const LINE_NUMBERS: bool> GrepTool<LINE_NUMBERS> {
 }
 
 impl<const LINE_NUMBERS: bool> Tool for GrepTool<LINE_NUMBERS> {
-    const NAME: &'static str = "Grep";
+    const NAME: &'static str = tool_names::GREP;
 
     type Error = ToolError;
     type Args = GrepArgs;
@@ -107,7 +108,7 @@ impl<const LINE_NUMBERS: bool> Tool for GrepTool<LINE_NUMBERS> {
 }
 
 impl<const LINE_NUMBERS: bool> ToolContext for GrepTool<LINE_NUMBERS> {
-    const NAME: &'static str = "Grep";
+    const NAME: &'static str = tool_names::GREP;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::GREP_ABSOLUTE

--- a/src/llm-coding-tools-rig/src/absolute/read.rs
+++ b/src/llm-coding-tools-rig/src/absolute/read.rs
@@ -2,6 +2,7 @@
 
 use llm_coding_tools_core::operations::read_file;
 use llm_coding_tools_core::path::AbsolutePathResolver;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolContext, ToolError, ToolOutput};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
@@ -45,7 +46,7 @@ impl<const LINE_NUMBERS: bool> ReadTool<LINE_NUMBERS> {
 }
 
 impl<const LINE_NUMBERS: bool> Tool for ReadTool<LINE_NUMBERS> {
-    const NAME: &'static str = "Read";
+    const NAME: &'static str = tool_names::READ;
 
     type Error = ToolError;
     type Args = ReadArgs;
@@ -72,7 +73,7 @@ impl<const LINE_NUMBERS: bool> Tool for ReadTool<LINE_NUMBERS> {
 }
 
 impl<const LINE_NUMBERS: bool> ToolContext for ReadTool<LINE_NUMBERS> {
-    const NAME: &'static str = "Read";
+    const NAME: &'static str = tool_names::READ;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::READ_ABSOLUTE

--- a/src/llm-coding-tools-rig/src/absolute/write.rs
+++ b/src/llm-coding-tools-rig/src/absolute/write.rs
@@ -2,6 +2,7 @@
 
 use llm_coding_tools_core::operations::write_file;
 use llm_coding_tools_core::path::AbsolutePathResolver;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolContext, ToolError};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
@@ -30,7 +31,7 @@ impl WriteTool {
 }
 
 impl Tool for WriteTool {
-    const NAME: &'static str = "Write";
+    const NAME: &'static str = tool_names::WRITE;
 
     type Error = ToolError;
     type Args = WriteToolArgs;
@@ -54,7 +55,7 @@ impl Tool for WriteTool {
 }
 
 impl ToolContext for WriteTool {
-    const NAME: &'static str = "Write";
+    const NAME: &'static str = tool_names::WRITE;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::WRITE_ABSOLUTE

--- a/src/llm-coding-tools-rig/src/allowed/edit.rs
+++ b/src/llm-coding-tools-rig/src/allowed/edit.rs
@@ -2,6 +2,7 @@
 
 use llm_coding_tools_core::operations::edit_file;
 use llm_coding_tools_core::path::AllowedPathResolver;
+use llm_coding_tools_core::tool_names;
 pub use llm_coding_tools_core::EditError;
 use llm_coding_tools_core::{ToolContext, ToolResult};
 use rig::completion::ToolDefinition;
@@ -45,7 +46,7 @@ impl EditTool {
 }
 
 impl Tool for EditTool {
-    const NAME: &'static str = "Edit";
+    const NAME: &'static str = tool_names::EDIT;
 
     type Error = EditError;
     type Args = EditArgs;
@@ -75,7 +76,7 @@ impl Tool for EditTool {
 }
 
 impl ToolContext for EditTool {
-    const NAME: &'static str = "Edit";
+    const NAME: &'static str = tool_names::EDIT;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::EDIT_ALLOWED

--- a/src/llm-coding-tools-rig/src/allowed/glob.rs
+++ b/src/llm-coding-tools-rig/src/allowed/glob.rs
@@ -2,6 +2,7 @@
 
 use llm_coding_tools_core::operations::glob_files;
 use llm_coding_tools_core::path::AllowedPathResolver;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{GlobOutput, ToolContext, ToolError, ToolResult};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
@@ -39,7 +40,7 @@ impl GlobTool {
 }
 
 impl Tool for GlobTool {
-    const NAME: &'static str = "Glob";
+    const NAME: &'static str = tool_names::GLOB;
 
     type Error = ToolError;
     type Args = GlobArgs;
@@ -62,7 +63,7 @@ impl Tool for GlobTool {
 }
 
 impl ToolContext for GlobTool {
-    const NAME: &'static str = "Glob";
+    const NAME: &'static str = tool_names::GLOB;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::GLOB_ALLOWED

--- a/src/llm-coding-tools-rig/src/allowed/grep.rs
+++ b/src/llm-coding-tools-rig/src/allowed/grep.rs
@@ -2,6 +2,7 @@
 
 use llm_coding_tools_core::operations::{grep_search, DEFAULT_MAX_LINE_LENGTH};
 use llm_coding_tools_core::path::AllowedPathResolver;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolContext, ToolError, ToolOutput, ToolResult};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
@@ -52,7 +53,7 @@ impl<const LINE_NUMBERS: bool> GrepTool<LINE_NUMBERS> {
 }
 
 impl<const LINE_NUMBERS: bool> Tool for GrepTool<LINE_NUMBERS> {
-    const NAME: &'static str = "Grep";
+    const NAME: &'static str = tool_names::GREP;
 
     type Error = ToolError;
     type Args = GrepArgs;
@@ -110,7 +111,7 @@ impl<const LINE_NUMBERS: bool> Tool for GrepTool<LINE_NUMBERS> {
 }
 
 impl<const LINE_NUMBERS: bool> ToolContext for GrepTool<LINE_NUMBERS> {
-    const NAME: &'static str = "Grep";
+    const NAME: &'static str = tool_names::GREP;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::GREP_ALLOWED

--- a/src/llm-coding-tools-rig/src/allowed/read.rs
+++ b/src/llm-coding-tools-rig/src/allowed/read.rs
@@ -2,6 +2,7 @@
 
 use llm_coding_tools_core::operations::read_file;
 use llm_coding_tools_core::path::AllowedPathResolver;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolContext, ToolError, ToolOutput, ToolResult};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
@@ -56,7 +57,7 @@ impl<const LINE_NUMBERS: bool> ReadTool<LINE_NUMBERS> {
 }
 
 impl<const LINE_NUMBERS: bool> Tool for ReadTool<LINE_NUMBERS> {
-    const NAME: &'static str = "Read";
+    const NAME: &'static str = tool_names::READ;
 
     type Error = ToolError;
     type Args = ReadArgs;
@@ -84,7 +85,7 @@ impl<const LINE_NUMBERS: bool> Tool for ReadTool<LINE_NUMBERS> {
 }
 
 impl<const LINE_NUMBERS: bool> ToolContext for ReadTool<LINE_NUMBERS> {
-    const NAME: &'static str = "Read";
+    const NAME: &'static str = tool_names::READ;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::READ_ALLOWED

--- a/src/llm-coding-tools-rig/src/allowed/write.rs
+++ b/src/llm-coding-tools-rig/src/allowed/write.rs
@@ -2,6 +2,7 @@
 
 use llm_coding_tools_core::operations::write_file;
 use llm_coding_tools_core::path::AllowedPathResolver;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolContext, ToolError, ToolResult};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
@@ -39,7 +40,7 @@ impl WriteTool {
 }
 
 impl Tool for WriteTool {
-    const NAME: &'static str = "Write";
+    const NAME: &'static str = tool_names::WRITE;
 
     type Error = ToolError;
     type Args = WriteToolArgs;
@@ -62,7 +63,7 @@ impl Tool for WriteTool {
 }
 
 impl ToolContext for WriteTool {
-    const NAME: &'static str = "Write";
+    const NAME: &'static str = tool_names::WRITE;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::WRITE_ALLOWED

--- a/src/llm-coding-tools-rig/src/bash.rs
+++ b/src/llm-coding-tools-rig/src/bash.rs
@@ -3,6 +3,7 @@
 //! Provides cross-platform shell command execution with timeout support.
 
 use llm_coding_tools_core::operations::execute_command;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolContext, ToolError, ToolOutput};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
@@ -45,7 +46,7 @@ impl BashTool {
 }
 
 impl Tool for BashTool {
-    const NAME: &'static str = "Bash";
+    const NAME: &'static str = tool_names::BASH;
 
     type Error = ToolError;
     type Args = BashArgs;
@@ -71,7 +72,7 @@ impl Tool for BashTool {
 }
 
 impl ToolContext for BashTool {
-    const NAME: &'static str = "Bash";
+    const NAME: &'static str = tool_names::BASH;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::BASH

--- a/src/llm-coding-tools-rig/src/lib.rs
+++ b/src/llm-coding-tools-rig/src/lib.rs
@@ -68,6 +68,7 @@ pub use webfetch::{WebFetchArgs, WebFetchTool};
 #[cfg(test)]
 mod tests {
     use super::*;
+    use llm_coding_tools_core::tool_names;
 
     #[test]
     fn preamble_builder_with_real_tools() {
@@ -82,7 +83,10 @@ mod tests {
         assert!(preamble.contains("absolute path")); // From READ_ABSOLUTE
 
         // Tools are returned unchanged
-        assert_eq!(<absolute::ReadTool<true> as rig::tool::Tool>::NAME, "Read");
+        assert_eq!(
+            <absolute::ReadTool<true> as rig::tool::Tool>::NAME,
+            tool_names::READ
+        );
         let _ = read;
         let _ = bash;
     }

--- a/src/llm-coding-tools-rig/src/task.rs
+++ b/src/llm-coding-tools-rig/src/task.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides [`TaskTool`] for spawning sub-agents to handle complex tasks.
 
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolContext, ToolError, ToolOutput};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
@@ -63,7 +64,7 @@ impl TaskTool<MockTaskExecutor> {
 }
 
 impl<E: TaskExecutor + 'static> Tool for TaskTool<E> {
-    const NAME: &'static str = "Task";
+    const NAME: &'static str = tool_names::TASK;
 
     type Error = ToolError;
     type Args = TaskArgs;
@@ -86,7 +87,7 @@ impl<E: TaskExecutor + 'static> Tool for TaskTool<E> {
 }
 
 impl<E: TaskExecutor> ToolContext for TaskTool<E> {
-    const NAME: &'static str = "Task";
+    const NAME: &'static str = tool_names::TASK;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::TASK

--- a/src/llm-coding-tools-rig/src/todo.rs
+++ b/src/llm-coding-tools-rig/src/todo.rs
@@ -3,6 +3,7 @@
 //! Provides tools for reading and writing todo items.
 
 use llm_coding_tools_core::operations::{read_todos, write_todos};
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolContext, ToolError, ToolOutput};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
@@ -37,7 +38,7 @@ impl TodoWriteTool {
 }
 
 impl Tool for TodoWriteTool {
-    const NAME: &'static str = "TodoWrite";
+    const NAME: &'static str = tool_names::TODO_WRITE;
 
     type Error = ToolError;
     type Args = TodoWriteArgs;
@@ -72,7 +73,7 @@ impl TodoReadTool {
 }
 
 impl Tool for TodoReadTool {
-    const NAME: &'static str = "TodoRead";
+    const NAME: &'static str = tool_names::TODO_READ;
 
     type Error = ToolError;
     type Args = TodoReadArgs;
@@ -94,7 +95,7 @@ impl Tool for TodoReadTool {
 }
 
 impl ToolContext for TodoWriteTool {
-    const NAME: &'static str = "TodoWrite";
+    const NAME: &'static str = tool_names::TODO_WRITE;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::TODO_WRITE
@@ -102,7 +103,7 @@ impl ToolContext for TodoWriteTool {
 }
 
 impl ToolContext for TodoReadTool {
-    const NAME: &'static str = "TodoRead";
+    const NAME: &'static str = tool_names::TODO_READ;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::TODO_READ

--- a/src/llm-coding-tools-rig/src/webfetch.rs
+++ b/src/llm-coding-tools-rig/src/webfetch.rs
@@ -3,6 +3,7 @@
 //! Provides URL fetching with format conversion support.
 
 use llm_coding_tools_core::operations::fetch_url;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolContext, ToolError, ToolOutput};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
@@ -58,7 +59,7 @@ impl WebFetchTool {
 }
 
 impl Tool for WebFetchTool {
-    const NAME: &'static str = "WebFetch";
+    const NAME: &'static str = tool_names::WEBFETCH;
 
     type Error = ToolError;
     type Args = WebFetchArgs;
@@ -83,7 +84,7 @@ impl Tool for WebFetchTool {
 }
 
 impl ToolContext for WebFetchTool {
-    const NAME: &'static str = "WebFetch";
+    const NAME: &'static str = tool_names::WEBFETCH;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::WEBFETCH

--- a/src/llm-coding-tools-serdesai/src/absolute/edit.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/edit.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use llm_coding_tools_core::ToolContext;
 use llm_coding_tools_core::operations::edit_file;
 use llm_coding_tools_core::path::AbsolutePathResolver;
+use llm_coding_tools_core::tool_names;
 use serde::Deserialize;
 use serdes_ai::tools::{
     RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult, ToolReturn,
@@ -53,15 +54,15 @@ impl<Deps: Send + Sync> Tool<Deps> for EditTool {
             .expect("schema build should not fail");
 
         ToolDefinition::new(
-            "Edit",
-            "Makes exact string replacements in files. Use replace_all=true to replace all occurrences.",
-        )
-        .with_parameters(schema)
+             tool_names::EDIT,
+             "Makes exact string replacements in files. Use replace_all=true to replace all occurrences.",
+         )
+         .with_parameters(schema)
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
         let args: EditArgs = serde_json::from_value(args)
-            .map_err(|e| ToolError::validation_error("Edit", None, e.to_string()))?;
+            .map_err(|e| ToolError::validation_error(tool_names::EDIT, None, e.to_string()))?;
 
         let resolver = AbsolutePathResolver;
         let result = edit_file(
@@ -78,7 +79,7 @@ impl<Deps: Send + Sync> Tool<Deps> for EditTool {
 }
 
 impl ToolContext for EditTool {
-    const NAME: &'static str = "Edit";
+    const NAME: &'static str = tool_names::EDIT;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::EDIT_ABSOLUTE

--- a/src/llm-coding-tools-serdesai/src/absolute/glob.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/glob.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use llm_coding_tools_core::operations::glob_files;
 use llm_coding_tools_core::path::AbsolutePathResolver;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolContext, ToolOutput};
 use serde::Deserialize;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
@@ -46,22 +47,22 @@ impl<Deps: Send + Sync> Tool<Deps> for GlobTool {
             .expect("schema build should not fail");
 
         ToolDefinition::new(
-            "Glob",
-            "Find files matching a glob pattern. Respects .gitignore and returns paths sorted by modification time (newest first).",
-        )
-        .with_parameters(schema)
+             tool_names::GLOB,
+             "Find files matching a glob pattern. Respects .gitignore and returns paths sorted by modification time (newest first).",
+         )
+         .with_parameters(schema)
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
         let args: GlobArgs = serde_json::from_value(args)
-            .map_err(|e| ToolError::validation_error("Glob", None, e.to_string()))?;
+            .map_err(|e| ToolError::validation_error(tool_names::GLOB, None, e.to_string()))?;
 
         let resolver = AbsolutePathResolver;
         let result = glob_files(&resolver, &args.pattern, &args.path);
 
         // Convert GlobOutput to ToolOutput for consistent error handling
         to_serdes_result(
-            "Glob",
+            tool_names::GLOB,
             result.map(|output| {
                 let content = if output.files.is_empty() {
                     "No files found matching the pattern.".to_string()
@@ -79,7 +80,7 @@ impl<Deps: Send + Sync> Tool<Deps> for GlobTool {
 }
 
 impl ToolContext for GlobTool {
-    const NAME: &'static str = "Glob";
+    const NAME: &'static str = tool_names::GLOB;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::GLOB_ABSOLUTE

--- a/src/llm-coding-tools-serdesai/src/absolute/grep.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/grep.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use llm_coding_tools_core::ToolContext;
 use llm_coding_tools_core::operations::{DEFAULT_MAX_LINE_LENGTH, grep_search};
 use llm_coding_tools_core::path::AbsolutePathResolver;
+use llm_coding_tools_core::tool_names;
 use serde::Deserialize;
 use serdes_ai::tools::{
     RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult, ToolReturn,
@@ -76,17 +77,17 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
             .build()
             .expect("schema build should not fail");
 
-        ToolDefinition::new("Grep", description).with_parameters(schema)
+        ToolDefinition::new(tool_names::GREP, description).with_parameters(schema)
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
         let args: GrepArgs = serde_json::from_value(args)
-            .map_err(|e| ToolError::validation_error("Grep", None, e.to_string()))?;
+            .map_err(|e| ToolError::validation_error(tool_names::GREP, None, e.to_string()))?;
 
         let pattern = args.pattern.trim();
         if pattern.is_empty() {
             return Err(ToolError::validation_error(
-                "Grep",
+                tool_names::GREP,
                 Some("pattern".to_string()),
                 "pattern must not be empty".to_string(),
             ));
@@ -95,7 +96,7 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
         let limit = args.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
         if limit == 0 {
             return Err(ToolError::validation_error(
-                "Grep",
+                tool_names::GREP,
                 Some("limit".to_string()),
                 "limit must be greater than zero".to_string(),
             ));
@@ -114,7 +115,7 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
         let result = grep_search(&resolver, pattern, include, &args.path, limit);
 
         match result {
-            Err(e) => to_serdes_result("Grep", Err(e)),
+            Err(e) => to_serdes_result(tool_names::GREP, Err(e)),
             Ok(grep_output) => {
                 if grep_output.files.is_empty() {
                     return Ok(ToolReturn::text("No matches found."));
@@ -128,7 +129,7 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
 }
 
 impl<const LINE_NUMBERS: bool> ToolContext for GrepTool<LINE_NUMBERS> {
-    const NAME: &'static str = "Grep";
+    const NAME: &'static str = tool_names::GREP;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::GREP_ABSOLUTE

--- a/src/llm-coding-tools-serdesai/src/absolute/read.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/read.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use llm_coding_tools_core::ToolContext;
 use llm_coding_tools_core::operations::read_file;
 use llm_coding_tools_core::path::AbsolutePathResolver;
+use llm_coding_tools_core::tool_names;
 use serde::Deserialize;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
 
@@ -77,23 +78,23 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for ReadTool<LINE_N
             .build()
             .expect("schema build should not fail");
 
-        ToolDefinition::new("Read", description).with_parameters(schema)
+        ToolDefinition::new(tool_names::READ, description).with_parameters(schema)
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
         let args: ReadArgs = serde_json::from_value(args)
-            .map_err(|e| ToolError::validation_error("Read", None, e.to_string()))?;
+            .map_err(|e| ToolError::validation_error(tool_names::READ, None, e.to_string()))?;
 
         let resolver = AbsolutePathResolver;
         // Core uses 1-indexed offset directly; args.offset defaults to 1
         let result =
             read_file::<_, LINE_NUMBERS>(&resolver, &args.file_path, args.offset, args.limit).await;
-        to_serdes_result("Read", result)
+        to_serdes_result(tool_names::READ, result)
     }
 }
 
 impl<const LINE_NUMBERS: bool> ToolContext for ReadTool<LINE_NUMBERS> {
-    const NAME: &'static str = "Read";
+    const NAME: &'static str = tool_names::READ;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::READ_ABSOLUTE

--- a/src/llm-coding-tools-serdesai/src/absolute/write.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/write.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use llm_coding_tools_core::operations::write_file;
 use llm_coding_tools_core::path::AbsolutePathResolver;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolContext, ToolOutput};
 use serde::Deserialize;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
@@ -42,7 +43,7 @@ impl<Deps: Send + Sync> Tool<Deps> for WriteTool {
             .expect("schema build should not fail");
 
         ToolDefinition::new(
-            "Write",
+            tool_names::WRITE,
             "Write content to a file, creating parent directories if needed. Overwrites existing files.",
         )
         .with_parameters(schema)
@@ -50,18 +51,18 @@ impl<Deps: Send + Sync> Tool<Deps> for WriteTool {
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
         let args: WriteArgs = serde_json::from_value(args)
-            .map_err(|e| ToolError::validation_error("Write", None, e.to_string()))?;
+            .map_err(|e| ToolError::validation_error(tool_names::WRITE, None, e.to_string()))?;
 
         let resolver = AbsolutePathResolver;
         let result = write_file(&resolver, &args.file_path, &args.content).await;
 
         // Convert String result to ToolOutput for consistent error handling
-        to_serdes_result("Write", result.map(ToolOutput::new))
+        to_serdes_result(tool_names::WRITE, result.map(ToolOutput::new))
     }
 }
 
 impl ToolContext for WriteTool {
-    const NAME: &'static str = "Write";
+    const NAME: &'static str = tool_names::WRITE;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::WRITE_ABSOLUTE

--- a/src/llm-coding-tools-serdesai/src/allowed/edit.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/edit.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use llm_coding_tools_core::ToolContext;
 use llm_coding_tools_core::operations::edit_file;
 use llm_coding_tools_core::path::AllowedPathResolver;
+use llm_coding_tools_core::tool_names;
 use serde::Deserialize;
 use serdes_ai::tools::{
     RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult, ToolReturn,
@@ -65,16 +66,16 @@ impl<Deps: Send + Sync> Tool<Deps> for EditTool {
             .expect("schema build should not fail");
 
         ToolDefinition::new(
-            "Edit",
+            tool_names::EDIT,
             "Make exact string replacements in files within allowed directories. \
-             Paths are relative to configured base directories.",
+              Paths are relative to configured base directories.",
         )
         .with_parameters(schema)
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
         let args: EditArgs = serde_json::from_value(args)
-            .map_err(|e| ToolError::validation_error("Edit", None, e.to_string()))?;
+            .map_err(|e| ToolError::validation_error(tool_names::EDIT, None, e.to_string()))?;
 
         let result = edit_file(
             &self.resolver,
@@ -90,7 +91,7 @@ impl<Deps: Send + Sync> Tool<Deps> for EditTool {
 }
 
 impl ToolContext for EditTool {
-    const NAME: &'static str = "Edit";
+    const NAME: &'static str = tool_names::EDIT;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::EDIT_ALLOWED

--- a/src/llm-coding-tools-serdesai/src/allowed/glob.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/glob.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use llm_coding_tools_core::operations::glob_files;
 use llm_coding_tools_core::path::AllowedPathResolver;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolContext, ToolOutput};
 use serde::Deserialize;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
@@ -54,20 +55,20 @@ impl<Deps: Send + Sync> Tool<Deps> for GlobTool {
             .expect("schema build should not fail");
 
         ToolDefinition::new(
-            "Glob",
+            tool_names::GLOB,
             "Find files matching a glob pattern within allowed directories. \
-             Paths are relative to configured base directories.",
+              Paths are relative to configured base directories.",
         )
         .with_parameters(schema)
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
         let args: GlobArgs = serde_json::from_value(args)
-            .map_err(|e| ToolError::validation_error("Glob", None, e.to_string()))?;
+            .map_err(|e| ToolError::validation_error(tool_names::GLOB, None, e.to_string()))?;
 
         let result = glob_files(&self.resolver, &args.pattern, &args.path);
         to_serdes_result(
-            "Glob",
+            tool_names::GLOB,
             result.map(|output| {
                 let content = if output.files.is_empty() {
                     "No files found matching the pattern.".to_string()
@@ -85,7 +86,7 @@ impl<Deps: Send + Sync> Tool<Deps> for GlobTool {
 }
 
 impl ToolContext for GlobTool {
-    const NAME: &'static str = "Glob";
+    const NAME: &'static str = tool_names::GLOB;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::GLOB_ALLOWED

--- a/src/llm-coding-tools-serdesai/src/allowed/grep.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/grep.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use llm_coding_tools_core::ToolContext;
 use llm_coding_tools_core::operations::{DEFAULT_MAX_LINE_LENGTH, grep_search};
 use llm_coding_tools_core::path::AllowedPathResolver;
+use llm_coding_tools_core::tool_names;
 use serde::Deserialize;
 use serdes_ai::tools::{
     RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult, ToolReturn,
@@ -83,17 +84,17 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
             .build()
             .expect("schema build should not fail");
 
-        ToolDefinition::new("Grep", description).with_parameters(schema)
+        ToolDefinition::new(tool_names::GREP, description).with_parameters(schema)
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
         let args: GrepArgs = serde_json::from_value(args)
-            .map_err(|e| ToolError::validation_error("Grep", None, e.to_string()))?;
+            .map_err(|e| ToolError::validation_error(tool_names::GREP, None, e.to_string()))?;
 
         let pattern = args.pattern.trim();
         if pattern.is_empty() {
             return Err(ToolError::validation_error(
-                "Grep",
+                tool_names::GREP,
                 Some("pattern".to_string()),
                 "pattern must not be empty".to_string(),
             ));
@@ -102,7 +103,7 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
         let limit = args.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
         if limit == 0 {
             return Err(ToolError::validation_error(
-                "Grep",
+                tool_names::GREP,
                 Some("limit".to_string()),
                 "limit must be greater than zero".to_string(),
             ));
@@ -120,7 +121,7 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
         let result = grep_search(&self.resolver, pattern, include, &args.path, limit);
 
         match result {
-            Err(e) => to_serdes_result("Grep", Err(e)),
+            Err(e) => to_serdes_result(tool_names::GREP, Err(e)),
             Ok(grep_output) => {
                 if grep_output.files.is_empty() {
                     return Ok(ToolReturn::text("No matches found."));
@@ -134,7 +135,7 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
 }
 
 impl<const LINE_NUMBERS: bool> ToolContext for GrepTool<LINE_NUMBERS> {
-    const NAME: &'static str = "Grep";
+    const NAME: &'static str = tool_names::GREP;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::GREP_ALLOWED

--- a/src/llm-coding-tools-serdesai/src/allowed/read.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/read.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use llm_coding_tools_core::operations::read_file;
 use llm_coding_tools_core::path::AllowedPathResolver;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolContext, ToolResult as CoreToolResult};
 use serde::Deserialize;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
@@ -86,22 +87,22 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for ReadTool<LINE_N
             .build()
             .expect("schema build should not fail");
 
-        ToolDefinition::new("Read", description).with_parameters(schema)
+        ToolDefinition::new(tool_names::READ, description).with_parameters(schema)
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
         let args: ReadArgs = serde_json::from_value(args)
-            .map_err(|e| ToolError::validation_error("Read", None, e.to_string()))?;
+            .map_err(|e| ToolError::validation_error(tool_names::READ, None, e.to_string()))?;
 
         let result =
             read_file::<_, LINE_NUMBERS>(&self.resolver, &args.file_path, args.offset, args.limit)
                 .await;
-        to_serdes_result("Read", result)
+        to_serdes_result(tool_names::READ, result)
     }
 }
 
 impl<const LINE_NUMBERS: bool> ToolContext for ReadTool<LINE_NUMBERS> {
-    const NAME: &'static str = "Read";
+    const NAME: &'static str = tool_names::READ;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::READ_ALLOWED

--- a/src/llm-coding-tools-serdesai/src/allowed/write.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/write.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use llm_coding_tools_core::operations::write_file;
 use llm_coding_tools_core::path::AllowedPathResolver;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolContext, ToolOutput};
 use serde::Deserialize;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
@@ -49,7 +50,7 @@ impl<Deps: Send + Sync> Tool<Deps> for WriteTool {
             .expect("schema build should not fail");
 
         ToolDefinition::new(
-            "Write",
+            tool_names::WRITE,
             "Write content to a file within allowed directories. \
              Paths are relative to configured base directories.",
         )
@@ -58,15 +59,15 @@ impl<Deps: Send + Sync> Tool<Deps> for WriteTool {
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
         let args: WriteArgs = serde_json::from_value(args)
-            .map_err(|e| ToolError::validation_error("Write", None, e.to_string()))?;
+            .map_err(|e| ToolError::validation_error(tool_names::WRITE, None, e.to_string()))?;
 
         let result = write_file(&self.resolver, &args.file_path, &args.content).await;
-        to_serdes_result("Write", result.map(ToolOutput::new))
+        to_serdes_result(tool_names::WRITE, result.map(ToolOutput::new))
     }
 }
 
 impl ToolContext for WriteTool {
-    const NAME: &'static str = "Write";
+    const NAME: &'static str = tool_names::WRITE;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::WRITE_ALLOWED

--- a/src/llm-coding-tools-serdesai/src/bash.rs
+++ b/src/llm-coding-tools-serdesai/src/bash.rs
@@ -6,6 +6,7 @@ use crate::convert::to_serdes_result;
 use async_trait::async_trait;
 use llm_coding_tools_core::context::ToolContext;
 use llm_coding_tools_core::operations::execute_command;
+use llm_coding_tools_core::tool_names;
 use serde::Deserialize;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
 use std::path::{Path, PathBuf};
@@ -64,7 +65,7 @@ impl BashTool {
 impl<Deps: Send + Sync> Tool<Deps> for BashTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition::new(
-            "Bash",
+            tool_names::BASH,
             "Execute a shell command with optional working directory and timeout.",
         )
         .with_parameters(
@@ -96,7 +97,7 @@ impl<Deps: Send + Sync> Tool<Deps> for BashTool {
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
         let args: BashArgs = serde_json::from_value(args)
-            .map_err(|e| ToolError::validation_error("Bash", None, e.to_string()))?;
+            .map_err(|e| ToolError::validation_error(tool_names::BASH, None, e.to_string()))?;
 
         // Use arg workdir, falling back to default_workdir
         let workdir: Option<&Path> = args
@@ -114,12 +115,15 @@ impl<Deps: Send + Sync> Tool<Deps> for BashTool {
 
         let result = execute_command(&args.command, workdir, timeout).await;
 
-        to_serdes_result("Bash", result.map(|output| output.format_output()))
+        to_serdes_result(
+            tool_names::BASH,
+            result.map(|output| output.format_output()),
+        )
     }
 }
 
 impl ToolContext for BashTool {
-    const NAME: &'static str = "Bash";
+    const NAME: &'static str = tool_names::BASH;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::BASH

--- a/src/llm-coding-tools-serdesai/src/convert.rs
+++ b/src/llm-coding-tools-serdesai/src/convert.rs
@@ -6,6 +6,7 @@
 //! [`llm_coding_tools_core`]: llm_coding_tools_core
 
 use llm_coding_tools_core::operations::EditError;
+use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolError as CoreError, ToolOutput, ToolResult as CoreResult};
 use serde_json::json;
 use serdes_ai::tools::{ToolError as SerdesError, ToolReturn};
@@ -68,28 +69,28 @@ pub fn to_serdes_result(
 pub fn edit_error_to_serdes(err: EditError) -> SerdesError {
     match err {
         EditError::NotFound => SerdesError::validation_error(
-            "edit",
+            tool_names::EDIT,
             Some("old_string".to_string()),
             "old_string not found in file content".to_string(),
         ),
         EditError::AmbiguousMatch(count) => SerdesError::validation_error(
-            "edit",
+            tool_names::EDIT,
             Some("old_string".to_string()),
             format!(
                 "old_string found {count} times and requires more code context to uniquely identify the intended match"
             ),
         ),
         EditError::EmptyOldString => SerdesError::validation_error(
-            "edit",
+            tool_names::EDIT,
             Some("old_string".to_string()),
             "old_string must not be empty".to_string(),
         ),
         EditError::IdenticalStrings => SerdesError::validation_error(
-            "edit",
+            tool_names::EDIT,
             None,
             "old_string and new_string must be different".to_string(),
         ),
-        EditError::Tool(tool_err) => core_error_to_serdes("edit", tool_err),
+        EditError::Tool(tool_err) => core_error_to_serdes(tool_names::EDIT, tool_err),
     }
 }
 

--- a/src/llm-coding-tools-serdesai/src/task.rs
+++ b/src/llm-coding-tools-serdesai/src/task.rs
@@ -6,6 +6,7 @@ use crate::convert::to_serdes_result;
 use async_trait::async_trait;
 use llm_coding_tools_core::ToolOutput;
 use llm_coding_tools_core::context::ToolContext;
+use llm_coding_tools_core::tool_names;
 use serde::Deserialize;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
 use std::sync::Arc;
@@ -75,7 +76,11 @@ impl TaskTool<MockTaskExecutor> {
 #[async_trait]
 impl<Deps: Send + Sync, E: TaskExecutor + Send + Sync + 'static> Tool<Deps> for TaskTool<E> {
     fn definition(&self) -> ToolDefinition {
-        ToolDefinition::new("Task", "Delegate a task to a specialized sub-agent.").with_parameters(
+        ToolDefinition::new(
+            tool_names::TASK,
+            "Delegate a task to a specialized sub-agent.",
+        )
+        .with_parameters(
             SchemaBuilder::new()
                 .string("description", "Short 3-5 word task description", true)
                 .string("prompt", "Detailed instructions for the sub-agent", true)
@@ -92,15 +97,18 @@ impl<Deps: Send + Sync, E: TaskExecutor + Send + Sync + 'static> Tool<Deps> for 
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
         let args: TaskArgs = serde_json::from_value(args)
-            .map_err(|e| ToolError::validation_error("Task", None, e.to_string()))?;
+            .map_err(|e| ToolError::validation_error(tool_names::TASK, None, e.to_string()))?;
         let core_args = CoreTaskArgs::from(args);
         let result = self.executor.execute(&core_args).await;
-        to_serdes_result("Task", result.map(|r| ToolOutput::new(r.format())))
+        to_serdes_result(
+            tool_names::TASK,
+            result.map(|r| ToolOutput::new(r.format())),
+        )
     }
 }
 
 impl<E: TaskExecutor> ToolContext for TaskTool<E> {
-    const NAME: &'static str = "Task";
+    const NAME: &'static str = tool_names::TASK;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::TASK

--- a/src/llm-coding-tools-serdesai/src/todo.rs
+++ b/src/llm-coding-tools-serdesai/src/todo.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use llm_coding_tools_core::ToolOutput;
 use llm_coding_tools_core::context::ToolContext;
 use llm_coding_tools_core::operations::{read_todos, write_todos};
+use llm_coding_tools_core::tool_names;
 use serde::Deserialize;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
 
@@ -43,7 +44,11 @@ impl TodoWriteTool {
 #[async_trait]
 impl<Deps: Send + Sync> Tool<Deps> for TodoWriteTool {
     fn definition(&self) -> ToolDefinition {
-        ToolDefinition::new("TodoWrite", "Replace the todo list with new items.").with_parameters(
+        ToolDefinition::new(
+            tool_names::TODO_WRITE,
+            "Replace the todo list with new items.",
+        )
+        .with_parameters(
             SchemaBuilder::new()
                 .raw(
                     "todos",
@@ -77,15 +82,16 @@ impl<Deps: Send + Sync> Tool<Deps> for TodoWriteTool {
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
-        let args: TodoWriteArgs = serde_json::from_value(args)
-            .map_err(|e| ToolError::validation_error("TodoWrite", None, e.to_string()))?;
+        let args: TodoWriteArgs = serde_json::from_value(args).map_err(|e| {
+            ToolError::validation_error(tool_names::TODO_WRITE, None, e.to_string())
+        })?;
         let result = write_todos(&self.state, args.todos);
-        to_serdes_result("TodoWrite", result.map(ToolOutput::new))
+        to_serdes_result(tool_names::TODO_WRITE, result.map(ToolOutput::new))
     }
 }
 
 impl ToolContext for TodoWriteTool {
-    const NAME: &'static str = "TodoWrite";
+    const NAME: &'static str = tool_names::TODO_WRITE;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::TODO_WRITE
@@ -108,7 +114,7 @@ impl TodoReadTool {
 #[async_trait]
 impl<Deps: Send + Sync> Tool<Deps> for TodoReadTool {
     fn definition(&self) -> ToolDefinition {
-        ToolDefinition::new("TodoRead", "Read the current todo list.").with_parameters(
+        ToolDefinition::new(tool_names::TODO_READ, "Read the current todo list.").with_parameters(
             SchemaBuilder::new()
                 .build()
                 .expect("schema serialization should never fail"),
@@ -118,14 +124,14 @@ impl<Deps: Send + Sync> Tool<Deps> for TodoReadTool {
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
         // Validate JSON is a proper object (empty struct validates this)
         let _args: TodoReadArgs = serde_json::from_value(args)
-            .map_err(|e| ToolError::validation_error("TodoRead", None, e.to_string()))?;
+            .map_err(|e| ToolError::validation_error(tool_names::TODO_READ, None, e.to_string()))?;
         let content = read_todos(&self.state);
         Ok(crate::convert::output_to_return(ToolOutput::new(content)))
     }
 }
 
 impl ToolContext for TodoReadTool {
-    const NAME: &'static str = "TodoRead";
+    const NAME: &'static str = tool_names::TODO_READ;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::TODO_READ

--- a/src/llm-coding-tools-serdesai/src/webfetch.rs
+++ b/src/llm-coding-tools-serdesai/src/webfetch.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use llm_coding_tools_core::ToolOutput;
 use llm_coding_tools_core::context::ToolContext;
 use llm_coding_tools_core::operations::fetch_url;
+use llm_coding_tools_core::tool_names;
 use serde::Deserialize;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
 use std::time::Duration;
@@ -62,7 +63,7 @@ impl WebFetchTool {
 impl<Deps: Send + Sync> Tool<Deps> for WebFetchTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition::new(
-            "WebFetch",
+            tool_names::WEBFETCH,
             "Fetch content from a URL. HTML is converted to markdown, JSON is prettified.",
         )
         .with_parameters(
@@ -82,16 +83,16 @@ impl<Deps: Send + Sync> Tool<Deps> for WebFetchTool {
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
         let args: WebFetchArgs = serde_json::from_value(args)
-            .map_err(|e| ToolError::validation_error("WebFetch", None, e.to_string()))?;
+            .map_err(|e| ToolError::validation_error(tool_names::WEBFETCH, None, e.to_string()))?;
         let timeout = Duration::from_millis(args.timeout_ms);
         let result = fetch_url(&self.client, &args.url, timeout).await;
 
-        to_serdes_result("WebFetch", result.map(ToolOutput::from))
+        to_serdes_result(tool_names::WEBFETCH, result.map(ToolOutput::from))
     }
 }
 
 impl ToolContext for WebFetchTool {
-    const NAME: &'static str = "WebFetch";
+    const NAME: &'static str = tool_names::WEBFETCH;
 
     fn context(&self) -> &'static str {
         llm_coding_tools_core::context::WEBFETCH


### PR DESCRIPTION
## Summary

- Introduces `llm_coding_tools_core::tool_names` module with canonical constants for all tool names
- Replaces hardcoded string literals across all tools in both rig and serdesai crates
- Provides a single source of truth for tool names, reducing duplication and risk of inconsistencies

## Constants Added

```rust
pub const READ: &str = "Read";
pub const WRITE: &str = "Write";
pub const EDIT: &str = "Edit";
pub const GLOB: &str = "Glob";
pub const GREP: &str = "Grep";
pub const BASH: &str = "Bash";
pub const WEBFETCH: &str = "WebFetch";
pub const TASK: &str = "Task";
pub const TODO_WRITE: &str = "TodoWrite";
pub const TODO_READ: &str = "TodoRead";
```

## Files Changed

- **1 new file**: `llm-coding-tools-core/src/tool_names.rs`
- **30 files modified**: All tool implementations in rig and serdesai crates updated to use constants