### PR TITLE
Fixed: Windows bash workdir tests failing due to UNC path prefix

### DIFF
--- a/src/llm-coding-tools-serdesai/src/bash.rs
+++ b/src/llm-coding-tools-serdesai/src/bash.rs
@@ -138,6 +138,22 @@ mod tests {
         RunContext::minimal("test-model")
     }
 
+    /// Strips Windows extended-length path prefix (`\\?\`) from canonicalized paths.
+    ///
+    /// On Windows, `std::fs::canonicalize()` returns UNC paths, but shell commands
+    /// like `cd` output normal paths. This helper normalizes for comparison.
+    #[allow(unused_variables)]
+    fn normalize_path(path: std::path::PathBuf) -> std::path::PathBuf {
+        #[cfg(windows)]
+        {
+            let s = path.to_string_lossy();
+            if let Some(stripped) = s.strip_prefix(r"\\?\") {
+                return std::path::PathBuf::from(stripped);
+            }
+        }
+        path
+    }
+
     #[tokio::test]
     async fn executes_echo() {
         let tool = BashTool::new();
@@ -183,7 +199,7 @@ mod tests {
         let result = tool.call(&mock_ctx(), args).await.unwrap();
         let output = result.as_text().unwrap();
         // Canonicalize both paths for comparison (handles symlinks like /tmp -> /private/tmp on macOS)
-        let expected = temp_dir.canonicalize().unwrap_or(temp_dir);
+        let expected = normalize_path(temp_dir.canonicalize().unwrap_or(temp_dir));
         assert!(output.contains(expected.to_string_lossy().as_ref()));
     }
 
@@ -203,7 +219,7 @@ mod tests {
         let result = tool.call(&mock_ctx(), args).await.unwrap();
         let output = result.as_text().unwrap();
         // Canonicalize both paths for comparison (handles symlinks like /tmp -> /private/tmp on macOS)
-        let expected = temp_dir.canonicalize().unwrap_or(temp_dir);
+        let expected = normalize_path(temp_dir.canonicalize().unwrap_or(temp_dir));
         assert!(output.contains(expected.to_string_lossy().as_ref()));
     }
 


### PR DESCRIPTION
## Summary
- Fixed two failing tests on Windows CI: `default_workdir_is_used` and `workdir_parameter_changes_directory`
- Added `normalize_path()` helper to strip Windows UNC path prefix (`\\?\`) from canonicalized paths before comparison

## Root Cause
On Windows, `std::fs::canonicalize()` returns extended-length paths with the `\\?\` prefix (e.g., `\\?\C:\Users\...`), but shell commands like `cd` output normal paths without this prefix. The string comparison in tests failed because the expected path contained `\\?\` but the command output did not.

## Changes
- Added test helper function `normalize_path()` that strips the `\\?\` prefix on Windows
- Applied the helper to both affected test assertions