### PR TITLE
Changed: Migrate examples to agent builder pattern

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -38,32 +38,30 @@ Add to your `Cargo.toml`:
 llm-coding-tools-rig = "0.1"
 ```
 
-```rust
+```rust,no_run
 use llm_coding_tools_rig::absolute::{ReadTool, WriteTool, GlobTool};
 use llm_coding_tools_rig::{BashTool, PreambleBuilder, TodoTools};
-use rig::tool::ToolSet;
+use rig::providers::openai;
+use rig::completion::Prompt;
 
 // Track tools and generate LLM guidance
-let mut pb = PreambleBuilder::new();
+let mut pb = PreambleBuilder::<false>::new();
 let todos = TodoTools::new();
 
-let toolset = ToolSet::builder()
-    .static_tool(pb.track(ReadTool::<true>::new()))
-    .static_tool(pb.track(WriteTool::new()))
-    .static_tool(pb.track(GlobTool::new()))
-    .static_tool(pb.track(BashTool::new()))
-    .static_tool(pb.track(todos.read))
-    .static_tool(pb.track(todos.write))
+let client = openai::Client::from_env();
+let agent = client
+    .agent("gpt-4o")
+    .tool(pb.track(ReadTool::<true>::new()))
+    .tool(pb.track(WriteTool::new()))
+    .tool(pb.track(GlobTool::new()))
+    .tool(pb.track(BashTool::new()))
+    .tool(pb.track(todos.read))
+    .tool(pb.track(todos.write))
+    .preamble(&pb.build())
     .build();
 
-// Generate preamble for agent system prompt
-let preamble = pb.build();
-
-// Use with rig agent:
-// let agent = client.agent("gpt-4o")
-//     .preamble(&preamble)
-//     .tools(toolset)
-//     .build();
+// Use the agent
+// let response = agent.prompt("List all files").await?;
 ```
 
 ## Examples

--- a/src/llm-coding-tools-core/src/lib.rs
+++ b/src/llm-coding-tools-core/src/lib.rs
@@ -1,16 +1,5 @@
+#![doc = include_str!(concat!("../", env!("CARGO_PKG_README")))]
 #![warn(missing_docs)]
-//! Core types and utilities for coding tools.
-//!
-//! This crate provides framework-agnostic building blocks:
-//! - [`ToolError`] and [`ToolResult`] for error handling
-//! - [`ToolOutput`] for tool responses with truncation metadata
-//! - Utility functions for text processing
-//!
-//! # Features
-//!
-//! - `async`: Enables async function signatures and async-only modules.
-//! - `tokio` (default): Enables async via tokio runtime (implies `async`).
-//!   When disabled, all operations are synchronous.
 
 // Validate feature combinations at compile time
 #[cfg(all(feature = "async", not(feature = "tokio")))]

--- a/src/llm-coding-tools-core/src/preamble.rs
+++ b/src/llm-coding-tools-core/src/preamble.rs
@@ -119,11 +119,13 @@ impl<const ENV: bool> PreambleBuilder<ENV> {
     /// // register _my_tool with your tool collection
     /// ```
     ///
-    /// For example, if working with rig's ToolSet builder:
+    /// For example, if working with rig's agent builder:
     /// ```text
     /// let mut pb = PreambleBuilder::new();
-    /// let toolset = ToolSet::builder()
-    ///     .static_tool(pb.track(ReadTool::new()))
+    /// let agent = client
+    ///     .agent("gpt-4o")
+    ///     .tool(pb.track(ReadTool::new()))
+    ///     .preamble(&pb.build())
     ///     .build();
     /// ```
     pub fn track<T: ToolContext>(&mut self, tool: T) -> T {

--- a/src/llm-coding-tools-rig/README.md
+++ b/src/llm-coding-tools-rig/README.md
@@ -29,33 +29,29 @@ llm-coding-tools-rig = "0.1"
 
 Minimal runnable agent (requires `OPENAI_API_KEY`):
 
-```rust
+```rust,no_run
 use llm_coding_tools_rig::absolute::{GlobTool, GrepTool, ReadTool};
 use llm_coding_tools_rig::{BashTool, PreambleBuilder, TodoTools};
 use rig::providers::openai;
-use rig::tool::ToolSet;
+use rig::client::{ProviderClient, CompletionClient};
+use rig::completion::Prompt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let todos = TodoTools::new();
     let mut pb = PreambleBuilder::<false>::new();
 
-    let toolset = ToolSet::builder()
-        .static_tool(pb.track(ReadTool::<true>::new()))
-        .static_tool(pb.track(GlobTool::new()))
-        .static_tool(pb.track(GrepTool::<true>::new()))
-        .static_tool(pb.track(BashTool::new()))
-        .static_tool(pb.track(todos.read))
-        .static_tool(pb.track(todos.write))
-        .build();
-
-    let preamble = pb.build();
-
+    // Build agent with preamble tracking
     let client = openai::Client::from_env();
     let agent = client
         .agent("gpt-4o")
-        .preamble(&preamble)
-        .tools(toolset)
+        .tool(pb.track(ReadTool::<true>::new()))
+        .tool(pb.track(GlobTool::new()))
+        .tool(pb.track(GrepTool::<true>::new()))
+        .tool(pb.track(BashTool::new()))
+        .tool(pb.track(todos.read))
+        .tool(pb.track(todos.write))
+        .preamble(&pb.build())  // Build preamble after tracking tools
         .build();
 
     let response = agent
@@ -85,7 +81,7 @@ Executes shell commands.
 
 File tools come in `absolute::*` (unrestricted) and `allowed::*` (sandboxed) variants:
 
-```rust
+```rust,no_run
 use llm_coding_tools_rig::absolute::{ReadTool, WriteTool};
 use llm_coding_tools_rig::allowed::{ReadTool as AllowedReadTool, WriteTool as AllowedWriteTool};
 use llm_coding_tools_rig::AllowedPathResolver;

--- a/src/llm-coding-tools-rig/examples/rig-basic.rs
+++ b/src/llm-coding-tools-rig/examples/rig-basic.rs
@@ -1,40 +1,46 @@
-//! PreambleBuilder example - pass-through tracking for ToolSet.
+//! PreambleBuilder example - building a complete rig agent.
 //!
 //! Demonstrates:
-//! - Using PreambleBuilder alongside ToolSet::builder()
-//! - Full access to Rig's API (no wrapper limitations)
+//! - Using PreambleBuilder with rig's agent builder
+//! - Chained .tool() calls for registering tools
 //! - TodoTools with shared state
 //! - Generating and using the preamble string
 //!
-//! Run: cargo run --example rig-basic -p llm-coding-tools-rig
+//! Run: OPENAI_API_KEY=... cargo run --example rig-basic -p llm-coding-tools-rig
 
 use llm_coding_tools_rig::absolute::{GlobTool, GrepTool, ReadTool};
 use llm_coding_tools_rig::{BashTool, PreambleBuilder, TodoTools};
-use rig::tool::ToolSet;
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::openai;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // === Create shared state for todos ===
     let todos = TodoTools::new();
 
     // === Create preamble builder to track tools ===
     let mut pb = PreambleBuilder::<false>::new();
 
-    // === Use ToolSet::builder() directly - full Rig API! ===
-    let _toolset = ToolSet::builder()
-        .static_tool(pb.track(ReadTool::<true>::new()))
-        .static_tool(pb.track(GlobTool::new()))
-        .static_tool(pb.track(GrepTool::<true>::new()))
-        .static_tool(pb.track(BashTool::new()))
+    // === Build agent with chained .tool() calls ===
+    let client = openai::Client::from_env();
+    let agent = client
+        .agent("gpt-4o")
+        .tool(pb.track(ReadTool::<true>::new()))
+        .tool(pb.track(GlobTool::new()))
+        .tool(pb.track(GrepTool::<true>::new()))
+        .tool(pb.track(BashTool::new()))
         // Todo tools share state for read/write coordination
-        .static_tool(pb.track(todos.read))
-        .static_tool(pb.track(todos.write))
-        // Can use any ToolSet method here - dynamic_tool, etc.
+        .tool(pb.track(todos.read))
+        .tool(pb.track(todos.write))
+        .preamble(&pb.build())
         .build();
 
-    // === Generate preamble string ===
-    let preamble = pb.build();
+    // === Use the agent ===
+    let response = agent
+        .prompt("What files are in the current directory?")
+        .await?;
+    println!("{response}");
 
-    // Print the preamble
-    println!("{preamble}");
+    Ok(())
 }

--- a/src/llm-coding-tools-rig/examples/rig-sandboxed.rs
+++ b/src/llm-coding-tools-rig/examples/rig-sandboxed.rs
@@ -7,11 +7,13 @@
 //! - Security-conscious deployments limiting filesystem exposure
 //! - Project-scoped agents that shouldn't touch system files
 //!
-//! Run: cargo run --example rig-sandboxed -p llm-coding-tools-rig
+//! Run: OPENAI_API_KEY=... cargo run --example rig-sandboxed -p llm-coding-tools-rig
 
 use llm_coding_tools_rig::allowed::{EditTool, GlobTool, GrepTool, ReadTool, WriteTool};
 use llm_coding_tools_rig::{AllowedPathResolver, PreambleBuilder};
-use rig::tool::ToolSet;
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::openai;
 use std::path::PathBuf;
 
 #[tokio::main]
@@ -40,20 +42,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let glob = GlobTool::with_resolver(resolver.clone());
     let grep: GrepTool<true> = GrepTool::with_resolver(resolver);
 
-    // === Build toolset ===
+    // === Build agent with sandboxed tools ===
     let mut pb = PreambleBuilder::<false>::new();
-    let _toolset = ToolSet::builder()
-        .static_tool(pb.track(read))
-        .static_tool(pb.track(write))
-        .static_tool(pb.track(edit))
-        .static_tool(pb.track(glob))
-        .static_tool(pb.track(grep))
+    let client = openai::Client::from_env();
+    let agent = client
+        .agent("gpt-4o")
+        .tool(pb.track(read))
+        .tool(pb.track(write))
+        .tool(pb.track(edit))
+        .tool(pb.track(glob))
+        .tool(pb.track(grep))
+        .preamble(&pb.build())
         .build();
 
-    let preamble = pb.build();
-
-    // Print the preamble
-    println!("{preamble}");
+    // === Use the agent ===
+    let response = agent
+        .prompt("List all Rust files in the current directory")
+        .await?;
+    println!("{response}");
 
     Ok(())
 }

--- a/src/llm-coding-tools-rig/src/lib.rs
+++ b/src/llm-coding-tools-rig/src/lib.rs
@@ -1,21 +1,4 @@
-//! Rig framework Tool implementations for coding tools.
-//!
-//! This crate provides `rig_core::tool::Tool` implementations wrapping
-//! the core operations from [`llm_coding_tools_core`].
-//!
-//! # Module Organization
-//!
-//! - [`absolute`] - Tools requiring absolute paths (no path restriction)
-//! - [`allowed`] - Tools restricted to allowed directories
-//! - Standalone tools (bash, todo, webfetch) at crate root
-//!
-//! # Example
-//!
-//! ```no_run
-//! use llm_coding_tools_rig::absolute::ReadTool;
-//! use llm_coding_tools_rig::BashTool;
-//! ```
-
+#![doc = include_str!(concat!("../", env!("CARGO_PKG_README")))]
 #![warn(missing_docs)]
 
 pub mod absolute;

--- a/src/llm-coding-tools-serdesai/README.md
+++ b/src/llm-coding-tools-serdesai/README.md
@@ -43,13 +43,13 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     // Build agent with tools - call .system_prompt() last
     let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
-        .tool_impl(pb.track(ReadTool::<true>::new()))
-        .tool_impl(pb.track(GlobTool::new()))
-        .tool_impl(pb.track(GrepTool::<true>::new()))
-        .tool_impl(pb.track(BashTool::new()))
-        .tool_impl(pb.track(todo_read))
-        .tool_impl(pb.track(todo_write))
-        .system_prompt(&pb.build())  // Last, after tracking all tools
+        .tool(pb.track(ReadTool::<true>::new()))
+        .tool(pb.track(GlobTool::new()))
+        .tool(pb.track(GrepTool::<true>::new()))
+        .tool(pb.track(BashTool::new()))
+        .tool(pb.track(todo_read))
+        .tool(pb.track(todo_write))
+        .system_prompt(pb.build())  // Last, after tracking all tools
         .build();
 
     // Run agent with tools
@@ -84,7 +84,7 @@ let sandboxed_write = AllowedWriteTool::new(allowed_paths).unwrap();
 
 Other tools: `BashTool`, `WebFetchTool`, `TaskTool`, `TodoReadTool`, `TodoWriteTool`.
 Use `PreambleBuilder` to track tools and pass `pb.build()` to `.system_prompt()`.
-Use `AgentBuilderExt::tool_impl()` to add tools that implement `Tool<Deps>` to the agent.
+Use `AgentBuilderExt::tool()` to add tools that implement `Tool<Deps>` to the agent.
 Context strings are re-exported in `llm_coding_tools_serdesai::context` (e.g., `BASH`, `READ_ABSOLUTE`).
 
 ## Examples

--- a/src/llm-coding-tools-serdesai/README.md
+++ b/src/llm-coding-tools-serdesai/README.md
@@ -28,39 +28,47 @@ llm-coding-tools-serdesai = "0.1"
 
 ## Quick Start
 
-```rust
+Minimal runnable agent (requires `OPENAI_API_KEY`):
+
+```rust,no_run
 use llm_coding_tools_serdesai::absolute::{GlobTool, GrepTool, ReadTool};
+use llm_coding_tools_serdesai::agent_ext::AgentBuilderExt;
 use llm_coding_tools_serdesai::{BashTool, PreambleBuilder, create_todo_tools};
-use serdes_ai::tools::ToolRegistry;
+use serdes_ai::prelude::*;
 
 #[tokio::main]
-async fn main() {
-    let mut pb = PreambleBuilder::<false>::new();
-    let mut registry = ToolRegistry::<()>::new();
-
-    registry.register(pb.track(ReadTool::<true>::new()));
-    registry.register(pb.track(GlobTool::new()));
-    registry.register(pb.track(GrepTool::<true>::new()));
-    registry.register(pb.track(BashTool::new()));
-
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let (todo_read, todo_write, _state) = create_todo_tools();
-    registry.register(pb.track(todo_read));
-    registry.register(pb.track(todo_write));
+    let mut pb = PreambleBuilder::<false>::new();
 
-    let preamble = pb.build();
+    // Build agent with tools - call .system_prompt() last
+    let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
+        .tool_impl(pb.track(ReadTool::<true>::new()))
+        .tool_impl(pb.track(GlobTool::new()))
+        .tool_impl(pb.track(GrepTool::<true>::new()))
+        .tool_impl(pb.track(BashTool::new()))
+        .tool_impl(pb.track(todo_read))
+        .tool_impl(pb.track(todo_write))
+        .system_prompt(&pb.build())  // Last, after tracking all tools
+        .build();
 
-    // Pass `preamble` to your agent's system prompt
-    // Pass `registry` to your agent's tools
+    // Run agent with tools
+    let response = agent
+        .run("Search for TODO comments in src/", ())
+        .await?;
+    println!("{}", response.output());
+
+    Ok(())
 }
 ```
 
-See the [basic example](examples/basic.rs) for a complete working setup.
+See the [serdesai-basic example](examples/serdesai-basic.rs) for a complete working setup.
 
 ## Usage
 
 File tools come in `absolute::*` (unrestricted) and `allowed::*` (sandboxed) variants:
 
-```rust
+```rust,no_run
 use llm_coding_tools_serdesai::absolute::{ReadTool, WriteTool};
 use llm_coding_tools_serdesai::allowed::{ReadTool as AllowedReadTool, WriteTool as AllowedWriteTool};
 use std::path::PathBuf;
@@ -70,22 +78,23 @@ let read = ReadTool::<true>::new();
 
 // Sandboxed access (paths relative to allowed directories)
 let allowed_paths = vec![PathBuf::from("/home/user/project"), PathBuf::from("/tmp")];
-let sandboxed_read: AllowedReadTool<true> = AllowedReadTool::new(allowed_paths.clone());
-let sandboxed_write = AllowedWriteTool::new(allowed_paths);
+let sandboxed_read: AllowedReadTool<true> = AllowedReadTool::new(allowed_paths.clone()).unwrap();
+let sandboxed_write = AllowedWriteTool::new(allowed_paths).unwrap();
 ```
 
 Other tools: `BashTool`, `WebFetchTool`, `TaskTool`, `TodoReadTool`, `TodoWriteTool`.
-Use `PreambleBuilder` to register tools and pass `pb.build()` to your agent's system prompt.
+Use `PreambleBuilder` to track tools and pass `pb.build()` to `.system_prompt()`.
+Use `AgentBuilderExt::tool_impl()` to add tools that implement `Tool<Deps>` to the agent.
 Context strings are re-exported in `llm_coding_tools_serdesai::context` (e.g., `BASH`, `READ_ABSOLUTE`).
 
 ## Examples
 
 ```bash
-# Basic toolset setup with PreambleBuilder
-cargo run --example basic -p llm-coding-tools-serdesai
+# Basic agent setup with AgentBuilderExt
+cargo run --example serdesai-basic -p llm-coding-tools-serdesai
 
 # Sandboxed file access with allowed::* tools
-cargo run --example sandboxed -p llm-coding-tools-serdesai
+cargo run --example serdesai-sandboxed -p llm-coding-tools-serdesai
 ```
 
 ## License

--- a/src/llm-coding-tools-serdesai/examples/serdesai-basic.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-basic.rs
@@ -24,18 +24,18 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // === Build agent with tools - call .system_prompt() last ===
     let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
         // File operations
-        .tool_impl(pb.track(ReadTool::<true>::new()))
-        .tool_impl(pb.track(GlobTool::new()))
-        .tool_impl(pb.track(GrepTool::<true>::new()))
+        .tool(pb.track(ReadTool::<true>::new()))
+        .tool(pb.track(GlobTool::new()))
+        .tool(pb.track(GrepTool::<true>::new()))
         // Shell execution
-        .tool_impl(pb.track(BashTool::new()))
+        .tool(pb.track(BashTool::new()))
         // Web content fetching
-        .tool_impl(pb.track(WebFetchTool::new()))
+        .tool(pb.track(WebFetchTool::new()))
         // Todo tools with shared state
-        .tool_impl(pb.track(todo_read))
-        .tool_impl(pb.track(todo_write))
+        .tool(pb.track(todo_read))
+        .tool(pb.track(todo_write))
         // System prompt last (after tracking all tools)
-        .system_prompt(&pb.build())
+        .system_prompt(pb.build())
         .build();
 
     // === Print tool info ===

--- a/src/llm-coding-tools-serdesai/examples/serdesai-basic.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-basic.rs
@@ -3,62 +3,53 @@
 //! Shows:
 //! - Creating tools individually
 //! - Using [`PreambleBuilder`] for context generation
-//! - Registering tools with [`ToolRegistry`]
+//! - Using [`AgentBuilderExt`] to add tools to an agent
+//! - Running the agent with tools
 //!
-//! Run: cargo run --example basic -p llm-coding-tools-serdesai
+//! Run: OPENAI_API_KEY=... cargo run --example serdesai-basic -p llm-coding-tools-serdesai
 
 use llm_coding_tools_serdesai::absolute::{GlobTool, GrepTool, ReadTool};
+use llm_coding_tools_serdesai::agent_ext::AgentBuilderExt;
 use llm_coding_tools_serdesai::{BashTool, PreambleBuilder, WebFetchTool, create_todo_tools};
-use serdes_ai::tools::ToolRegistry;
+use serdes_ai::prelude::*;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // === Create preamble builder to track tools ===
     let mut pb = PreambleBuilder::<false>::new();
 
-    // === Create and register tools with ToolRegistry ===
-    let mut registry = ToolRegistry::<()>::new();
-
-    // File operations
-    registry.register(pb.track(ReadTool::<true>::new()));
-    registry.register(pb.track(GlobTool::new()));
-    registry.register(pb.track(GrepTool::<true>::new()));
-
-    // Shell execution
-    registry.register(pb.track(BashTool::new()));
-
-    // Web content fetching
-    registry.register(pb.track(WebFetchTool::new()));
-
-    // Todo tools with shared state
+    // === Create todo tools with shared state ===
     let (todo_read, todo_write, _state) = create_todo_tools();
-    registry.register(pb.track(todo_read));
-    registry.register(pb.track(todo_write));
 
-    // === Generate preamble string ===
-    let preamble = pb.build();
+    // === Build agent with tools - call .system_prompt() last ===
+    let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
+        // File operations
+        .tool_impl(pb.track(ReadTool::<true>::new()))
+        .tool_impl(pb.track(GlobTool::new()))
+        .tool_impl(pb.track(GrepTool::<true>::new()))
+        // Shell execution
+        .tool_impl(pb.track(BashTool::new()))
+        // Web content fetching
+        .tool_impl(pb.track(WebFetchTool::new()))
+        // Todo tools with shared state
+        .tool_impl(pb.track(todo_read))
+        .tool_impl(pb.track(todo_write))
+        // System prompt last (after tracking all tools)
+        .system_prompt(&pb.build())
+        .build();
 
-    // === Print tool definitions from registry ===
-    println!("=== Tools in Registry ({}) ===", registry.len());
-    for def in registry.definitions() {
-        println!("  - {}: {}", def.name, def.description);
-    }
+    // === Print tool info ===
+    println!("=== Agent Ready ({} tools) ===", agent.tools().len());
 
-    // === Print generated preamble ===
-    println!(
-        "\n=== Generated Preamble ({} chars) ===\n",
-        preamble.chars().count()
-    );
-    println!("{}", preamble);
+    // === Run the agent ===
+    println!("\n=== Running Agent ===");
+    let result = agent
+        .run(
+            "List the Rust files in the current directory using glob",
+            (),
+        )
+        .await?;
+    println!("\n=== Response ===\n{}", result.output());
 
-    // === Integration with serdesAI Agent ===
-    // IMPORTANT: Pass the preamble to your agent's system prompt!
-    //
-    // let agent = Agent::builder()
-    //     .model("openai:gpt-4o")
-    //     .system_prompt(&preamble)
-    //     .tools(registry)
-    //     .build()?;
-    //
-    // let response = agent.run("Read Cargo.toml", ()).await?;
+    Ok(())
 }

--- a/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed.rs
@@ -35,12 +35,12 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // === Build agent with sandboxed tools - call .system_prompt() last ===
     let mut pb = PreambleBuilder::<false>::new();
     let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
-        .tool_impl(pb.track(read))
-        .tool_impl(pb.track(write))
-        .tool_impl(pb.track(edit))
-        .tool_impl(pb.track(glob))
-        .tool_impl(pb.track(grep))
-        .system_prompt(&pb.build())
+        .tool(pb.track(read))
+        .tool(pb.track(write))
+        .tool(pb.track(edit))
+        .tool(pb.track(glob))
+        .tool(pb.track(grep))
+        .system_prompt(pb.build())
         .build();
 
     // === Print info ===

--- a/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed.rs
@@ -26,11 +26,11 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     ];
 
     // === Create tools with allowed paths ===
-    let read: ReadTool<true> = ReadTool::new(allowed_paths.clone()).unwrap();
-    let write = WriteTool::new(allowed_paths.clone()).unwrap();
-    let edit = EditTool::new(allowed_paths.clone()).unwrap();
-    let glob = GlobTool::new(allowed_paths.clone()).unwrap();
-    let grep: GrepTool<true> = GrepTool::new(allowed_paths).unwrap();
+    let read: ReadTool<true> = ReadTool::new(allowed_paths.clone())?;
+    let write = WriteTool::new(allowed_paths.clone())?;
+    let edit = EditTool::new(allowed_paths.clone())?;
+    let glob = GlobTool::new(allowed_paths.clone())?;
+    let grep: GrepTool<true> = GrepTool::new(allowed_paths)?;
 
     // === Build agent with sandboxed tools - call .system_prompt() last ===
     let mut pb = PreambleBuilder::<false>::new();

--- a/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed.rs
@@ -7,14 +7,15 @@
 //! - Security-conscious deployments limiting filesystem exposure
 //! - Project-scoped agents that shouldn't touch system files
 //!
-//! Run: cargo run --example sandboxed -p llm-coding-tools-serdesai
+//! Run: OPENAI_API_KEY=... cargo run --example serdesai-sandboxed -p llm-coding-tools-serdesai
 
 use llm_coding_tools_serdesai::PreambleBuilder;
+use llm_coding_tools_serdesai::agent_ext::AgentBuilderExt;
 use llm_coding_tools_serdesai::allowed::{EditTool, GlobTool, GrepTool, ReadTool, WriteTool};
-use serdes_ai::tools::ToolRegistry;
+use serdes_ai::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // === Define allowed directories ===
     //
     // Only these directories (and their subdirectories) will be accessible.
@@ -25,29 +26,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
 
     // === Create tools with allowed paths ===
-    //
-    // Each tool is initialized with the same set of allowed directories.
-    // The `allowed` module tools use `AllowedPathResolver` internally.
-    let read: ReadTool<true> = ReadTool::new(allowed_paths.clone())?;
-    let write = WriteTool::new(allowed_paths.clone())?;
-    let edit = EditTool::new(allowed_paths.clone())?;
-    let glob = GlobTool::new(allowed_paths.clone())?;
-    let grep: GrepTool<true> = GrepTool::new(allowed_paths)?;
+    let read: ReadTool<true> = ReadTool::new(allowed_paths.clone()).unwrap();
+    let write = WriteTool::new(allowed_paths.clone()).unwrap();
+    let edit = EditTool::new(allowed_paths.clone()).unwrap();
+    let glob = GlobTool::new(allowed_paths.clone()).unwrap();
+    let grep: GrepTool<true> = GrepTool::new(allowed_paths).unwrap();
 
-    // === Build registry with preamble tracking ===
+    // === Build agent with sandboxed tools - call .system_prompt() last ===
     let mut pb = PreambleBuilder::<false>::new();
-    let mut registry = ToolRegistry::<()>::new();
+    let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
+        .tool_impl(pb.track(read))
+        .tool_impl(pb.track(write))
+        .tool_impl(pb.track(edit))
+        .tool_impl(pb.track(glob))
+        .tool_impl(pb.track(grep))
+        .system_prompt(&pb.build())
+        .build();
 
-    registry.register(pb.track(read));
-    registry.register(pb.track(write));
-    registry.register(pb.track(edit));
-    registry.register(pb.track(glob));
-    registry.register(pb.track(grep));
+    // === Print info ===
+    println!(
+        "=== Sandboxed Agent Ready ({} tools) ===",
+        agent.tools().len()
+    );
+    println!("Allowed paths:");
+    println!("  - Current directory: {:?}", std::env::current_dir()?);
+    println!("  - Temp directory: {:?}", std::env::temp_dir());
 
-    let preamble = pb.build();
-
-    // Print the preamble
-    println!("{preamble}");
+    // === Run the agent ===
+    println!("\n=== Running Agent ===");
+    let result = agent
+        .run("List all Rust source files in the current directory", ())
+        .await?;
+    println!("\n=== Response ===\n{}", result.output());
 
     Ok(())
 }

--- a/src/llm-coding-tools-serdesai/src/agent_ext.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_ext.rs
@@ -5,15 +5,19 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use llm_coding_tools_serdesai::absolute::ReadTool;
+//! ```no_run
+//! use llm_coding_tools_serdesai::absolute::{ReadTool, GlobTool};
 //! use llm_coding_tools_serdesai::agent_ext::AgentBuilderExt;
 //! use serdes_ai::prelude::*;
 //!
+//! # fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 //! let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
+//!     .tool(ReadTool::<true>::new())
+//!     .tool(GlobTool::new())
 //!     .system_prompt("You are helpful.")
-//!     .tool_impl(ReadTool::<true>::new())
 //!     .build();
+//! # Ok(())
+//! # }
 //! ```
 
 use async_trait::async_trait;
@@ -54,17 +58,20 @@ pub trait AgentBuilderExt<Deps, Output> {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// use llm_coding_tools_serdesai::absolute::ReadTool;
+    /// ```no_run
+    /// use llm_coding_tools_serdesai::absolute::{ReadTool, GlobTool};
     /// use llm_coding_tools_serdesai::agent_ext::AgentBuilderExt;
     /// use serdes_ai::prelude::*;
     ///
+    /// # fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     /// let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
-    ///     .tool_impl(ReadTool::<true>::new())
-    ///     .tool_impl(GlobTool::new())
+    ///     .tool(ReadTool::<true>::new())
+    ///     .tool(GlobTool::new())
     ///     .build();
+    /// # Ok(())
+    /// # }
     /// ```
-    fn tool_impl<T: Tool<Deps> + 'static>(self, tool: T) -> Self;
+    fn tool<T: Tool<Deps> + 'static>(self, tool: T) -> Self;
 }
 
 impl<Deps, Output> AgentBuilderExt<Deps, Output> for AgentBuilder<Deps, Output>
@@ -72,7 +79,7 @@ where
     Deps: Send + Sync + 'static,
     Output: Send + Sync + 'static,
 {
-    fn tool_impl<T: Tool<Deps> + 'static>(self, tool: T) -> Self {
+    fn tool<T: Tool<Deps> + 'static>(self, tool: T) -> Self {
         let definition = tool.definition();
         self.tool_with_executor(definition, ToolAsExecutor(tool))
     }

--- a/src/llm-coding-tools-serdesai/src/agent_ext.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_ext.rs
@@ -1,0 +1,79 @@
+//! Extension traits for integrating tools with serdes-ai AgentBuilder.
+//!
+//! This module provides adapters to use [`Tool`] implementations with
+//! serdes-ai's [`AgentBuilder`].
+//!
+//! # Example
+//!
+//! ```ignore
+//! use llm_coding_tools_serdesai::absolute::ReadTool;
+//! use llm_coding_tools_serdesai::agent_ext::AgentBuilderExt;
+//! use serdes_ai::prelude::*;
+//!
+//! let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
+//!     .system_prompt("You are helpful.")
+//!     .tool_impl(ReadTool::<true>::new())
+//!     .build();
+//! ```
+
+use async_trait::async_trait;
+use serde_json::Value as JsonValue;
+use serdes_ai::agent::ToolExecutor;
+use serdes_ai::tools::{RunContext as ToolsRunContext, Tool, ToolError, ToolReturn};
+use serdes_ai::{AgentBuilder, RunContext as AgentRunContext};
+
+/// Adapter that wraps a [`Tool`] to implement [`ToolExecutor`].
+///
+/// This bridges the gap between `serdes_ai::tools::Tool` (which uses
+/// `tools::RunContext`) and `serdes_ai::agent::ToolExecutor` (which uses
+/// `agent::RunContext`).
+struct ToolAsExecutor<T>(T);
+
+#[async_trait]
+impl<Deps: Send + Sync + 'static, T: Tool<Deps>> ToolExecutor<Deps> for ToolAsExecutor<T> {
+    async fn execute(
+        &self,
+        args: JsonValue,
+        ctx: &AgentRunContext<Deps>,
+    ) -> Result<ToolReturn, ToolError> {
+        // Convert agent::RunContext to tools::RunContext
+        let tools_ctx = ToolsRunContext::from_arc(ctx.deps.clone(), &ctx.model_name)
+            .with_run_id(&ctx.run_id)
+            .with_model_settings(ctx.model_settings.clone());
+
+        self.0.call(&tools_ctx, args).await
+    }
+}
+
+/// Extension trait for [`AgentBuilder`] to add tools that implement [`Tool`].
+pub trait AgentBuilderExt<Deps, Output> {
+    /// Add a tool that implements the [`Tool`] trait.
+    ///
+    /// This is a convenience method that extracts the tool's definition
+    /// and wraps it with an executor adapter.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use llm_coding_tools_serdesai::absolute::ReadTool;
+    /// use llm_coding_tools_serdesai::agent_ext::AgentBuilderExt;
+    /// use serdes_ai::prelude::*;
+    ///
+    /// let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
+    ///     .tool_impl(ReadTool::<true>::new())
+    ///     .tool_impl(GlobTool::new())
+    ///     .build();
+    /// ```
+    fn tool_impl<T: Tool<Deps> + 'static>(self, tool: T) -> Self;
+}
+
+impl<Deps, Output> AgentBuilderExt<Deps, Output> for AgentBuilder<Deps, Output>
+where
+    Deps: Send + Sync + 'static,
+    Output: Send + Sync + 'static,
+{
+    fn tool_impl<T: Tool<Deps> + 'static>(self, tool: T) -> Self {
+        let definition = tool.definition();
+        self.tool_with_executor(definition, ToolAsExecutor(tool))
+    }
+}

--- a/src/llm-coding-tools-serdesai/src/convert.rs
+++ b/src/llm-coding-tools-serdesai/src/convert.rs
@@ -144,9 +144,7 @@ mod tests {
     #[test]
     fn invalid_path_error_maps_to_validation_error() {
         let core_err = CoreError::InvalidPath("not absolute".into());
-        let result: Result<ToolReturn, SerdesError> =
-            Err(core_error_to_serdes("test_tool", core_err));
-        let serdes_err = result.unwrap_err();
+        let serdes_err = core_error_to_serdes("test_tool", core_err);
         // Use pattern matching - is_validation_error() doesn't exist
         assert!(matches!(serdes_err, SerdesError::ValidationFailed { .. }));
     }
@@ -154,18 +152,14 @@ mod tests {
     #[test]
     fn invalid_pattern_error_maps_to_validation_error() {
         let core_err = CoreError::InvalidPattern("bad regex".into());
-        let result: Result<ToolReturn, SerdesError> =
-            Err(core_error_to_serdes("test_tool", core_err));
-        let serdes_err = result.unwrap_err();
+        let serdes_err = core_error_to_serdes("test_tool", core_err);
         assert!(matches!(serdes_err, SerdesError::ValidationFailed { .. }));
     }
 
     #[test]
     fn out_of_bounds_error_maps_to_validation_error() {
         let core_err = CoreError::OutOfBounds("offset too large".into());
-        let result: Result<ToolReturn, SerdesError> =
-            Err(core_error_to_serdes("test_tool", core_err));
-        let serdes_err = result.unwrap_err();
+        let serdes_err = core_error_to_serdes("test_tool", core_err);
         assert!(matches!(serdes_err, SerdesError::ValidationFailed { .. }));
     }
 

--- a/src/llm-coding-tools-serdesai/src/lib.rs
+++ b/src/llm-coding-tools-serdesai/src/lib.rs
@@ -1,24 +1,8 @@
-//! serdesAI framework Tool implementations for coding tools.
-//!
-//! This crate provides `serdes_ai::Tool` implementations wrapping
-//! the core operations from [`llm_coding_tools_core`].
-//!
-//! # Module Organization
-//!
-//! - [`absolute`] - Tools requiring absolute paths (no path restriction)
-//! - [`allowed`] - Tools restricted to allowed directories
-//! - Standalone tools (bash, todo, webfetch) at crate root
-//!
-//! # Example
-//!
-//! ```no_run
-//! use llm_coding_tools_serdesai::absolute::ReadTool;
-//! use llm_coding_tools_serdesai::BashTool;
-//! ```
-
+#![doc = include_str!(concat!("../", env!("CARGO_PKG_README")))]
 #![warn(missing_docs)]
 
 pub mod absolute;
+pub mod agent_ext;
 pub mod allowed;
 pub mod bash;
 pub mod convert;


### PR DESCRIPTION
## Summary

- Added `AgentBuilderExt` trait for serdesai to bridge `Tool<Deps>` to `AgentBuilder`
- Updated rig examples to use `client.agent().tool()` instead of `ToolSet::builder()`
- Updated serdesai examples to use `AgentBuilderExt::tool()`
- Updated READMEs and doc comments to reflect the new patterns

## Details

The agent builder pattern is the idiomatic way to construct agents with tools, replacing the deprecated `ToolSet::builder().static_tool()` approach.

### Rig Examples
```rust
// Before
let _toolset = ToolSet::builder()
    .static_tool(pb.track(ReadTool::new()))
    .build();

// After
let agent = client
    .agent("gpt-4o")
    .tool(pb.track(ReadTool::<true>::new()))
    .preamble(&pb.build())
    .build();
```

### SerdesAI Examples
Created `AgentBuilderExt` trait with `.tool()` method to bridge the gap between `serdes_ai::tools::Tool` and `serdes_ai::agent::ToolExecutor`.

```rust
let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
    .tool(pb.track(ReadTool::<true>::new()))
    .system_prompt(pb.build())  // Called LAST after tracking tools
    .build();
```