### PR TITLE
CI: Add llm-coding-tools-serdesai to semver checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
           cargo +stable binstall --no-confirm cargo-semver-checks --force
           rustup +stable target add ${{ matrix.target }}
 
-          for CRATE in "llm-coding-tools-core" "llm-coding-tools-rig"; do
+          for CRATE in "llm-coding-tools-core" "llm-coding-tools-rig" "llm-coding-tools-serdesai"; do
             SEARCH_RESULT=$(cargo search "^${CRATE}$" --limit 1)
             if echo "$SEARCH_RESULT" | grep -q "^${CRATE} "; then
               echo "Running semver checks for ${CRATE}..."


### PR DESCRIPTION
## Summary
- Add `llm-coding-tools-serdesai` to the semver checks loop in the CI workflow
- Previously only `llm-coding-tools-core` and `llm-coding-tools-rig` were being checked for semver compliance