### PR TITLE
Changed: Move Edit-specific error conversion to common module

### DIFF
--- a/src/llm-coding-tools-serdesai/src/absolute/edit.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/edit.rs
@@ -10,7 +10,7 @@ use serdes_ai::tools::{
     RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult, ToolReturn,
 };
 
-use crate::convert::edit_error_to_serdes;
+use crate::common::edit::error_to_serdes;
 
 /// Internal args for JSON deserialization.
 #[derive(Debug, Deserialize)]
@@ -74,7 +74,7 @@ impl<Deps: Send + Sync> Tool<Deps> for EditTool {
         )
         .await;
 
-        result.map(ToolReturn::text).map_err(edit_error_to_serdes)
+        result.map(ToolReturn::text).map_err(error_to_serdes)
     }
 }
 

--- a/src/llm-coding-tools-serdesai/src/allowed/edit.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/edit.rs
@@ -11,7 +11,7 @@ use serdes_ai::tools::{
 };
 use std::path::Path;
 
-use crate::convert::edit_error_to_serdes;
+use crate::common::edit::error_to_serdes;
 
 /// Internal args for JSON deserialization.
 #[derive(Debug, Deserialize)]
@@ -86,7 +86,7 @@ impl<Deps: Send + Sync> Tool<Deps> for EditTool {
         )
         .await;
 
-        result.map(ToolReturn::text).map_err(edit_error_to_serdes)
+        result.map(ToolReturn::text).map_err(error_to_serdes)
     }
 }
 

--- a/src/llm-coding-tools-serdesai/src/common/edit.rs
+++ b/src/llm-coding-tools-serdesai/src/common/edit.rs
@@ -1,0 +1,40 @@
+//! Shared helpers for Edit tool implementations.
+
+use llm_coding_tools_core::operations::EditError;
+use llm_coding_tools_core::tool_names;
+use serdes_ai::tools::ToolError;
+
+use crate::convert::core_error_to_serdes;
+
+/// Convert [`EditError`] to serdesAI error.
+///
+/// Maps edit-specific errors to appropriate error types:
+/// - Validation errors: `NotFound`, `AmbiguousMatch`, `EmptyOldString`, `IdenticalStrings`
+/// - Execution errors: `Tool(ToolError)` (IO, path errors)
+pub(crate) fn error_to_serdes(err: EditError) -> ToolError {
+    match err {
+        EditError::NotFound => ToolError::validation_error(
+            tool_names::EDIT,
+            Some("old_string".to_string()),
+            "old_string not found in file content".to_string(),
+        ),
+        EditError::AmbiguousMatch(count) => ToolError::validation_error(
+            tool_names::EDIT,
+            Some("old_string".to_string()),
+            format!(
+                "old_string found {count} times and requires more code context to uniquely identify the intended match"
+            ),
+        ),
+        EditError::EmptyOldString => ToolError::validation_error(
+            tool_names::EDIT,
+            Some("old_string".to_string()),
+            "old_string must not be empty".to_string(),
+        ),
+        EditError::IdenticalStrings => ToolError::validation_error(
+            tool_names::EDIT,
+            None,
+            "old_string and new_string must be different".to_string(),
+        ),
+        EditError::Tool(tool_err) => core_error_to_serdes(tool_names::EDIT, tool_err),
+    }
+}

--- a/src/llm-coding-tools-serdesai/src/common/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/common/mod.rs
@@ -1,0 +1,3 @@
+//! Shared helpers for tool implementations.
+
+pub(crate) mod edit;

--- a/src/llm-coding-tools-serdesai/src/convert.rs
+++ b/src/llm-coding-tools-serdesai/src/convert.rs
@@ -5,8 +5,6 @@
 //!
 //! [`llm_coding_tools_core`]: llm_coding_tools_core
 
-use llm_coding_tools_core::operations::EditError;
-use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::{ToolError as CoreError, ToolOutput, ToolResult as CoreResult};
 use serde_json::json;
 use serdes_ai::tools::{ToolError as SerdesError, ToolReturn};
@@ -57,41 +55,6 @@ pub fn to_serdes_result(
     result
         .map(output_to_return)
         .map_err(|err| core_error_to_serdes(tool_name, err))
-}
-
-/// Convert [`EditError`] to serdesAI error.
-///
-/// Maps edit-specific errors to appropriate error types:
-/// - Validation errors: `NotFound`, `AmbiguousMatch`, `EmptyOldString`, `IdenticalStrings`
-/// - Execution errors: `Tool(ToolError)` (IO, path errors)
-///
-/// [`EditError`]: llm_coding_tools_core::operations::EditError
-pub fn edit_error_to_serdes(err: EditError) -> SerdesError {
-    match err {
-        EditError::NotFound => SerdesError::validation_error(
-            tool_names::EDIT,
-            Some("old_string".to_string()),
-            "old_string not found in file content".to_string(),
-        ),
-        EditError::AmbiguousMatch(count) => SerdesError::validation_error(
-            tool_names::EDIT,
-            Some("old_string".to_string()),
-            format!(
-                "old_string found {count} times and requires more code context to uniquely identify the intended match"
-            ),
-        ),
-        EditError::EmptyOldString => SerdesError::validation_error(
-            tool_names::EDIT,
-            Some("old_string".to_string()),
-            "old_string must not be empty".to_string(),
-        ),
-        EditError::IdenticalStrings => SerdesError::validation_error(
-            tool_names::EDIT,
-            None,
-            "old_string and new_string must be different".to_string(),
-        ),
-        EditError::Tool(tool_err) => core_error_to_serdes(tool_names::EDIT, tool_err),
-    }
 }
 
 /// Convert core [`ToolError`][core] to serdesAI [`ToolError`][serdes] with tool name context.

--- a/src/llm-coding-tools-serdesai/src/lib.rs
+++ b/src/llm-coding-tools-serdesai/src/lib.rs
@@ -5,6 +5,7 @@ pub mod absolute;
 pub mod agent_ext;
 pub mod allowed;
 pub mod bash;
+mod common;
 pub mod convert;
 pub mod todo;
 pub mod webfetch;


### PR DESCRIPTION
## Summary

- Extract tool-specific error handling from `convert.rs` into new `common/edit.rs` module
- `convert.rs` now contains only general-purpose conversions (`output_to_return`, `to_serdes_result`, `core_error_to_serdes`)
- Both `absolute/edit.rs` and `allowed/edit.rs` now import `error_to_serdes` from `common::edit`

This establishes a pattern for future tool-specific helpers - each tool can have its own module under `common/` if needed.

## Structure

```
llm-coding-tools-serdesai/src/
├── common/
│   ├── mod.rs          # Shared helpers module
│   └── edit.rs         # Edit-specific error_to_serdes
├── convert.rs          # General conversions only
├── absolute/edit.rs    # Uses common::edit::error_to_serdes
└── allowed/edit.rs     # Uses common::edit::error_to_serdes
```