### PR TITLE
Log serdesai stream output as XML entries

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -104,9 +104,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.2"
+version = "1.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
+checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
+checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
 dependencies = [
  "cc",
  "cmake",
@@ -170,9 +170,9 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.51"
+version = "1.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
+checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -471,9 +471,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "fnv"
@@ -619,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -747,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "html-to-markdown-rs"
-version = "2.22.5"
+version = "2.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b25aeeb0e1b159e10a8af787b3b8cda1851aca02bbc5645086ad493db6c87"
+checksum = "e1f4d6781ac8dd203853803d27054ca4153c7fd0f3956cb7fc95dc06f42a1c46"
 dependencies = [
  "astral-tl",
  "base64",
@@ -761,7 +761,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1117,9 +1117,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.179"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1152,7 +1152,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "wiremock",
 ]
@@ -1206,9 +1206,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
  "hashbrown",
 ]
@@ -1535,7 +1535,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1557,7 +1557,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1610,7 +1610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1630,7 +1630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1639,14 +1639,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
@@ -1816,7 +1816,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -1831,7 +1831,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1885,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1922,9 +1922,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2084,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8569bee40f2a987f3475e3d6782d8a77f06de16c39673028039c6243b2a0ecf9"
+checksum = "529a55f25c8f40f691c1ccdbbd7e6e0f7c610365b0848a4affcdc5444cbbb9aa"
 dependencies = [
  "futures",
  "serdes-ai-agent",
@@ -2105,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-agent"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed7bd40c9d7926475b223a077d5bf21bddba5181f52037ece4f92fd637ac5e7"
+checksum = "eb86956517388c219f8bdcd2d06a26323bcd209aa62e975986747f48d0764383"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2127,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "676c99ca60334ed24283a4468273ceada2756c0fb7de4b013c6d6d95fd4047ef"
+checksum = "0edca768fae68ebc176484581627d6138abeb68df0bd5643d0b858a54898986e"
 dependencies = [
  "anyhow",
  "base64",
@@ -2147,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18800715aeadd544510c8f9c201ccd39386767ebc6bf39676f6fa9c71363942f"
+checksum = "0866b17dfd0172f3d0f58126e6ad2572edff6be55fbce74d3a96e5d9bb150557"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2159,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-models"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6509a072a0853207cb80849fdafc6c3840b41e6a8c03b8613d1148158673356f"
+checksum = "43e45f57f5d00cdcc56a4c455bdd29180dc79989321f88d6ad1a7872df8a6c85"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2186,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-output"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c382cd2cc061d118c9390e5445f8655acc8cacb430eae1c24a09927f23c767a9"
+checksum = "d9a7840de58a2c7a353f01efa0001b97d7d771df9d8cf9dac16d726bda880cce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2207,13 +2207,13 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-providers"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d421ede16430bd11fc3539aea7e55d7b8491157b18ae5430262cfaa0f64a4e5"
+checksum = "d8066463375ef9f3d96808cf9c2d9d0889090d99f797150b0b3ea5dd16fb3b6b"
 dependencies = [
  "async-trait",
  "base64",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "parking_lot",
  "reqwest 0.12.28",
  "serde",
@@ -2229,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-retries"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1f7a5278e683e094981fbb235b8b4633dea5eb2143ae24cc82f50685b0b73e"
+checksum = "42080e96dd393ab010836de92d19b3e28e023e788d0b2ebbd66fb2774b283111"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2245,9 +2245,9 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-streaming"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804ecff9861822dce45e4b11d6317a9afa41413f0c0e009bd66f92dcf2bbe7dc"
+checksum = "e372252366e5b85da53ed1a3106ea4c1a4216f1dd39ebaaf1a7f04ddced3842b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2265,9 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-tools"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1548b8e44d2320944c741ff51b08c728776ab92d2f145a9175d6657fe9ec19f2"
+checksum = "9acc8f423aaa6e83ff6bb2ecac6c51651e9e82a7f38a5e6acb929e68eaa13b55"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2285,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-toolsets"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d62f4cd04af6b4907bbd8ce28161a18e17223d631f18e20adb266bcec034e56"
+checksum = "a0749ffa1aad64623e00d00217dcf72aa95853d52159a4bfe89927c9308d7c67"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2372,7 +2372,6 @@ dependencies = [
  "parking_lot",
  "phf_shared",
  "precomputed-hash",
- "serde",
 ]
 
 [[package]]
@@ -2486,11 +2485,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2506,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2604,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2802,18 +2801,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2824,11 +2823,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -2837,9 +2837,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2847,9 +2847,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2860,9 +2860,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
@@ -2882,9 +2882,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2902,9 +2902,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd0c322f146d0f8aad130ce6c187953889359584497dac6561204c8e17bb43d"
+checksum = "30e588f10c7bc3465f5fc1ab087fc97877ec1064a7ec89fb685ac4ee998dac4a"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -3345,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
@@ -3470,6 +3470,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.12"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"

--- a/src/llm-coding-tools-serdesai/examples/serdesai-basic.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-basic.rs
@@ -14,6 +14,7 @@ use llm_coding_tools_serdesai::agent_ext::AgentBuilderExt;
 use llm_coding_tools_serdesai::{BashTool, SystemPromptBuilder, WebFetchTool, create_todo_tools};
 use serdes_ai::models::openrouter::OpenRouterModel;
 use serdes_ai::prelude::*;
+use std::fmt::Write;
 
 // API key below has a zero spend limit; it cannot incur charges.
 // If this no longer works, find a free model to use on OpenRouter for testing.
@@ -56,15 +57,28 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let prompt = "List the Rust files in the current directory using glob";
     let mut stream = agent.run_stream(prompt, ()).await?;
 
+    fn log_xml(request_id: u32, tag: &str, content: &str) {
+        let mut line = String::with_capacity(content.len() + tag.len() * 2 + 18);
+        let _ = write!(line, "<{request_id}:{tag}>{content}</{tag}>");
+        println!("{line}");
+    }
+
+    let mut request_id = 0u32;
+    log_xml(request_id, "user", prompt);
+    request_id = request_id.saturating_add(1);
+    let mut assistant_message = String::with_capacity(256);
+
     while let Some(event) = stream.next().await {
         match event? {
-            AgentStreamEvent::TextDelta { text, .. } => print!("{text}"),
-            AgentStreamEvent::ToolCallStart {
-                tool_name,
-                tool_call_id,
-            } => {
-                let call_id = tool_call_id.unwrap_or_else(|| "unknown".to_string());
-                println!("Tool call start: {tool_name} ({call_id})");
+            AgentStreamEvent::TextDelta { text, .. } => assistant_message.push_str(&text),
+            AgentStreamEvent::RequestStart { .. } => assistant_message.clear(),
+            AgentStreamEvent::ToolCallStart { tool_name, .. } => {
+                log_xml(request_id, "tool", &tool_name);
+                request_id = request_id.saturating_add(1);
+            }
+            AgentStreamEvent::ResponseComplete { .. } => {
+                log_xml(request_id, "assistant", &assistant_message);
+                request_id = request_id.saturating_add(1);
             }
             _ => {}
         }

--- a/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed.rs
@@ -16,6 +16,7 @@ use llm_coding_tools_serdesai::agent_ext::AgentBuilderExt;
 use llm_coding_tools_serdesai::allowed::{EditTool, GlobTool, GrepTool, ReadTool, WriteTool};
 use serdes_ai::models::openrouter::OpenRouterModel;
 use serdes_ai::prelude::*;
+use std::fmt::Write;
 
 // API key below has a zero spend limit; it cannot incur charges.
 // If this no longer works, find a free model to use on OpenRouter for testing.
@@ -79,15 +80,28 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let prompt = "List the Rust files in the current directory using glob";
     let mut stream = agent.run_stream(prompt, ()).await?;
 
+    fn log_xml(request_id: u32, tag: &str, content: &str) {
+        let mut line = String::with_capacity(content.len() + tag.len() * 2 + 18);
+        let _ = write!(line, "<{request_id}:{tag}>{content}</{tag}>");
+        println!("{line}");
+    }
+
+    let mut request_id = 0u32;
+    log_xml(request_id, "user", prompt);
+    request_id = request_id.saturating_add(1);
+    let mut assistant_message = String::with_capacity(256);
+
     while let Some(event) = stream.next().await {
         match event? {
-            AgentStreamEvent::TextDelta { text, .. } => print!("{}", text),
-            AgentStreamEvent::ToolCallStart {
-                tool_name,
-                tool_call_id,
-            } => {
-                let call_id = tool_call_id.unwrap_or_else(|| "unknown".to_string());
-                println!("Tool call start: {tool_name} ({call_id})");
+            AgentStreamEvent::TextDelta { text, .. } => assistant_message.push_str(&text),
+            AgentStreamEvent::RequestStart { .. } => assistant_message.clear(),
+            AgentStreamEvent::ToolCallStart { tool_name, .. } => {
+                log_xml(request_id, "tool", &tool_name);
+                request_id = request_id.saturating_add(1);
+            }
+            AgentStreamEvent::ResponseComplete { .. } => {
+                log_xml(request_id, "assistant", &assistant_message);
+                request_id = request_id.saturating_add(1);
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary
- Emit numbered <n:user|assistant|tool> entries for stream logging in the serdesai basic and sandboxed examples so output is parseable.
- Refresh Cargo.lock after verification to keep dependencies in sync.

## Testing
- `.cargo/verify.sh` (fails: publish dry-run cannot find llm-coding-tools-core on crates.io)