### PR TITLE
Add serdesAI framework to README and remove task delegation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,6 +2,7 @@
 
 [![Crates.io - llm-coding-tools-core](https://img.shields.io/crates/v/llm-coding-tools-core.svg)](https://crates.io/crates/llm-coding-tools-core)
 [![Crates.io - llm-coding-tools-rig](https://img.shields.io/crates/v/llm-coding-tools-rig.svg)](https://crates.io/crates/llm-coding-tools-rig)
+[![Crates.io - llm-coding-tools-serdesai](https://img.shields.io/crates/v/llm-coding-tools-serdesai.svg)](https://crates.io/crates/llm-coding-tools-serdesai)
 [![Docs.rs](https://docs.rs/llm-coding-tools-rig/badge.svg)](https://docs.rs/llm-coding-tools-rig)
 [![CI](https://github.com/Sewer56/llm-coding-tools/actions/workflows/rust.yml/badge.svg)](https://github.com/Sewer56/llm-coding-tools/actions)
 
@@ -13,6 +14,7 @@ This workspace contains multiple Rust crates for integrating coding tools with L
 
 - **[llm-coding-tools-core](./src/llm-coding-tools-core/)**: Framework-agnostic core operations and utilities
 - **[llm-coding-tools-rig](./src/llm-coding-tools-rig/)**: Rig framework-specific Tool implementations
+- **[llm-coding-tools-serdesai](./src/llm-coding-tools-serdesai/)**: serdesAI framework-specific Tool implementations
 
 ## Features
 
@@ -20,7 +22,6 @@ This workspace contains multiple Rust crates for integrating coding tools with L
 - **Search**: Glob pattern matching and regex content search  
 - **Shell**: Cross-platform command execution with timeout
 - **Web**: URL fetching with HTML-to-markdown conversion
-- **Task Delegation**: Sub-agent spawning for complex workflows
 - **Path Security**: Choose between unrestricted or sandboxed file access
 - **Context Strings**: Embedded LLM guidance for tool usage
 
@@ -37,6 +38,8 @@ Add to your `Cargo.toml`:
 [dependencies]
 llm-coding-tools-rig = "0.1"
 ```
+
+See also [llm-coding-tools-serdesai](./src/llm-coding-tools-serdesai/README.md) for serdesAI framework support.
 
 ```rust,no_run
 use llm_coding_tools_rig::absolute::{ReadTool, WriteTool, GlobTool};
@@ -67,20 +70,24 @@ let agent = client
 ## Examples
 
 ```bash
-# Basic toolset setup
-cargo run --example basic -p llm-coding-tools-rig
+# Rig framework - Basic toolset setup
+cargo run --example rig-basic -p llm-coding-tools-rig
 
-# Complete agent configuration (recommended starting point)
-cargo run --example full_agent -p llm-coding-tools-rig
+# Rig framework - Sandboxed file access
+cargo run --example rig-sandboxed -p llm-coding-tools-rig
 
-# Sandboxed file access
-cargo run --example sandboxed -p llm-coding-tools-rig
+# serdesAI framework - Basic agent setup
+cargo run --example serdesai-basic -p llm-coding-tools-serdesai
+
+# serdesAI framework - Sandboxed file access
+cargo run --example serdesai-sandboxed -p llm-coding-tools-serdesai
 ```
 
 ## Documentation
 
 - [llm-coding-tools-core README](./src/llm-coding-tools-core/README.md)
 - [llm-coding-tools-rig README](./src/llm-coding-tools-rig/README.md)
+- [llm-coding-tools-serdesai README](./src/llm-coding-tools-serdesai/README.md)
 - [Developer Guidelines](./src/AGENTS.md)
 
 ## Contributing

--- a/src/llm-coding-tools-rig/README.md
+++ b/src/llm-coding-tools-rig/README.md
@@ -12,7 +12,6 @@ Lightweight, high-performance Rig framework Tool implementations for coding tool
   - `allowed::*` - Sandboxed to configured directories
 - **Shell execution** - Cross-platform command execution with timeout
 - **Web fetching** - URL content retrieval with format conversion
-- **Task delegation** - Sub-agent spawning for complex tasks
 - **Todo management** - Shared-state todo list tracking
 - **Context strings** - LLM guidance text for tool usage (re-exported from core)
 
@@ -94,7 +93,7 @@ let sandboxed_read: AllowedReadTool<true> = AllowedReadTool::new(resolver.clone(
 let sandboxed_write = AllowedWriteTool::new(resolver);
 ```
 
-Other tools: `BashTool`, `WebFetchTool`, `TaskTool`, `TodoTools`.
+Other tools: `BashTool`, `WebFetchTool`, `TodoTools`.
 Use `SystemPromptBuilder` to register tools and pass `pb.build()` to `.preamble()`. Set `working_directory()` so the environment section is populated.
 Context strings are re-exported in `llm_coding_tools_rig::context` (e.g., `BASH`, `READ_ABSOLUTE`).
 

--- a/src/llm-coding-tools-serdesai/README.md
+++ b/src/llm-coding-tools-serdesai/README.md
@@ -12,7 +12,6 @@ Lightweight, high-performance serdesAI framework Tool implementations for coding
   - `allowed::*` - Sandboxed to configured directories
 - **Shell execution** - Cross-platform command execution with timeout
 - **Web fetching** - URL content retrieval with format conversion
-- **Task delegation** - Sub-agent spawning for complex tasks
 - **Todo management** - Shared-state todo list tracking
 - **Context strings** - LLM guidance text for tool usage (re-exported from core)
 - **Schema builders** - Composable helpers for custom tool definitions


### PR DESCRIPTION
## Summary

- **Add serdesAI framework** to main README
  - Add serdesAI crate badge and workspace entry
  - Add serdesAI examples to Examples section
  - Add serdesAI link to Documentation section
  - Add note about serdesAI framework support in Quick Start

- **Remove Task Delegation mentions** from all READMEs
  - Remove from main README Features section (feature no longer available)
  - Remove from rig README Features section
  - Remove from serdesai README Features section
  - Remove TaskTool reference from rig README

## Changes

- `README.MD`: Added serdesAI badges, workspace entry, examples, docs link; removed Task Delegation
- `src/llm-coding-tools-serdesai/README.md`: Removed Task Delegation from Features
- `src/llm-coding-tools-rig/README.md`: Removed Task Delegation from Features and TaskTool from usage section