### PR TITLE
Move RUSTDOCFLAGS from config.toml to verify scripts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,7 +69,14 @@ jobs:
             SEARCH_RESULT=$(cargo search "^${CRATE}$" --limit 1)
             if echo "$SEARCH_RESULT" | grep -q "^${CRATE} "; then
               echo "Running semver checks for ${CRATE}..."
-              cargo +stable semver-checks -p "${CRATE}" --target ${{ matrix.target }}
+              # Note: llm-coding-tools-core has mutually exclusive async/blocking features,
+              # so we must use --only-explicit-features to avoid enabling all features.
+              # The rig/serdesai crates are async-only and don't have the tokio feature.
+              if [ "${CRATE}" = "llm-coding-tools-core" ]; then
+                cargo +stable semver-checks -p "${CRATE}" --target ${{ matrix.target }} --only-explicit-features --features tokio
+              else
+                cargo +stable semver-checks -p "${CRATE}" --target ${{ matrix.target }}
+              fi
             else
               echo "No previous version of ${CRATE} found on crates.io. Skipping semver checks."
             fi
@@ -117,6 +124,7 @@ jobs:
           rust-cargo-project-paths: |
             src/llm-coding-tools-core
             src/llm-coding-tools-rig
+            src/llm-coding-tools-serdesai
           compression-tool: 7z
           artifact-groups-file: .github/artifact-groups.yml
           changelog-enabled: "true"

--- a/src/.cargo/config.toml
+++ b/src/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustdocflags = ["-D", "warnings"]

--- a/src/.cargo/verify.ps1
+++ b/src/.cargo/verify.ps1
@@ -26,6 +26,7 @@ Write-Host "Testing blocking feature..."
 cargo test -p llm-coding-tools-core --no-default-features --features blocking --quiet
 
 Write-Host "Docs..."
+$env:RUSTDOCFLAGS = "-D warnings"
 cargo doc --workspace --no-deps --quiet
 
 Write-Host "Formatting..."

--- a/src/.cargo/verify.sh
+++ b/src/.cargo/verify.sh
@@ -27,7 +27,7 @@ echo "Testing blocking feature..."
 cargo test -p llm-coding-tools-core --no-default-features --features blocking --quiet
 
 echo "Docs..."
-cargo doc --workspace --no-deps --quiet
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --quiet
 
 echo "Formatting..."
 cargo fmt --all


### PR DESCRIPTION
## Summary
- Remove `.cargo/config.toml` which globally set `rustdocflags = ["-D", "warnings"]`
- Set `RUSTDOCFLAGS="-D warnings"` directly in `verify.sh` and `verify.ps1` for `cargo doc` command
- Keeps doc warning strictness explicit and local to verification only

## CI Fixes
- Fix `cargo-semver-checks` failing due to mutually exclusive `async`/`blocking` features by adding `--only-explicit-features --features tokio`
- Add `llm-coding-tools-serdesai` to the crate publish list