### PR TITLE
Fixed: surface grep/glob partial errors to callers

### DIFF
--- a/src/llm-coding-tools-core/src/tools/glob.rs
+++ b/src/llm-coding-tools-core/src/tools/glob.rs
@@ -17,6 +17,12 @@ pub struct GlobOutput {
     /// Whether results were truncated due to limit.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub truncated: bool,
+    /// Whether one or more paths could not be traversed or processed.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub partial: bool,
+    /// Per-path traversal errors encountered while collecting matches.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<String>,
 }
 
 /// Finds files matching a glob pattern in the given directory.
@@ -39,6 +45,7 @@ pub fn glob_files<R: PathResolver>(
     let matcher = Glob::new(pattern)?.compile_matcher();
 
     let mut files_with_mtime: Vec<(String, SystemTime)> = Vec::new();
+    let mut errors: Vec<String> = Vec::with_capacity(8);
 
     let walker = WalkBuilder::new(&path)
         .hidden(false)
@@ -50,7 +57,10 @@ pub fn glob_files<R: PathResolver>(
     for entry_result in walker {
         let entry = match entry_result {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(err) => {
+                errors.push(format!("walk error: {err}"));
+                continue;
+            }
         };
 
         if let Some(ft) = entry.file_type() {
@@ -63,7 +73,14 @@ pub fn glob_files<R: PathResolver>(
 
         let rel_path = match entry.path().strip_prefix(&path) {
             Ok(p) => p.to_string_lossy().into_owned(),
-            Err(_) => continue,
+            Err(err) => {
+                errors.push(format!(
+                    "failed to make '{}' relative to '{}': {err}",
+                    entry.path().display(),
+                    path.display()
+                ));
+                continue;
+            }
         };
 
         // Normalize Windows backslashes to forward slashes for glob pattern matching
@@ -97,7 +114,12 @@ pub fn glob_files<R: PathResolver>(
         .map(|(path, _)| path)
         .collect();
 
-    Ok(GlobOutput { files, truncated })
+    Ok(GlobOutput {
+        files,
+        truncated,
+        partial: !errors.is_empty(),
+        errors,
+    })
 }
 
 #[cfg(test)]
@@ -195,5 +217,35 @@ mod tests {
             assert!(!path.contains('\\'), "expected forward slashes: {path}");
         }
         assert!(result.files.iter().any(|f| f.contains('/')));
+    }
+
+    #[test]
+    fn glob_output_serializes_partial_metadata() {
+        let output = GlobOutput {
+            files: vec!["src/lib.rs".to_string()],
+            truncated: false,
+            partial: true,
+            errors: vec!["walk error: denied".to_string()],
+        };
+
+        let json = serde_json::to_value(&output).unwrap();
+
+        assert_eq!(json["partial"], true);
+        assert_eq!(json["errors"][0], "walk error: denied");
+    }
+
+    #[test]
+    fn glob_output_omits_partial_metadata_when_not_partial() {
+        let output = GlobOutput {
+            files: vec!["src/lib.rs".to_string()],
+            truncated: false,
+            partial: false,
+            errors: Vec::new(),
+        };
+
+        let json = serde_json::to_value(&output).unwrap();
+
+        assert!(json.get("partial").is_none());
+        assert!(json.get("errors").is_none());
     }
 }

--- a/src/llm-coding-tools-core/src/tools/grep.rs
+++ b/src/llm-coding-tools-core/src/tools/grep.rs
@@ -47,6 +47,12 @@ pub struct GrepOutput {
     pub match_count: usize,
     /// Whether results were truncated due to limit.
     pub truncated: bool,
+    /// Whether one or more files could not be searched.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub partial: bool,
+    /// Per-file traversal/search errors encountered while collecting matches.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<String>,
 }
 
 impl GrepOutput {
@@ -86,6 +92,14 @@ impl GrepOutput {
             let _ = write!(&mut output, "\n(Results truncated at {} matches)", limit);
         }
 
+        if self.partial {
+            let _ = write!(
+                &mut output,
+                "\n(Partial results: {} file error(s) encountered)",
+                self.errors.len()
+            );
+        }
+
         output
     }
 }
@@ -116,6 +130,7 @@ pub fn grep_search<R: PathResolver>(
         .build();
 
     let mut files: Vec<GrepFileMatches> = Vec::with_capacity(64);
+    let mut errors: Vec<String> = Vec::with_capacity(8);
 
     let walker = WalkBuilder::new(&path)
         .hidden(false)
@@ -127,7 +142,10 @@ pub fn grep_search<R: PathResolver>(
     for entry_result in walker {
         let entry = match entry_result {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(err) => {
+                errors.push(format!("walk error: {err}"));
+                continue;
+            }
         };
 
         // Skip directories and non-regular files.
@@ -149,8 +167,13 @@ pub fn grep_search<R: PathResolver>(
             }
         }
 
-        let matches = collect_file_matches(&matcher, &mut searcher, entry_path);
-        if matches.is_empty() {
+        let search_result = collect_file_matches(&matcher, &mut searcher, entry_path);
+
+        if let Some(error) = search_result.error {
+            errors.push(error);
+        }
+
+        if search_result.matches.is_empty() {
             continue;
         }
 
@@ -162,7 +185,7 @@ pub fn grep_search<R: PathResolver>(
 
         files.push(GrepFileMatches {
             path: entry_path.to_string_lossy().into_owned(),
-            matches,
+            matches: search_result.matches,
             mtime,
         });
     }
@@ -193,7 +216,14 @@ pub fn grep_search<R: PathResolver>(
         files,
         match_count,
         truncated,
+        partial: !errors.is_empty(),
+        errors,
     })
+}
+
+struct FileSearchResult {
+    matches: Vec<GrepLineMatch>,
+    error: Option<String>,
 }
 
 #[inline]
@@ -201,22 +231,25 @@ fn collect_file_matches(
     matcher: &RegexMatcher,
     searcher: &mut Searcher,
     path: &Path,
-) -> Vec<GrepLineMatch> {
+) -> FileSearchResult {
     let mut matches = Vec::new();
 
-    let _ = searcher.search_path(
-        matcher,
-        path,
-        UTF8(|line_num, line| {
-            matches.push(GrepLineMatch {
-                line_num,
-                line_text: line.trim_end().to_string(),
-            });
-            Ok(true)
-        }),
-    );
+    let error = searcher
+        .search_path(
+            matcher,
+            path,
+            UTF8(|line_num, line| {
+                matches.push(GrepLineMatch {
+                    line_num,
+                    line_text: line.trim_end().to_string(),
+                });
+                Ok(true)
+            }),
+        )
+        .err()
+        .map(|err| format!("failed to search '{}': {err}", path.display()));
 
-    matches
+    FileSearchResult { matches, error }
 }
 
 #[cfg(test)]
@@ -256,5 +289,50 @@ mod tests {
 
         assert_eq!(result.files.len(), 1);
         assert!(result.files[0].path.ends_with(".rs"));
+    }
+
+    #[test]
+    fn grep_format_includes_partial_marker() {
+        let output = GrepOutput {
+            files: Vec::new(),
+            match_count: 0,
+            truncated: false,
+            partial: true,
+            errors: vec!["walk error: denied".to_string()],
+        };
+
+        let formatted = output.format::<true>(10, DEFAULT_MAX_LINE_LENGTH);
+
+        assert!(formatted.contains("Partial results"));
+    }
+
+    #[test]
+    fn collect_file_matches_reports_error_for_missing_file() {
+        let temp = tempdir().unwrap();
+        let missing = temp.path().join("missing.txt");
+        let matcher = RegexMatcher::new("hello").unwrap();
+        let mut searcher = SearcherBuilder::new()
+            .binary_detection(BinaryDetection::quit(0))
+            .build();
+
+        let result = collect_file_matches(&matcher, &mut searcher, &missing);
+
+        assert!(result.matches.is_empty());
+        assert!(result.error.is_some());
+    }
+
+    #[test]
+    fn grep_marks_results_partial_when_walker_reports_error() {
+        let temp = tempdir().unwrap();
+        let missing_root = temp.path().join("missing-root");
+        let resolver = AbsolutePathResolver;
+
+        let result =
+            grep_search(&resolver, "hello", None, missing_root.to_str().unwrap(), 10).unwrap();
+
+        assert!(result.partial);
+        assert_eq!(result.match_count, 0);
+        assert!(!result.truncated);
+        assert!(!result.errors.is_empty());
     }
 }

--- a/src/llm-coding-tools-serdesai/src/absolute/glob.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/glob.rs
@@ -1,13 +1,14 @@
 //! Glob pattern file finding tool using [`AbsolutePathResolver`].
 
 use async_trait::async_trait;
+use llm_coding_tools_core::ToolContext;
 use llm_coding_tools_core::path::AbsolutePathResolver;
 use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::tools::glob_files;
-use llm_coding_tools_core::{ToolContext, ToolOutput};
 use serde::Deserialize;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
 
+use crate::common::glob::output_to_return as glob_output_to_return;
 use crate::convert::to_serdes_result;
 
 /// Internal args for JSON deserialization.
@@ -60,22 +61,10 @@ impl<Deps: Send + Sync> Tool<Deps> for GlobTool {
         let resolver = AbsolutePathResolver;
         let result = glob_files(&resolver, &args.pattern, &args.path);
 
-        // Convert GlobOutput to ToolOutput for consistent error handling
-        to_serdes_result(
-            tool_names::GLOB,
-            result.map(|output| {
-                let content = if output.files.is_empty() {
-                    "No files found matching the pattern.".to_string()
-                } else {
-                    output.files.join("\n")
-                };
-                if output.truncated {
-                    ToolOutput::truncated(content)
-                } else {
-                    ToolOutput::new(content)
-                }
-            }),
-        )
+        match result {
+            Err(e) => to_serdes_result(tool_names::GLOB, Err(e)),
+            Ok(output) => Ok(glob_output_to_return(output)),
+        }
     }
 }
 
@@ -90,6 +79,7 @@ impl ToolContext for GlobTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use llm_coding_tools_core::tools::GlobOutput;
     use serde_json::json;
     use serdes_ai::tools::RunContext;
     use std::fs::{self, File};
@@ -121,5 +111,19 @@ mod tests {
         let text = result.as_text().unwrap();
         assert!(text.contains("lib.rs"));
         assert!(text.contains("main.rs"));
+    }
+
+    #[test]
+    fn partial_glob_output_returns_json_payload() {
+        let payload = glob_output_to_return(GlobOutput {
+            files: vec!["src/lib.rs".to_string()],
+            truncated: false,
+            partial: true,
+            errors: vec!["walk error: denied".to_string()],
+        });
+
+        let json = payload.as_json().unwrap();
+        assert_eq!(json["partial"], true);
+        assert_eq!(json["errors"][0], "walk error: denied");
     }
 }

--- a/src/llm-coding-tools-serdesai/src/absolute/grep.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/grep.rs
@@ -6,10 +6,9 @@ use llm_coding_tools_core::path::AbsolutePathResolver;
 use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::tools::{DEFAULT_MAX_LINE_LENGTH, grep_search};
 use serde::Deserialize;
-use serdes_ai::tools::{
-    RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult, ToolReturn,
-};
+use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
 
+use crate::common::grep::output_to_return as grep_output_to_return;
 use crate::convert::to_serdes_result;
 
 const DEFAULT_LIMIT: usize = 100;
@@ -115,14 +114,11 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
 
         match result {
             Err(e) => to_serdes_result(tool_names::GREP, Err(e)),
-            Ok(grep_output) => {
-                if grep_output.files.is_empty() {
-                    return Ok(ToolReturn::text("No matches found."));
-                }
-
-                let output = grep_output.format::<LINE_NUMBERS>(limit, DEFAULT_MAX_LINE_LENGTH);
-                Ok(ToolReturn::text(output))
-            }
+            Ok(grep_output) => Ok(grep_output_to_return::<LINE_NUMBERS>(
+                grep_output,
+                limit,
+                DEFAULT_MAX_LINE_LENGTH,
+            )),
         }
     }
 }
@@ -245,6 +241,34 @@ mod tests {
         assert!(text.contains("code.rs"));
         assert!(!text.contains("code.py"));
         assert!(!text.contains("readme.txt"));
+    }
+
+    #[tokio::test]
+    async fn returns_partial_json_when_search_has_errors() {
+        let dir = TempDir::new().unwrap();
+        let missing_path = dir.path().join("missing-root");
+        let tool: GrepTool<true> = GrepTool::new();
+
+        let result = tool
+            .call(
+                &mock_ctx(),
+                json!({
+                    "pattern": "hello",
+                    "path": missing_path.to_string_lossy()
+                }),
+            )
+            .await
+            .unwrap();
+
+        let payload = result.as_json().unwrap();
+        assert_eq!(payload["partial"], true);
+        assert!(!payload["errors"].as_array().unwrap().is_empty());
+        assert!(
+            payload["content"]
+                .as_str()
+                .unwrap()
+                .contains("Partial results")
+        );
     }
 
     #[tokio::test]

--- a/src/llm-coding-tools-serdesai/src/allowed/glob.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/glob.rs
@@ -1,13 +1,14 @@
 //! Glob pattern file finding tool using [`AllowedPathResolver`].
 
 use async_trait::async_trait;
+use llm_coding_tools_core::ToolContext;
 use llm_coding_tools_core::path::AllowedPathResolver;
 use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::tools::glob_files;
-use llm_coding_tools_core::{ToolContext, ToolOutput};
 use serde::Deserialize;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
 
+use crate::common::glob::output_to_return as glob_output_to_return;
 use crate::convert::to_serdes_result;
 
 /// Internal args for JSON deserialization.
@@ -66,21 +67,10 @@ impl<Deps: Send + Sync> Tool<Deps> for GlobTool {
             .map_err(|e| ToolError::validation_error(tool_names::GLOB, None, e.to_string()))?;
 
         let result = glob_files(&self.resolver, &args.pattern, &args.path);
-        to_serdes_result(
-            tool_names::GLOB,
-            result.map(|output| {
-                let content = if output.files.is_empty() {
-                    "No files found matching the pattern.".to_string()
-                } else {
-                    output.files.join("\n")
-                };
-                if output.truncated {
-                    ToolOutput::truncated(content)
-                } else {
-                    ToolOutput::new(content)
-                }
-            }),
-        )
+        match result {
+            Err(e) => to_serdes_result(tool_names::GLOB, Err(e)),
+            Ok(output) => Ok(glob_output_to_return(output)),
+        }
     }
 }
 
@@ -95,6 +85,7 @@ impl ToolContext for GlobTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use llm_coding_tools_core::tools::GlobOutput;
     use serde_json::json;
     use serdes_ai::tools::RunContext;
     use std::fs::{self, File};
@@ -143,5 +134,19 @@ mod tests {
             .await;
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn partial_glob_output_returns_json_payload() {
+        let payload = glob_output_to_return(GlobOutput {
+            files: vec!["src/lib.rs".to_string()],
+            truncated: false,
+            partial: true,
+            errors: vec!["walk error: denied".to_string()],
+        });
+
+        let json = payload.as_json().unwrap();
+        assert_eq!(json["partial"], true);
+        assert_eq!(json["errors"][0], "walk error: denied");
     }
 }

--- a/src/llm-coding-tools-serdesai/src/allowed/grep.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/grep.rs
@@ -6,10 +6,9 @@ use llm_coding_tools_core::path::AllowedPathResolver;
 use llm_coding_tools_core::tool_names;
 use llm_coding_tools_core::tools::{DEFAULT_MAX_LINE_LENGTH, grep_search};
 use serde::Deserialize;
-use serdes_ai::tools::{
-    RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult, ToolReturn,
-};
+use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
 
+use crate::common::grep::output_to_return as grep_output_to_return;
 use crate::convert::to_serdes_result;
 
 const DEFAULT_LIMIT: usize = 100;
@@ -121,14 +120,11 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
 
         match result {
             Err(e) => to_serdes_result(tool_names::GREP, Err(e)),
-            Ok(grep_output) => {
-                if grep_output.files.is_empty() {
-                    return Ok(ToolReturn::text("No matches found."));
-                }
-
-                let output = grep_output.format::<LINE_NUMBERS>(limit, DEFAULT_MAX_LINE_LENGTH);
-                Ok(ToolReturn::text(output))
-            }
+            Ok(grep_output) => Ok(grep_output_to_return::<LINE_NUMBERS>(
+                grep_output,
+                limit,
+                DEFAULT_MAX_LINE_LENGTH,
+            )),
         }
     }
 }
@@ -209,5 +205,32 @@ mod tests {
             .await;
 
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn returns_partial_json_when_search_has_errors() {
+        let dir = TempDir::new().unwrap();
+        let resolver = AllowedPathResolver::new([dir.path()]).unwrap();
+        let tool: GrepTool<true> = GrepTool::new(resolver);
+        let result = tool
+            .call(
+                &mock_ctx(),
+                json!({
+                    "pattern": "hello",
+                    "path": "missing-root"
+                }),
+            )
+            .await
+            .unwrap();
+
+        let payload = result.as_json().unwrap();
+        assert_eq!(payload["partial"], true);
+        assert!(!payload["errors"].as_array().unwrap().is_empty());
+        assert!(
+            payload["content"]
+                .as_str()
+                .unwrap()
+                .contains("Partial results")
+        );
     }
 }

--- a/src/llm-coding-tools-serdesai/src/common/glob.rs
+++ b/src/llm-coding-tools-serdesai/src/common/glob.rs
@@ -1,0 +1,39 @@
+//! Shared helpers for Glob tool implementations.
+
+use llm_coding_tools_core::tools::GlobOutput;
+use serde_json::json;
+use serdes_ai::tools::ToolReturn;
+
+const NO_FILES_FOUND: &str = "No files found matching the pattern.";
+
+#[inline]
+fn output_content(files: &[String]) -> String {
+    if files.is_empty() {
+        NO_FILES_FOUND.to_string()
+    } else {
+        files.join("\n")
+    }
+}
+
+#[inline]
+pub(crate) fn output_to_return(output: GlobOutput) -> ToolReturn {
+    let content = output_content(&output.files);
+
+    if output.partial {
+        return ToolReturn::json(json!({
+            "content": content,
+            "partial": true,
+            "errors": output.errors,
+            "truncated": output.truncated,
+        }));
+    }
+
+    if output.truncated {
+        ToolReturn::json(json!({
+            "content": content,
+            "truncated": true,
+        }))
+    } else {
+        ToolReturn::text(content)
+    }
+}

--- a/src/llm-coding-tools-serdesai/src/common/grep.rs
+++ b/src/llm-coding-tools-serdesai/src/common/grep.rs
@@ -1,0 +1,31 @@
+//! Shared helpers for Grep tool implementations.
+
+use llm_coding_tools_core::tools::GrepOutput;
+use serde_json::json;
+use serdes_ai::tools::ToolReturn;
+
+const NO_MATCHES_FOUND: &str = "No matches found.";
+
+#[inline]
+pub(crate) fn output_to_return<const LINE_NUMBERS: bool>(
+    output: GrepOutput,
+    limit: usize,
+    max_line_len: usize,
+) -> ToolReturn {
+    if output.partial {
+        let content = output.format::<LINE_NUMBERS>(limit, max_line_len);
+        return ToolReturn::json(json!({
+            "content": content,
+            "partial": true,
+            "errors": output.errors,
+            "match_count": output.match_count,
+            "truncated": output.truncated,
+        }));
+    }
+
+    if output.files.is_empty() {
+        return ToolReturn::text(NO_MATCHES_FOUND);
+    }
+
+    ToolReturn::text(output.format::<LINE_NUMBERS>(limit, max_line_len))
+}

--- a/src/llm-coding-tools-serdesai/src/common/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/common/mod.rs
@@ -1,3 +1,5 @@
 //! Shared helpers for tool implementations.
 
 pub(crate) mod edit;
+pub(crate) mod glob;
+pub(crate) mod grep;


### PR DESCRIPTION
## Summary
- fix grep and glob so per-file traversal/search failures are no longer silently dropped
- preserve successful matches/files from readable paths while surfacing partial-state metadata (partial, errors)
- propagate partial-state metadata through serdesAI wrappers so callers can distinguish partial results from true no-match/no-file outcomes
- deduplicate both glob and grep return-shaping logic in shared serdesAI helpers

## What Changed
- **Core grep** (`llm-coding-tools-core/src/tools/grep.rs`)
  - capture walker entry errors instead of silently continuing
  - capture `searcher.search_path(...)` failures per file while preserving readable-file matches
  - extend `GrepOutput` with `partial: bool` and `errors: Vec<String>`
  - include a partial-results marker in formatted text output

- **Core glob** (`llm-coding-tools-core/src/tools/glob.rs`)
  - capture walker traversal errors instead of swallowing them
  - capture `strip_prefix` processing failures with path context
  - extend `GlobOutput` with `partial: bool` and `errors: Vec<String>`

- **serdesAI wrappers**
  - grep absolute/allowed wrappers emit JSON when partial with:
    - `content`, `partial`, `errors`, `match_count`, `truncated`
  - glob absolute/allowed wrappers emit JSON when partial with:
    - `content`, `partial`, `errors`, `truncated`
  - non-partial success behavior remains unchanged (plain text unless truncated)

- **Dedup follow-ups**
  - moved duplicated glob conversion code to `llm-coding-tools-serdesai/src/common/glob.rs`
  - moved duplicated grep conversion code to `llm-coding-tools-serdesai/src/common/grep.rs`
  - absolute and allowed variants now reuse shared conversion helpers for consistency

## Commit
- `e77d318` — Fixed: Surface grep/glob partial errors end-to-end

## Behavior Notes
- hard failures remain reserved for invalid top-level inputs (invalid regex/glob/root path)
- per-file traversal/read/search failures now produce explicit partial metadata instead of silent zero-result output
- existing readable-file success paths keep their previous semantics

## Testing
- `cargo fmt`
- `.cargo/verify.sh`
  - build/test/clippy/doc all pass
  - script still fails at `cargo publish --dry-run -p llm-coding-tools-agents` because crates.io currently cannot resolve `llm-coding-tools-core = ^0.2.0` (pre-existing publish environment issue)

## Review
- `@coderabbit` review run on committed changes; no findings