### PR TITLE
Fixed: Reject overflowing Content-Length in webfetch

### DIFF
--- a/src/llm-coding-tools-core/src/tools/webfetch/blocking_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/webfetch/blocking_impl.rs
@@ -35,7 +35,17 @@ pub fn fetch_url(
         .to_string();
 
     // Check Content-Length header if available for early rejection and preallocation
-    let content_length = response.content_length().map(|len| len as usize);
+    let content_length = response
+        .content_length()
+        .map(|len| {
+            usize::try_from(len).map_err(|_| {
+                ToolError::Http(format!(
+                    "Content-Length {} exceeds platform limits for {}",
+                    len, url
+                ))
+            })
+        })
+        .transpose()?;
     if let Some(len) = content_length {
         check_size(len, url)?;
     }

--- a/src/llm-coding-tools-core/src/tools/webfetch/tokio_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/webfetch/tokio_impl.rs
@@ -36,7 +36,15 @@ pub async fn fetch_url(
     // Check Content-Length header if available for early rejection and preallocation
     let content_length = response
         .content_length()
-        .and_then(|len| usize::try_from(len).ok());
+        .map(|len| {
+            usize::try_from(len).map_err(|_| {
+                ToolError::Http(format!(
+                    "Content-Length {} exceeds platform limits for {}",
+                    len, url
+                ))
+            })
+        })
+        .transpose()?;
     if let Some(len) = content_length {
         check_size(len, url)?;
     }


### PR DESCRIPTION
## Summary
- Fail fast when `Content-Length` exceeds platform `usize` in both blocking and tokio webfetch.
- Use checked conversion instead of silent fallback, avoiding unnecessary downloads on 32-bit targets.