### PR TITLE
Fixed: Remove UB-prone uninit slice cast in blocking webfetch

### DIFF
--- a/src/llm-coding-tools-core/src/tools/webfetch/blocking_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/webfetch/blocking_impl.rs
@@ -3,7 +3,6 @@
 use super::{categorize_reqwest_error, check_size, process_content, WebFetchOutput};
 use crate::error::{ToolError, ToolResult};
 use std::io::Read;
-use std::mem::MaybeUninit;
 use std::time::Duration;
 
 /// Fetches content from a URL and returns processed content.
@@ -53,24 +52,18 @@ pub fn fetch_url(
     // Stream response body with incremental size checks to avoid memory exhaustion
     let mut bytes = content_length.map_or_else(Vec::new, Vec::with_capacity);
     let mut total_len: usize = 0;
-    let mut buffer = [MaybeUninit::<u8>::uninit(); 8192];
-    let buffer_ptr = buffer.as_mut_ptr() as *mut u8;
-    let buffer_len = buffer.len();
+    let mut buffer = [0u8; 8192];
 
     loop {
-        let n = {
-            let buf = unsafe { std::slice::from_raw_parts_mut(buffer_ptr, buffer_len) };
-            response
-                .read(buf)
-                .map_err(|e| ToolError::Http(e.to_string()))?
-        };
+        let n = response
+            .read(&mut buffer)
+            .map_err(|e| ToolError::Http(e.to_string()))?;
         if n == 0 {
             break;
         }
         total_len += n;
         check_size(total_len, url)?;
-        let initialized = unsafe { std::slice::from_raw_parts(buffer_ptr, n) };
-        bytes.extend_from_slice(initialized);
+        bytes.extend_from_slice(&buffer[..n]);
     }
 
     let byte_length = total_len;


### PR DESCRIPTION
## Summary
- Replace unsafe `MaybeUninit` slice casting in the blocking webfetch read loop with a safe initialized `[0u8; 8192]` buffer.
- Keep chunked read/append behavior and response size checks unchanged.
- Remove undefined behavior risk from creating `&mut [u8]` over uninitialized memory.

Basically, the old behaviour was technically correct.
But the slice constructor assumes that the data is 'initialized'.
I don't want to risk it with future compiler changes.