### PR TITLE
Fixed: Handle reader thread panics explicitly in blocking bash

### DIFF
--- a/src/llm-coding-tools-core/src/tools/bash/blocking_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/bash/blocking_impl.rs
@@ -110,8 +110,12 @@ pub fn execute_command(
     };
 
     // Join pipe-draining threads (they will complete once child exits or is killed)
-    let stdout_data = stdout_thread.join().unwrap_or_default();
-    let stderr_data = stderr_thread.join().unwrap_or_default();
+    let stdout_data = stdout_thread
+        .join()
+        .map_err(|_| ToolError::Execution("stdout reader thread panicked".to_string()))?;
+    let stderr_data = stderr_thread
+        .join()
+        .map_err(|_| ToolError::Execution("stderr reader thread panicked".to_string()))?;
 
     // Return result
     match exit_status {


### PR DESCRIPTION
## Summary

Fix B008: Replace `unwrap_or_default()` with explicit error handling for reader thread joins in blocking bash implementation.

## Changes

- **llm-coding-tools-core/src/tools/bash/blocking_impl.rs:113-116**
  - Convert `stdout_thread.join().unwrap_or_default()` to explicit `map_err()` with `ToolError::Execution`
  - Convert `stderr_thread.join().unwrap_or_default()` to explicit `map_err()` with `ToolError::Execution`
  - Add context indicating which thread panicked ("stdout reader thread panicked" / "stderr reader thread panicked")

## Why

Previously, if either stdout or stderr reader thread panicked (OOM edge case, future regression, or dependency panic), the panic was silently converted to empty bytes via `unwrap_or_default()`. This made debugging impossible and violated the principle that failures should be explicit.

Now panics are properly propagated as `ToolError::Execution` errors with clear context about which thread failed.

## Verification

All existing tests pass:
- 194 tests in llm-coding-tools-core ✓
- 61 tests in llm-coding-tools-agents ✓
- 49 tests in llm-coding-tools-serdesai ✓
- Clippy clean ✓
- Formatting clean ✓

Fixes: B008