### PR TITLE
Fixed: surface kill() failures in bash timeout handling

### DIFF
--- a/src/llm-coding-tools-core/src/error.rs
+++ b/src/llm-coding-tools-core/src/error.rs
@@ -33,6 +33,15 @@ pub enum ToolError {
     #[error("timeout: {0}")]
     Timeout(String),
 
+    /// Timeout with kill failure - process may still be running.
+    #[error("timeout: {message}\n(kill failed: {kill_error})")]
+    TimeoutWithKillFailure {
+        /// Timeout message including context.
+        message: String,
+        /// Kill error message.
+        kill_error: String,
+    },
+
     /// Validation failed.
     #[error("validation error: {0}")]
     Validation(String),
@@ -73,5 +82,16 @@ mod tests {
         let glob_err = globset::Glob::new("[invalid").unwrap_err();
         let err: ToolError = glob_err.into();
         assert!(matches!(err, ToolError::InvalidPattern(_)));
+    }
+
+    #[test]
+    fn timeout_with_kill_failure_displays_both_contexts() {
+        let err = ToolError::TimeoutWithKillFailure {
+            message: "command timed out after 100ms".into(),
+            kill_error: "permission denied".into(),
+        };
+        let display = err.to_string();
+        assert!(display.contains("command timed out after 100ms"));
+        assert!(display.contains("kill failed: permission denied"));
     }
 }

--- a/src/llm-coding-tools-core/src/tools/bash/blocking_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/bash/blocking_impl.rs
@@ -1,6 +1,9 @@
 //! Blocking shell command execution.
 
-use super::{BashOutput, PIPE_BUFFER_CAPACITY};
+use super::{
+    timeout_error_with_kill_failure, timeout_message_with_buffered_output, BashOutput,
+    PIPE_BUFFER_CAPACITY,
+};
 use crate::error::{ToolError, ToolResult};
 use process_wrap::std::*;
 use std::io::Read;
@@ -8,6 +11,12 @@ use std::path::Path;
 use std::process::Stdio;
 use std::thread;
 use std::time::{Duration, Instant};
+
+enum WaitOutcome {
+    Exited(std::process::ExitStatus),
+    TimedOut { kill_error: Option<std::io::Error> },
+    WaitError(std::io::Error),
+}
 
 /// Executes a shell command with optional working directory and timeout.
 ///
@@ -90,22 +99,20 @@ pub fn execute_command(
 
     let start = Instant::now();
 
-    // Poll for completion with timeout
-    let exit_status = loop {
+    // Poll for completion with timeout.
+    let wait_outcome = loop {
         match child.try_wait() {
-            Ok(Some(status)) => break Ok(status),
+            Ok(Some(status)) => break WaitOutcome::Exited(status),
             Ok(None) => {
                 if start.elapsed() >= timeout {
                     // Kill entire process tree via Job Object (Windows) or process group (Unix)
-                    let _ = child.kill();
-                    break Err(ToolError::Timeout(format!(
-                        "command timed out after {}ms",
-                        timeout.as_millis()
-                    )));
+                    break WaitOutcome::TimedOut {
+                        kill_error: child.kill().err(),
+                    };
                 }
                 thread::sleep(Duration::from_millis(10));
             }
-            Err(e) => break Err(ToolError::Execution(e.to_string())),
+            Err(e) => break WaitOutcome::WaitError(e),
         }
     };
 
@@ -118,13 +125,17 @@ pub fn execute_command(
         .map_err(|_| ToolError::Execution("stderr reader thread panicked".to_string()))?;
 
     // Return result
-    match exit_status {
-        Ok(status) => Ok(BashOutput {
+    match wait_outcome {
+        WaitOutcome::Exited(status) => Ok(BashOutput {
             exit_code: status.code(),
             stdout: String::from_utf8_lossy(&stdout_data).into_owned(),
             stderr: String::from_utf8_lossy(&stderr_data).into_owned(),
         }),
-        Err(e) => Err(e),
+        WaitOutcome::TimedOut { kill_error } => Err(timeout_error_with_kill_failure(
+            timeout_message_with_buffered_output(timeout, &stdout_data, &stderr_data),
+            kill_error.map(|e| e.to_string()),
+        )),
+        WaitOutcome::WaitError(e) => Err(ToolError::Execution(e.to_string())),
     }
 }
 
@@ -166,7 +177,10 @@ mod tests {
         };
 
         let result = execute_command(cmd, None, Duration::from_millis(100));
-        assert!(matches!(result, Err(ToolError::Timeout(_))));
+        assert!(matches!(
+            result,
+            Err(ToolError::Timeout(_) | ToolError::TimeoutWithKillFailure { .. })
+        ));
     }
 
     #[test]

--- a/src/llm-coding-tools-core/src/tools/bash/mod.rs
+++ b/src/llm-coding-tools-core/src/tools/bash/mod.rs
@@ -1,12 +1,53 @@
 //! Shell command execution operation.
 
+use crate::error::ToolError;
 use crate::ToolOutput;
 use core::fmt::Write;
 use serde::Serialize;
+use std::time::Duration;
 
 /// Default buffer capacity for stdout/stderr pipe reads.
 /// 32KB covers typical command output without reallocations.
 const PIPE_BUFFER_CAPACITY: usize = 32 * 1024;
+
+#[inline]
+fn timeout_message_with_buffered_output(
+    timeout: Duration,
+    stdout_data: &[u8],
+    stderr_data: &[u8],
+) -> String {
+    let stdout = String::from_utf8_lossy(stdout_data);
+    let stderr = String::from_utf8_lossy(stderr_data);
+
+    let mut message = String::with_capacity(stdout.len() + stderr.len() + 64);
+    let _ = write!(message, "command timed out after {}ms", timeout.as_millis());
+
+    if !stdout.is_empty() {
+        message.push('\n');
+        message.push_str(&stdout);
+    }
+
+    if !stderr.is_empty() {
+        if stdout.is_empty() || !stdout.ends_with('\n') {
+            message.push('\n');
+        }
+        message.push_str("[stderr]\n");
+        message.push_str(&stderr);
+    }
+
+    message
+}
+
+#[inline]
+fn timeout_error_with_kill_failure(message: String, kill_error: Option<String>) -> ToolError {
+    match kill_error {
+        Some(kill_error) => ToolError::TimeoutWithKillFailure {
+            message,
+            kill_error,
+        },
+        None => ToolError::Timeout(message),
+    }
+}
 
 /// Result of shell command execution.
 #[derive(Debug, Clone, Serialize)]

--- a/src/llm-coding-tools-core/src/tools/bash/tokio_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/bash/tokio_impl.rs
@@ -1,8 +1,10 @@
 //! Tokio-based async shell command execution.
 
-use super::{BashOutput, PIPE_BUFFER_CAPACITY};
+use super::{
+    timeout_error_with_kill_failure, timeout_message_with_buffered_output, BashOutput,
+    PIPE_BUFFER_CAPACITY,
+};
 use crate::error::{ToolError, ToolResult};
-use core::fmt::Write;
 use parking_lot::Mutex;
 use process_wrap::tokio::*;
 use std::path::Path;
@@ -77,35 +79,6 @@ async fn await_pipe_drain_task_with_grace(task: PipeDrainTask, grace: Duration) 
     }
 
     take_pipe_buffer(buffer)
-}
-
-#[inline]
-fn timeout_with_buffered_output(
-    timeout: Duration,
-    stdout_data: &[u8],
-    stderr_data: &[u8],
-) -> ToolError {
-    let stdout = String::from_utf8_lossy(stdout_data);
-    let stderr = String::from_utf8_lossy(stderr_data);
-
-    // Base message + outputs + stderr label.
-    let mut message = String::with_capacity(stdout.len() + stderr.len() + 64);
-    let _ = write!(message, "command timed out after {}ms", timeout.as_millis());
-
-    if !stdout.is_empty() {
-        message.push('\n');
-        message.push_str(&stdout);
-    }
-
-    if !stderr.is_empty() {
-        if stdout.is_empty() || !stdout.ends_with('\n') {
-            message.push('\n');
-        }
-        message.push_str("[stderr]\n");
-        message.push_str(&stderr);
-    }
-
-    ToolError::Timeout(message)
 }
 
 /// Executes a shell command with optional working directory and timeout.
@@ -201,17 +174,16 @@ pub async fn execute_command(
         None => {
             // Timeout: explicitly kill the process tree (Job Object on Windows,
             // process group on Unix), then briefly await pipe drains for buffered output.
-            let _ = Pin::from(child.kill()).await;
+            let kill_result = Pin::from(child.kill()).await;
 
             let (stdout_data, stderr_data) = tokio::join!(
                 await_pipe_drain_task_with_grace(stdout_task, PIPE_DRAIN_GRACE_PERIOD),
                 await_pipe_drain_task_with_grace(stderr_task, PIPE_DRAIN_GRACE_PERIOD)
             );
 
-            Err(timeout_with_buffered_output(
-                timeout,
-                &stdout_data,
-                &stderr_data,
+            Err(timeout_error_with_kill_failure(
+                timeout_message_with_buffered_output(timeout, &stdout_data, &stderr_data),
+                kill_result.err().map(|e| e.to_string()),
             ))
         }
     }
@@ -259,7 +231,10 @@ mod tests {
         };
 
         let result = execute_command(cmd, None, Duration::from_millis(100)).await;
-        assert!(matches!(result, Err(ToolError::Timeout(_))));
+        assert!(matches!(
+            result,
+            Err(ToolError::Timeout(_) | ToolError::TimeoutWithKillFailure { .. })
+        ));
     }
 
     #[tokio::test]
@@ -272,7 +247,8 @@ mod tests {
 
         let result = execute_command(cmd, None, Duration::from_millis(500)).await;
         match result {
-            Err(ToolError::Timeout(message)) => {
+            Err(ToolError::Timeout(message))
+            | Err(ToolError::TimeoutWithKillFailure { message, .. }) => {
                 assert!(message.contains("stdout-before-timeout"));
                 assert!(message.contains("stderr-before-timeout"));
             }

--- a/src/llm-coding-tools-serdesai/src/convert.rs
+++ b/src/llm-coding-tools-serdesai/src/convert.rs
@@ -79,6 +79,7 @@ pub(crate) fn core_error_to_serdes(tool_name: &str, err: CoreError) -> SerdesErr
         | CoreError::Http(_)
         | CoreError::Execution(_)
         | CoreError::Timeout(_)
+        | CoreError::TimeoutWithKillFailure { .. }
         | CoreError::Json(_) => SerdesError::execution_failed(err.to_string()),
     }
 }
@@ -149,6 +150,18 @@ mod tests {
         let core_err = CoreError::Timeout("timed out".into());
         let serdes_err = core_error_to_serdes("test_tool", core_err);
         assert!(!matches!(serdes_err, SerdesError::ValidationFailed { .. }));
+    }
+
+    #[test]
+    fn timeout_with_kill_failure_maps_to_execution_failed() {
+        let core_err = CoreError::TimeoutWithKillFailure {
+            message: "timed out".into(),
+            kill_error: "operation not permitted".into(),
+        };
+        let serdes_err = core_error_to_serdes("test_tool", core_err);
+        assert!(!matches!(serdes_err, SerdesError::ValidationFailed { .. }));
+        assert!(serdes_err.message().contains("timed out"));
+        assert!(serdes_err.message().contains("operation not permitted"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Surface `kill()` failures during timeout in both tokio and blocking bash paths via `ToolError::TimeoutWithKillFailure`.
- Share timeout message/error construction in `llm-coding-tools-core/src/tools/bash/mod.rs` so both implementations behave consistently.
- Update serdesAI conversion and tests to handle the new timeout-with-kill-failure variant.

## Why
Timeout handling previously ignored `kill()` errors, which could report a plain timeout even when process termination failed. That hides an important cleanup failure mode from callers. This change makes that state explicit while preserving buffered timeout output and keeping cleanup/reaping behavior intact.