### PR TITLE
Fix: Align WebFetchOutput feature gates to tokio|blocking

### DIFF
--- a/src/llm-coding-tools-core/src/lib.rs
+++ b/src/llm-coding-tools-core/src/lib.rs
@@ -34,6 +34,6 @@ pub use tools::{
     TaskInput, TaskOutput, Todo, TodoPriority, TodoState, TodoStatus,
 };
 
-// Re-export webfetch tools (requires async or blocking feature)
-#[cfg(any(feature = "async", feature = "blocking"))]
+// Re-export webfetch tools (requires tokio or blocking feature)
+#[cfg(any(feature = "tokio", feature = "blocking"))]
 pub use tools::{fetch_url, format_json, html_to_markdown, WebFetchOutput};

--- a/src/llm-coding-tools-core/src/tools/mod.rs
+++ b/src/llm-coding-tools-core/src/tools/mod.rs
@@ -23,9 +23,9 @@ pub use task::{TaskInput, TaskOutput};
 pub use todo::{read_todos, write_todos, Todo, TodoPriority, TodoState, TodoStatus};
 pub use write::write_file;
 
-// Webfetch available in both async and blocking modes
-#[cfg(any(feature = "async", feature = "blocking"))]
+// Webfetch available in both tokio and blocking modes
+#[cfg(any(feature = "tokio", feature = "blocking"))]
 pub mod webfetch;
 
-#[cfg(any(feature = "async", feature = "blocking"))]
+#[cfg(any(feature = "tokio", feature = "blocking"))]
 pub use webfetch::{fetch_url, format_json, html_to_markdown, WebFetchOutput};


### PR DESCRIPTION
## Summary
Aligns the feature gate for `WebFetchOutput` export with its `From` implementation.

## Problem
- `WebFetchOutput` export was gated by `async|blocking` (in `lib.rs:38` and `tools/mod.rs:27,30`)
- `From<WebFetchOutput> for ToolOutput` was gated by `tokio|blocking` (in `output.rs:49`)
- This caused an inconsistent API surface when building with `async` feature without `tokio`

## Changes
- Changed feature gates from `async|blocking` to `tokio|blocking` in:
  - `llm-coding-tools-core/src/lib.rs:38`
  - `llm-coding-tools-core/src/tools/mod.rs:27,30`