### PR TITLE
Add SerdesAI agent runtime with provider bridge and credential resolution

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -123,6 +123,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96571e6996817bf3d58f6b569e4b9fd2e9d2fcf9f7424eed07b2ce9bb87535e5"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,10 +187,352 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81b5b2898f6798ad58f484856768bca817e3cd9de0974c24ae0f1113fe88f1b"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-bedrockruntime"
+version = "1.120.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b8dcf42378ab2d5accac1652cdd059114fb071baf53250ceafb76fcdde347f"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.91.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee6402a36f27b52fe67661c6732d684b2635152b676aa2babbfb5204f99115d"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45a7f750bbd170ee3677671ad782d90b894548f4e4ae168302c57ec9de5cb3e"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55542378e419558e6b1f398ca70adb0b2088077e79ad9f14eb09441f2f7b2164"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e523e1c4e8e7e8ff219d732988e22bfeae8a1cafdbe6d9eca1546fa080be7c"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee19095c7c4dda59f1697d028ce704c24b2d33c6718790c7f1d5a3015b4107c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc12f8b310e38cad85cf3bef45ad236f470717393c613266ce0a89512286b650"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.62.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e62db736db19c488966c8d787f52e6270be565727236fd5579eaa301e7bc4a"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.8.1",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f616c3f2260612fe44cede278bafa18e73e6479c4e393e2c4518cf2a9a228a"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae5d689cf437eae90460e944a58b5668530d433b4ff85789e69d2f2a556e057d"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a392db6c583ea4a912538afb86b7be7c5d8887d91604f50eb55c262ee1b4a5f5"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0d43d899f9e508300e587bf582ba54c27a452dd0a9ea294690669138ae14a2"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "905cb13a9895626d49cf2ced759b062d913834c7482c38e49557eac4e6193f01"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11b2f670422ff42bf7065031e72b45bc52a3508bd089f743ea90731ca2b6ea57"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d980627d2dd7bfc32a3c025685a033eeab8d365cc840c631ef59d1b8f428164"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bitcode"
@@ -238,6 +622,16 @@ name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cast"
@@ -416,6 +810,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +957,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +1004,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -942,6 +1355,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -951,7 +1383,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1003,6 +1435,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1489,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -1052,12 +1510,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1068,8 +1537,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1087,6 +1556,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -1095,9 +1588,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -1110,17 +1603,33 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
- "rustls",
+ "rustls 0.23.36",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots",
 ]
@@ -1136,14 +1645,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -1527,6 +2036,7 @@ dependencies = [
  "indexmap",
  "llm-coding-tools-agents",
  "llm-coding-tools-core",
+ "llm-coding-tools-models-dev",
  "reqwest 0.13.1",
  "serde",
  "serde_json",
@@ -1651,6 +2161,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,6 +2217,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "page_size"
@@ -1833,6 +2364,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,8 +2428,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
- "socket2",
+ "rustls 0.23.36",
+ "socket2 0.6.1",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1912,7 +2449,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -1930,7 +2467,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2099,6 +2636,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,25 +2657,25 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2156,24 +2699,24 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower",
  "tower-http",
  "tower-service",
@@ -2204,6 +2747,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2218,6 +2770,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
@@ -2226,7 +2790,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
 ]
@@ -2264,10 +2828,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -2279,6 +2843,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -2361,6 +2935,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sdd"
@@ -2560,6 +3144,8 @@ checksum = "cbca6da3265b8d1fce6255c4aee81b02ac9d2dba6e93829e09eaf1bc29d2886e"
 dependencies = [
  "anyhow",
  "async-trait",
+ "aws-config",
+ "aws-sdk-bedrockruntime",
  "base64",
  "bytes",
  "chrono",
@@ -2769,6 +3355,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
@@ -2914,6 +3510,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,7 +3605,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2997,11 +3623,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.36",
  "tokio",
 ]
 
@@ -3053,8 +3689,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -3195,6 +3831,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -3768,9 +4410,9 @@ dependencies = [
  "base64",
  "deadpool",
  "futures",
- "http",
+ "http 1.4.0",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "log",
  "once_cell",
@@ -3874,6 +4516,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1521,8 +1521,11 @@ dependencies = [
 name = "llm-coding-tools-serdesai"
 version = "0.2.0"
 dependencies = [
+ "ahash",
  "async-trait",
  "futures",
+ "indexmap",
+ "llm-coding-tools-agents",
  "llm-coding-tools-core",
  "reqwest 0.13.1",
  "serde",
@@ -1531,6 +1534,7 @@ dependencies = [
  "serdes-ai-models",
  "serdes-ai-streaming",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "wiremock",
 ]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1998,6 +1998,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "temp-env",
  "tempfile",
  "thiserror 2.0.18",
  "tinyvec",
@@ -2043,6 +2044,7 @@ dependencies = [
  "serdes-ai",
  "serdes-ai-models",
  "serdes-ai-streaming",
+ "temp-env",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3444,6 +3446,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -3069,7 +3069,6 @@ dependencies = [
  "futures",
  "serdes-ai-agent",
  "serdes-ai-core",
- "serdes-ai-macros",
  "serdes-ai-models",
  "serdes-ai-output",
  "serdes-ai-providers",
@@ -3163,6 +3162,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/src/llm-coding-tools-agents/README.md
+++ b/src/llm-coding-tools-agents/README.md
@@ -63,11 +63,7 @@ loader.add_directory(&mut catalog, "/home/user/.opencode")?;
 
 let runtime = AgentRuntimeBuilder::new()
     .catalog(catalog)
-    .defaults(AgentDefaults {
-        model: Some("openai/gpt-4o-mini".into()),
-        temperature: Some(0.2),
-        top_p: Some(0.95),
-    })
+    .defaults(AgentDefaults::with_model("openai/gpt-4o-mini"))
     // .tools(my_custom_tools)  // optional; defaults to read/write/edit/glob/grep/bash/webfetch/todoread/todowrite
     .build();
 

--- a/src/llm-coding-tools-agents/src/extensions.rs
+++ b/src/llm-coding-tools-agents/src/extensions.rs
@@ -3,16 +3,18 @@
 //! Helpers for converting agent permission config into runtime [`Ruleset`] values.
 //!
 //! ## What This Module Provides
-//! - [`RulesetExt`] trait for building a [`Ruleset`] from frontmatter data.
+//! - [`RulesetExt`] trait for building a [`Ruleset`] from frontmatter data and
+//!   filtering tool entries by permission.
 //! - Support for scalar (`allow`/`deny`) and pattern-map permission rules.
 //! - Iteration-order preservation via [`IndexMap`] (important for precedence).
 
+use crate::runtime::ToolCatalogEntry;
 use crate::types::PermissionRule;
 use indexmap::IndexMap;
 use llm_coding_tools_core::permissions::{Rule, Ruleset};
 
 /// Extension trait for building [`Ruleset`] from agent permission configs.
-pub trait RulesetExt {
+pub trait RulesetExt: Sized {
     /// Creates a [`Ruleset`] from frontmatter permission configuration.
     ///
     /// The config maps permission keys to either:
@@ -38,11 +40,41 @@ pub trait RulesetExt {
     /// assert!(ruleset.is_allowed("bash", "*"));
     /// ```
     fn from_permission_config(config: &IndexMap<String, PermissionRule>) -> Self;
+
+    /// Filters tool entries to those allowed by this ruleset.
+    ///
+    /// Returns only entries whose `name` passes `is_allowed(name, "*")`.
+    ///
+    /// # Arguments
+    ///
+    /// * `tools` - Slice of tool entries to filter.
+    ///
+    /// # Returns
+    ///
+    /// A vector containing only the tool entries allowed by this ruleset,
+    /// preserving the original order.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use llm_coding_tools_agents::{
+    ///     default_tools, PermissionRule, RulesetExt,
+    /// };
+    /// use llm_coding_tools_core::permissions::{PermissionAction, Ruleset};
+    /// use indexmap::IndexMap;
+    ///
+    /// let mut config = IndexMap::new();
+    /// config.insert("read".to_string(), PermissionRule::Action(PermissionAction::Allow));
+    ///
+    /// let ruleset = Ruleset::from_permission_config(&config);
+    /// let allowed = ruleset.filter_allowed_tools(&default_tools());
+    /// assert!(allowed.iter().any(|t| t.name == "read"));
+    /// ```
+    fn filter_allowed_tools(&self, tools: &[ToolCatalogEntry]) -> Vec<ToolCatalogEntry>;
 }
 
 impl RulesetExt for Ruleset {
     fn from_permission_config(config: &IndexMap<String, PermissionRule>) -> Self {
-        // Estimate capacity: most entries have 1-2 rules
         let mut ruleset = Self::with_capacity(config.len() * 2);
 
         for (key, rule) in config {
@@ -60,11 +92,20 @@ impl RulesetExt for Ruleset {
 
         ruleset
     }
+
+    fn filter_allowed_tools(&self, tools: &[ToolCatalogEntry]) -> Vec<ToolCatalogEntry> {
+        tools
+            .iter()
+            .copied()
+            .filter(|entry| self.is_allowed(entry.name, "*"))
+            .collect()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::default_tools;
     use llm_coding_tools_core::permissions::PermissionAction;
 
     #[test]
@@ -102,5 +143,25 @@ mod tests {
             ruleset.evaluate("task", "other-agent"),
             PermissionAction::Deny
         );
+    }
+
+    #[test]
+    fn filter_allowed_tools_returns_allowed_entries() {
+        let mut config = IndexMap::new();
+        config.insert(
+            "read".to_string(),
+            PermissionRule::Action(PermissionAction::Allow),
+        );
+        config.insert(
+            "glob".to_string(),
+            PermissionRule::Action(PermissionAction::Allow),
+        );
+
+        let ruleset = Ruleset::from_permission_config(&config);
+        let allowed = ruleset.filter_allowed_tools(&default_tools());
+
+        assert!(allowed.iter().any(|t| t.name == "read"));
+        assert!(allowed.iter().any(|t| t.name == "glob"));
+        assert!(!allowed.iter().any(|t| t.name == "bash"));
     }
 }

--- a/src/llm-coding-tools-agents/src/runtime/builder.rs
+++ b/src/llm-coding-tools-agents/src/runtime/builder.rs
@@ -86,7 +86,7 @@ mod tests {
         let catalog = AgentCatalog::from_entries([sample_config("planner", Some("openai/gpt-4o"))]);
         let defaults = AgentDefaults {
             model: Some("openai/gpt-4.1-mini".into()),
-            temperature: Some(0.2),
+            temperature: Some(1.0),
             top_p: Some(0.95),
         };
         let tools = vec![

--- a/src/llm-coding-tools-agents/src/runtime/mod.rs
+++ b/src/llm-coding-tools-agents/src/runtime/mod.rs
@@ -27,11 +27,7 @@
 //!
 //! let runtime = AgentRuntimeBuilder::new()
 //!     .catalog(AgentCatalog::new())
-//!     .defaults(AgentDefaults {
-//!         model: Some("openai/gpt-4o".into()),
-//!         temperature: Some(0.7),
-//!         top_p: Some(0.9),
-//!     })
+//!     .defaults(AgentDefaults::with_model("openai/gpt-4o"))
 //!     .build();
 //!
 //! assert!(runtime.catalog().iter().count() == 0);

--- a/src/llm-coding-tools-agents/src/runtime/model.rs
+++ b/src/llm-coding-tools-agents/src/runtime/model.rs
@@ -187,7 +187,33 @@ pub fn resolve_model_with_catalog(
     })
 }
 
-/// Extracts provider and model parts, checking agent override first.
+/// Resolves the effective provider and model for an agent.
+///
+/// Checks sources in precedence order: agent-level override first, then runtime defaults.
+/// Returns the parsed `(provider, model)` tuple along with a string identifying which
+/// source was used (`"agent override"` or `"runtime default"`).
+///
+/// # Examples
+///
+/// ```text
+/// Agent has its own model set: "openai/gpt-4o"
+/// Defaults also has a model set: "anthropic/claude-3-5-sonnet"
+/// Result: ("openai", "gpt-4o", "agent override")
+/// The agent's model wins because it was set directly.
+/// ```
+///
+/// ```text
+/// Agent has no model set.
+/// Defaults has model set: "anthropic/claude-3-5-sonnet"
+/// Result: ("anthropic", "claude-3-5-sonnet", "runtime default")
+/// Falls back to the default since agent didn't specify one.
+/// ```
+///
+/// # Errors
+///
+/// Returns [`ModelResolutionError::MalformedModelIdentifier`] if the model string
+/// from either source cannot be parsed (missing `/` separator).
+/// Returns [`ModelResolutionError::MissingEffectiveModel`] if neither source provides a model.
 fn get_provider_model<'a>(
     defaults: &'a super::state::AgentDefaults,
     agent: &'a AgentConfig,
@@ -258,7 +284,7 @@ mod tests {
             modalities: Modality::TEXT,
             max_input,
             max_output,
-            temperature: Some(0.2),
+            temperature: Some(1.0),
             top_p: Some(0.95),
         }
     }

--- a/src/llm-coding-tools-agents/src/runtime/model.rs
+++ b/src/llm-coding-tools-agents/src/runtime/model.rs
@@ -327,11 +327,7 @@ mod tests {
             )],
             vec![("openai", "gpt-4.1-mini", model_info(128_000, 16_384))],
         );
-        let defaults = AgentDefaults {
-            model: Some("openai/gpt-4.1-mini".into()),
-            temperature: None,
-            top_p: None,
-        };
+        let defaults = AgentDefaults::with_model("openai/gpt-4.1-mini");
         let agent = config_with_model("planner", None);
 
         let resolved = resolve_model_with_catalog(&catalog, &defaults, &agent)
@@ -362,11 +358,7 @@ mod tests {
                 ("openrouter", "openai/gpt-4o", model_info(128_000, 16_384)),
             ],
         );
-        let defaults = AgentDefaults {
-            model: Some("openrouter/openai/gpt-4.1-mini".into()),
-            temperature: None,
-            top_p: None,
-        };
+        let defaults = AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini");
         let agent = config_with_model("planner", Some("openrouter/openai/gpt-4o"));
 
         let resolved = resolve_model_with_catalog(&catalog, &defaults, &agent)
@@ -389,11 +381,7 @@ mod tests {
             )],
             vec![("openai", "gpt-4.1-mini", model_info(128_000, 16_384))],
         );
-        let defaults = AgentDefaults {
-            model: Some("openai/gpt-4.1-mini".into()),
-            temperature: None,
-            top_p: None,
-        };
+        let defaults = AgentDefaults::with_model("openai/gpt-4.1-mini");
         let agent = config_with_model("planner", Some("openai-only"));
 
         let err = resolve_model_with_catalog(&catalog, &defaults, &agent)
@@ -514,11 +502,7 @@ mod tests {
             )],
             vec![("openai", "gpt-4o", model_info(128_000, 16_384))],
         );
-        let defaults = AgentDefaults {
-            model: Some("openai-only".into()),
-            temperature: None,
-            top_p: None,
-        };
+        let defaults = AgentDefaults::with_model("openai-only");
         let agent = config_with_model("planner", None);
 
         let err = resolve_model_with_catalog(&catalog, &defaults, &agent)

--- a/src/llm-coding-tools-agents/src/runtime/state.rs
+++ b/src/llm-coding-tools-agents/src/runtime/state.rs
@@ -19,6 +19,18 @@ pub struct AgentDefaults {
     pub top_p: Option<f32>,
 }
 
+impl AgentDefaults {
+    /// Creates defaults with only a model specified; temperature and top_p inherit provider defaults.
+    #[inline]
+    pub fn with_model(model: impl Into<Box<str>>) -> Self {
+        Self {
+            model: Some(model.into()),
+            temperature: None,
+            top_p: None,
+        }
+    }
+}
+
 /// Your loaded agents plus their default settings and available tools.
 #[derive(Debug, Clone)]
 pub struct AgentRuntime {

--- a/src/llm-coding-tools-core/Cargo.toml
+++ b/src/llm-coding-tools-core/Cargo.toml
@@ -98,6 +98,7 @@ tokio = { version = "1.50", features = ["rt", "macros"] }
 wiremock = "0.6"
 indoc = "2"
 criterion = "0.8"
+temp-env = "0.3.6"
 
 [[bench]]
 name = "model_catalog_builder"

--- a/src/llm-coding-tools-core/README.md
+++ b/src/llm-coding-tools-core/README.md
@@ -209,7 +209,7 @@ assert_eq!(rules.evaluate("task", "orchestrator-review"), PermissionAction::Deny
 - [`set_override`] stores a value that takes precedence over environment variables.
 
 ```rust,no_run
-use llm_coding_tools_core::CredentialResolver;
+use llm_coding_tools_core::{CredentialLookup, CredentialResolver};
 
 let mut resolver = CredentialResolver::new();
 resolver.set_override("OPENAI_API_KEY", "sk-override");

--- a/src/llm-coding-tools-core/README.md
+++ b/src/llm-coding-tools-core/README.md
@@ -200,6 +200,22 @@ assert_eq!(rules.evaluate("bash", "any-agent"), PermissionAction::Allow);
 assert_eq!(rules.evaluate("task", "orchestrator-review"), PermissionAction::Deny); // last-match-wins
 ```
 
+## Credentials
+
+[`CredentialResolver`] looks up named credentials (like API keys) from overrides or environment variables.
+
+- [`CredentialResolver::new()`] checks overrides first, then falls back to environment variables.
+- [`CredentialResolver::without_env()`] only uses explicit overrides.
+- [`set_override`] stores a value that takes precedence over environment variables.
+
+```rust,no_run
+use llm_coding_tools_core::CredentialResolver;
+
+let mut resolver = CredentialResolver::new();
+resolver.set_override("OPENAI_API_KEY", "sk-override");
+let key = resolver.resolve("OPENAI_API_KEY");
+```
+
 [`tool_names`]: crate::tool_names
 [`read`]: crate::tool_names::READ
 [`write`]: crate::tool_names::WRITE
@@ -238,3 +254,7 @@ assert_eq!(rules.evaluate("task", "orchestrator-review"), PermissionAction::Deny
 [`Rule`]: crate::permissions::Rule
 [`Ruleset`]: crate::permissions::Ruleset
 [`PermissionAction::Deny`]: crate::permissions::PermissionAction::Deny
+[`CredentialResolver`]: crate::CredentialResolver
+[`CredentialResolver::new()`]: crate::CredentialResolver::new
+[`CredentialResolver::without_env()`]: crate::CredentialResolver::without_env
+[`set_override`]: crate::CredentialResolver::set_override

--- a/src/llm-coding-tools-core/src/credentials.rs
+++ b/src/llm-coding-tools-core/src/credentials.rs
@@ -1,0 +1,136 @@
+//! Resolve named credentials for model providers.
+//!
+//! Use [`CredentialResolver`] to look up credentials by their known names.
+//! Callers can set explicit overrides and optionally fall back to process
+//! environment variables.
+//!
+//! # Public API
+//!
+//! - [`CredentialResolver`] - Resolves one credential name at a time.
+//! - [`CredentialLookup`] - Trait for abstracting credential resolution.
+//!
+//! # Precedence
+//!
+//! 1. Explicit overrides added with [`CredentialResolver::set_override`]
+//! 2. Process environment variables, unless `READ_ENV` is `false`
+
+use ahash::AHashMap;
+
+/// Trait for resolving named credentials.
+///
+/// Implemented by [`CredentialResolver`] regardless of its `READ_ENV` parameter.
+/// Use `&impl CredentialLookup` in function signatures to accept any resolver variant.
+pub trait CredentialLookup {
+    /// Resolves one named credential.
+    ///
+    /// Returns `None` when neither overrides nor environment variables provide a non-empty value.
+    fn resolve(&self, name: &str) -> Option<String>;
+}
+
+/// Resolves named credentials from explicit overrides map.
+#[derive(Debug, Clone)]
+pub struct CredentialResolver<const READ_ENV: bool = true> {
+    overrides: AHashMap<Box<str>, Box<str>>,
+}
+
+impl Default for CredentialResolver {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CredentialResolver {
+    /// Creates a resolver that checks overrides first and then falls back to environment variables.
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            overrides: AHashMap::new(),
+        }
+    }
+}
+
+impl CredentialResolver<false> {
+    /// Creates a resolver that only uses explicit overrides (no environment fallback).
+    #[inline]
+    pub fn without_env() -> Self {
+        Self {
+            overrides: AHashMap::new(),
+        }
+    }
+}
+
+impl<const READ_ENV: bool> CredentialResolver<READ_ENV> {
+    /// Stores a value to return when callers resolve `name`.
+    #[inline]
+    pub fn set_override(&mut self, name: impl Into<Box<str>>, value: impl Into<Box<str>>) {
+        self.overrides.insert(name.into(), value.into());
+    }
+}
+
+impl<const READ_ENV: bool> CredentialLookup for CredentialResolver<READ_ENV> {
+    #[inline]
+    fn resolve(&self, name: &str) -> Option<String> {
+        if let Some(value) = self.overrides.get(name) {
+            if !value.is_empty() {
+                return Some(value.as_ref().to_owned());
+            }
+        }
+
+        // Statically resolved: when READ_ENV is false, the compiler eliminates this branch entirely.
+        if READ_ENV {
+            if let Ok(value) = std::env::var(name) {
+                if !value.is_empty() {
+                    return Some(value);
+                }
+            }
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CredentialLookup, CredentialResolver};
+
+    #[test]
+    fn resolve_prefers_overrides_to_environment_variables() {
+        temp_env::with_var("OPENAI_API_KEY", Some("env-key"), || {
+            let mut resolver = CredentialResolver::new();
+            resolver.set_override("OPENAI_API_KEY", "override-key");
+
+            assert_eq!(
+                resolver.resolve("OPENAI_API_KEY").as_deref(),
+                Some("override-key")
+            );
+        });
+    }
+
+    #[test]
+    fn resolve_skips_empty_override_and_uses_environment_value() {
+        temp_env::with_var("OPENAI_API_KEY", Some("env-key"), || {
+            let mut resolver = CredentialResolver::new();
+            resolver.set_override("OPENAI_API_KEY", "");
+
+            assert_eq!(
+                resolver.resolve("OPENAI_API_KEY").as_deref(),
+                Some("env-key")
+            );
+        });
+    }
+
+    #[test]
+    fn without_env_ignores_environment_variables() {
+        temp_env::with_var("OPENAI_API_KEY", Some("env-key"), || {
+            let mut resolver = CredentialResolver::without_env();
+            resolver.set_override("OPENAI_API_KEY", "override-key");
+
+            assert_eq!(
+                resolver.resolve("OPENAI_API_KEY").as_deref(),
+                Some("override-key")
+            );
+            assert_eq!(resolver.resolve("ANTHROPIC_API_KEY"), None);
+        });
+    }
+}

--- a/src/llm-coding-tools-core/src/lib.rs
+++ b/src/llm-coding-tools-core/src/lib.rs
@@ -8,6 +8,7 @@ compile_error!("Features `async` and `blocking` are mutually exclusive.");
 compile_error!("Either an async runtime (e.g., `tokio`) or `blocking` feature must be enabled.");
 
 pub mod context;
+pub mod credentials;
 pub mod error;
 pub mod fs;
 pub mod models;
@@ -22,6 +23,7 @@ pub mod util;
 mod internal;
 
 pub use context::ToolContext;
+pub use credentials::{CredentialLookup, CredentialResolver};
 pub use error::{ToolError, ToolResult};
 pub use output::ToolOutput;
 pub use path::{AbsolutePathResolver, AllowedPathResolver, PathResolver};

--- a/src/llm-coding-tools-models-dev/src/api/catalog_sources.rs
+++ b/src/llm-coding-tools-models-dev/src/api/catalog_sources.rs
@@ -140,6 +140,7 @@ fn model_max_input(limit: &ApiModelLimit) -> u32 {
 fn provider_type_from_models_dev_npm(npm_package: Option<&str>) -> ProviderType {
     match npm_package {
         Some("@ai-sdk/openai") => ProviderType::OpenAiCompletions,
+        Some("@ai-sdk/openai-compatible") => ProviderType::OpenAiCompletions,
         Some("@ai-sdk/openai-responses") => ProviderType::OpenAiResponses,
         Some("@ai-sdk/anthropic") => ProviderType::Anthropic,
         Some("@ai-sdk/google") => ProviderType::Google,
@@ -548,12 +549,64 @@ mod tests {
             ProviderType::OpenAiCompletions
         );
         assert_eq!(
+            provider_type_from_models_dev_npm(Some("@ai-sdk/openai-compatible")),
+            ProviderType::OpenAiCompletions
+        );
+        assert_eq!(
+            provider_type_from_models_dev_npm(Some("@ai-sdk/openai-responses")),
+            ProviderType::OpenAiResponses
+        );
+        assert_eq!(
+            provider_type_from_models_dev_npm(Some("@ai-sdk/anthropic")),
+            ProviderType::Anthropic
+        );
+        assert_eq!(
             provider_type_from_models_dev_npm(Some("@ai-sdk/google")),
             ProviderType::Google
         );
         assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/openai-compatible")),
-            ProviderType::Unknown
+            provider_type_from_models_dev_npm(Some("@ai-sdk/groq")),
+            ProviderType::Groq
+        );
+        assert_eq!(
+            provider_type_from_models_dev_npm(Some("@ai-sdk/mistral")),
+            ProviderType::Mistral
+        );
+        assert_eq!(
+            provider_type_from_models_dev_npm(Some("@ai-sdk/ollama")),
+            ProviderType::Ollama
+        );
+        assert_eq!(
+            provider_type_from_models_dev_npm(Some("@ai-sdk/amazon-bedrock")),
+            ProviderType::Bedrock
+        );
+        assert_eq!(
+            provider_type_from_models_dev_npm(Some("@ai-sdk/azure")),
+            ProviderType::Azure
+        );
+        assert_eq!(
+            provider_type_from_models_dev_npm(Some("@openrouter/ai-sdk-provider")),
+            ProviderType::OpenRouter
+        );
+        assert_eq!(
+            provider_type_from_models_dev_npm(Some("@ai-sdk/huggingface")),
+            ProviderType::HuggingFace
+        );
+        assert_eq!(
+            provider_type_from_models_dev_npm(Some("@ai-sdk/cohere")),
+            ProviderType::Cohere
+        );
+        assert_eq!(
+            provider_type_from_models_dev_npm(Some("@ai-sdk/chatgpt-oauth")),
+            ProviderType::ChatGptOAuth
+        );
+        assert_eq!(
+            provider_type_from_models_dev_npm(Some("@ai-sdk/claude-code-oauth")),
+            ProviderType::ClaudeCodeOAuth
+        );
+        assert_eq!(
+            provider_type_from_models_dev_npm(Some("@ai-sdk/antigravity")),
+            ProviderType::Antigravity
         );
         assert_eq!(
             provider_type_from_models_dev_npm(None),

--- a/src/llm-coding-tools-models-dev/src/catalog/mod.rs
+++ b/src/llm-coding-tools-models-dev/src/catalog/mod.rs
@@ -152,12 +152,12 @@ mod tests {
 
     /// Guard that restores the shared cache path env var on drop.
     struct CachePathGuard {
-        previous: Option<String>,
+        previous: Option<std::ffi::OsString>,
     }
 
     impl CachePathGuard {
         fn new(value: &std::ffi::OsStr) -> Self {
-            let previous = std::env::var(CACHE_PATH_ENV_VAR).ok();
+            let previous = std::env::var_os(CACHE_PATH_ENV_VAR);
             unsafe {
                 std::env::set_var(CACHE_PATH_ENV_VAR, value);
             }
@@ -169,7 +169,7 @@ mod tests {
         fn drop(&mut self) {
             super::sync::set_test_models_dev_api_url(None);
             unsafe {
-                match &self.previous {
+                match self.previous.take() {
                     Some(value) => std::env::set_var(CACHE_PATH_ENV_VAR, value),
                     None => std::env::remove_var(CACHE_PATH_ENV_VAR),
                 }

--- a/src/llm-coding-tools-models-dev/src/catalog/mod.rs
+++ b/src/llm-coding-tools-models-dev/src/catalog/mod.rs
@@ -150,31 +150,29 @@ mod tests {
     use llm_coding_tools_core::models::ProviderType;
     use tempfile::TempDir;
 
-    /// Guard that restores environment variables on drop
-    struct EnvGuard {
-        cache_path_var: Option<String>,
+    /// Guard that restores the shared cache path env var on drop.
+    struct CachePathGuard {
+        previous: Option<String>,
     }
 
-    impl EnvGuard {
-        fn new(value: Option<&str>) -> Self {
-            let cache_path_var = std::env::var(CACHE_PATH_ENV_VAR).ok();
-            match value {
-                Some(v) => std::env::set_var(CACHE_PATH_ENV_VAR, v),
-                None => std::env::remove_var(CACHE_PATH_ENV_VAR),
+    impl CachePathGuard {
+        fn new(value: &std::ffi::OsStr) -> Self {
+            let previous = std::env::var(CACHE_PATH_ENV_VAR).ok();
+            unsafe {
+                std::env::set_var(CACHE_PATH_ENV_VAR, value);
             }
-            Self { cache_path_var }
+            Self { previous }
         }
     }
 
-    impl Drop for EnvGuard {
+    impl Drop for CachePathGuard {
         fn drop(&mut self) {
-            // Clear test URL override
             super::sync::set_test_models_dev_api_url(None);
-
-            // Restore or remove cache path env var
-            match &self.cache_path_var {
-                Some(v) => std::env::set_var(CACHE_PATH_ENV_VAR, v),
-                None => std::env::remove_var(CACHE_PATH_ENV_VAR),
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(CACHE_PATH_ENV_VAR, value),
+                    None => std::env::remove_var(CACHE_PATH_ENV_VAR),
+                }
             }
         }
     }
@@ -186,9 +184,8 @@ mod tests {
     async fn facade_load_uses_shared_cache_path() {
         let temp = TempDir::new().expect("tempdir");
         let cache_path = temp.path().join("facade-test.cache");
-        let _guard = EnvGuard::new(Some(cache_path.to_str().unwrap()));
+        let _guard = CachePathGuard::new(cache_path.as_os_str());
 
-        // Start mock server and set URL override
         let body = String::from_utf8_lossy(sample_api_json()).to_string();
         let (_handle, url) = start_mock_server(MockResponse::Ok {
             etag: "\"facade-test-etag\"",
@@ -196,7 +193,6 @@ mod tests {
         });
         super::sync::set_test_models_dev_api_url(Some(url));
 
-        // Call public facade
         let result = ModelsDevCatalog::load().await.expect("load should succeed");
 
         assert_eq!(result.source, CatalogLoadSource::Downloaded);

--- a/src/llm-coding-tools-serdesai/Cargo.toml
+++ b/src/llm-coding-tools-serdesai/Cargo.toml
@@ -19,7 +19,7 @@ llm-coding-tools-agents = { version = "0.1.0", path = "../llm-coding-tools-agent
 
 # serdes-ai provides Tool trait, ToolDefinition, RunContext
 serdes-ai = "0.2.6"
-serdes-ai-models = { version = "0.2.6", features = ["openrouter"] }
+serdes-ai-models = { version = "0.2.6", features = ["openai"] }
 serdes-ai-streaming = "0.2"
 futures = "0.3"
 

--- a/src/llm-coding-tools-serdesai/Cargo.toml
+++ b/src/llm-coding-tools-serdesai/Cargo.toml
@@ -9,12 +9,30 @@ readme = "README.md"
 include = ["src/**/*", "examples/**/*", "README.md"]
 
 [features]
-default = ["openai"]
+default = ["full"]
+full = [
+    "openai",
+    "anthropic",
+    "azure",
+    "bedrock",
+    "chatgpt-oauth",
+    "claude-code-oauth",
+    "cohere",
+    "gemini",
+    "google",
+    "groq",
+    "huggingface",
+    "mistral",
+    "ollama",
+    "openrouter",
+    "antigravity",
+]
 # Provider features - pass through to serdes-ai-models
 openai = ["serdes-ai-models/openai"]
 anthropic = ["serdes-ai-models/anthropic"]
 azure = ["serdes-ai-models/azure"]
 bedrock = ["serdes-ai-models/bedrock"]
+antigravity = ["serdes-ai-models/antigravity"]
 chatgpt-oauth = ["serdes-ai-models/chatgpt-oauth"]
 claude-code-oauth = ["serdes-ai-models/claude-code-oauth"]
 cohere = ["serdes-ai-models/cohere"]
@@ -36,7 +54,7 @@ llm-coding-tools-core = { version = "0.2.0", path = "../llm-coding-tools-core", 
 llm-coding-tools-agents = { version = "0.1.0", path = "../llm-coding-tools-agents" }
 
 # serdes-ai provides Tool trait, ToolDefinition, RunContext
-serdes-ai = "0.2.6"
+serdes-ai = { version = "0.2.6", default-features = false }
 serdes-ai-models = { version = "0.2.6", default-features = false }
 serdes-ai-streaming = "0.2"
 futures = "0.3"

--- a/src/llm-coding-tools-serdesai/Cargo.toml
+++ b/src/llm-coding-tools-serdesai/Cargo.toml
@@ -8,6 +8,24 @@ license = "Apache-2.0"
 readme = "README.md"
 include = ["src/**/*", "examples/**/*", "README.md"]
 
+[features]
+default = ["openai"]
+# Provider features - pass through to serdes-ai-models
+openai = ["serdes-ai-models/openai"]
+anthropic = ["serdes-ai-models/anthropic"]
+azure = ["serdes-ai-models/azure"]
+bedrock = ["serdes-ai-models/bedrock"]
+chatgpt-oauth = ["serdes-ai-models/chatgpt-oauth"]
+claude-code-oauth = ["serdes-ai-models/claude-code-oauth"]
+cohere = ["serdes-ai-models/cohere"]
+gemini = ["serdes-ai-models/gemini"]
+google = ["serdes-ai-models/google"]
+groq = ["serdes-ai-models/groq"]
+huggingface = ["serdes-ai-models/huggingface"]
+mistral = ["serdes-ai-models/mistral"]
+ollama = ["serdes-ai-models/ollama"]
+openrouter = ["serdes-ai-models/openrouter"]
+
 [dependencies]
 # Core tool operations (file read/write/edit, glob, grep, bash, etc.)
 llm-coding-tools-core = { version = "0.2.0", path = "../llm-coding-tools-core", features = [
@@ -19,7 +37,7 @@ llm-coding-tools-agents = { version = "0.1.0", path = "../llm-coding-tools-agent
 
 # serdes-ai provides Tool trait, ToolDefinition, RunContext
 serdes-ai = "0.2.6"
-serdes-ai-models = { version = "0.2.6", features = ["openai"] }
+serdes-ai-models = { version = "0.2.6", default-features = false }
 serdes-ai-streaming = "0.2"
 futures = "0.3"
 
@@ -45,3 +63,5 @@ tempfile = "3"
 wiremock = "0.6"
 ahash = "0.8"
 indexmap = "2"
+# models.dev catalog loader for examples
+llm-coding-tools-models-dev = { version = "0.1.0", path = "../llm-coding-tools-models-dev" }

--- a/src/llm-coding-tools-serdesai/Cargo.toml
+++ b/src/llm-coding-tools-serdesai/Cargo.toml
@@ -81,5 +81,6 @@ tempfile = "3"
 wiremock = "0.6"
 ahash = "0.8"
 indexmap = "2"
+temp-env = "0.3.6"
 # models.dev catalog loader for examples
 llm-coding-tools-models-dev = { version = "0.1.0", path = "../llm-coding-tools-models-dev" }

--- a/src/llm-coding-tools-serdesai/Cargo.toml
+++ b/src/llm-coding-tools-serdesai/Cargo.toml
@@ -14,6 +14,9 @@ llm-coding-tools-core = { version = "0.2.0", path = "../llm-coding-tools-core", 
     "tokio",
 ] }
 
+# Generic agent runtime dependencies
+llm-coding-tools-agents = { version = "0.1.0", path = "../llm-coding-tools-agents" }
+
 # serdes-ai provides Tool trait, ToolDefinition, RunContext
 serdes-ai = "0.2.6"
 serdes-ai-models = { version = "0.2.6", features = ["openrouter"] }
@@ -22,6 +25,9 @@ futures = "0.3"
 
 # Tool trait is async - async-trait is NOT re-exported from serdes-ai
 async-trait = "0.1"
+
+# Error derives
+thiserror = "2.0"
 
 # Tool parameters use serde for deserialization, serde_json for schema
 serde = { version = "1.0", features = ["derive"] }
@@ -37,3 +43,5 @@ reqwest = { version = "0.13", default-features = false, features = [
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tempfile = "3"
 wiremock = "0.6"
+ahash = "0.8"
+indexmap = "2"

--- a/src/llm-coding-tools-serdesai/README.md
+++ b/src/llm-coding-tools-serdesai/README.md
@@ -63,9 +63,12 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
 See the [serdesai-basic example](examples/serdesai-basic.rs) for a complete working setup.
 
-## Usage
+## Tool Variants
 
-File tools come in `absolute::*` (unrestricted) and `allowed::*` (sandboxed) variants:
+File tools come in two variants with identical APIs:
+
+- **`absolute::*`** - Unrestricted filesystem access using absolute paths
+- **`allowed::*`** - Sandboxed to configured directories via `AllowedPathResolver`
 
 ```rust,no_run
 use llm_coding_tools_serdesai::absolute::{ReadTool, WriteTool};
@@ -73,20 +76,39 @@ use llm_coding_tools_serdesai::allowed::{ReadTool as AllowedReadTool, WriteTool 
 use llm_coding_tools_serdesai::AllowedPathResolver;
 use std::path::PathBuf;
 
-// Unrestricted access (absolute paths)
+// Unrestricted access
 let read = ReadTool::<true>::new();
 
-// Sandboxed access (paths relative to allowed directories)
+// Sandboxed access
 let allowed_paths = vec![PathBuf::from("/home/user/project"), PathBuf::from("/tmp")];
 let resolver = AllowedPathResolver::new(allowed_paths).unwrap();
 let sandboxed_read: AllowedReadTool<true> = AllowedReadTool::new(resolver.clone());
 let sandboxed_write = AllowedWriteTool::new(resolver);
 ```
 
-Other tools: `BashTool`, `WebFetchTool`, `TaskTool`, `TodoReadTool`, `TodoWriteTool`.
-Use `SystemPromptBuilder` to track tools and pass `pb.build()` to `.system_prompt()`. Set `working_directory()` so the environment section is populated.
-Use `AgentBuilderExt::tool()` to add tools that implement `Tool<Deps>` to the agent.
-Context strings are re-exported in `llm_coding_tools_serdesai::context` (e.g., `BASH`, `READ_ABSOLUTE`).
+Other tools: `BashTool`, `WebFetchTool`, `TodoReadTool`, `TodoWriteTool`.
+
+Use `SystemPromptBuilder` to track tools and generate context-aware prompts. Context strings are re-exported in `llm_coding_tools_serdesai::context` (e.g., `BASH`, `READ_ABSOLUTE`).
+
+## Agent Runtime
+
+For catalog-based agent configuration, use `AgentRuntimeExt` to build agents from an [`AgentRuntime`](https://docs.rs/llm-coding-tools-agents/latest/llm_coding_tools_agents/struct.AgentRuntime.html):
+
+```rust,no_run
+use llm_coding_tools_serdesai::AgentRuntimeExt;
+use llm_coding_tools_agents::AgentRuntimeBuilder;
+use llm_coding_tools_core::models::ModelCatalog;
+
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# fn get_catalog() -> ModelCatalog { unimplemented!() }
+let runtime = AgentRuntimeBuilder::new().build();
+let catalog = get_catalog(); // Load from models-dev, config file, etc.
+let _agent = runtime.build("planner", &catalog)?;
+# Ok(())
+# }
+```
+
+This requires the `llm-coding-tools-agents` crate and a `ModelCatalog` for model resolution.
 
 ## Examples
 

--- a/src/llm-coding-tools-serdesai/examples/agents/basic/file-reader.md
+++ b/src/llm-coding-tools-serdesai/examples/agents/basic/file-reader.md
@@ -1,0 +1,13 @@
+---
+mode: all
+description: Reads repository files and summarizes the important details.
+permission:
+  read: allow
+  glob: allow
+  grep: allow
+  task: deny
+---
+
+You are the `basic/file-reader` agent.
+Use the available read-only tools to inspect the requested files and return a concise summary.
+Do not delegate work; answer directly with the tools attached to this runtime build.

--- a/src/llm-coding-tools-serdesai/examples/serdesai-agents.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-agents.rs
@@ -1,0 +1,87 @@
+//! Markdown-agent runtime example.
+//!
+//! Loads markdown agents through [`AgentLoader`], builds one named agent through
+//! [`AgentRuntimeBuilder`], and runs it without Task/delegation.
+//!
+//! Run: cargo run --example serdesai-agents -p llm-coding-tools-serdesai
+
+use llm_coding_tools_agents::{AgentCatalog, AgentLoader, AgentRuntimeBuilder};
+use llm_coding_tools_core::models::{
+    Modality, ModelCatalog, ModelInfo, ProviderIdx, ProviderInfo, ProviderModelSource,
+    ProviderSource, ProviderType,
+};
+use llm_coding_tools_serdesai::{AgentDefaults, AgentRuntimeExt};
+use std::path::PathBuf;
+
+const AGENT_NAME: &str = "basic/file-reader";
+
+// API key below has a zero spend limit; it cannot incur charges.
+// If this no longer works, find a free model to use on OpenRouter for testing.
+const OPENROUTER_API_KEY: &str = "";
+const OPENROUTER_MODEL: &str = "z-ai/glm-4.5-air:free";
+
+fn build_model_catalog() -> ModelCatalog {
+    let providers = vec![ProviderSource::new(
+        "openrouter",
+        ProviderInfo {
+            api_url: "https://openrouter.ai/api/v1".into(),
+            env_vars: vec!["OPENROUTER_API_KEY".into()],
+            api_type: ProviderType::OpenRouter,
+        },
+    )];
+    let info = ModelInfo {
+        modalities: Modality::TEXT,
+        max_input: 128_000,
+        max_output: 16_384,
+        temperature: Some(1.0),
+        top_p: Some(0.95),
+    };
+    let models: Vec<ProviderModelSource<'_>> = vec![ProviderModelSource::new(
+        ProviderIdx::new(0),
+        OPENROUTER_MODEL,
+        info,
+    )];
+    ModelCatalog::build(&providers, &models).expect("model catalog should build")
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let examples_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples");
+    let readme_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("README.md");
+
+    // SAFETY: Setting API key before async runtime operations; single-threaded startup.
+    unsafe { std::env::set_var("OPENROUTER_API_KEY", OPENROUTER_API_KEY) };
+
+    let mut catalog = AgentCatalog::new();
+    AgentLoader::new().add_directory(&mut catalog, &examples_root)?;
+
+    let model_catalog = build_model_catalog();
+
+    let runtime = AgentRuntimeBuilder::new()
+        .catalog(catalog)
+        .defaults(AgentDefaults {
+            model: Some(format!("openrouter/{OPENROUTER_MODEL}").into()),
+            temperature: Some(0.2),
+            top_p: Some(0.95),
+        })
+        .build();
+
+    println!(
+        "Loading named agent `{AGENT_NAME}` from {}",
+        examples_root.display()
+    );
+    let agent = runtime.build(AGENT_NAME, &model_catalog)?;
+    println!(
+        "Built `{AGENT_NAME}` on demand with {} tools.",
+        agent.tools().len()
+    );
+
+    let prompt = format!(
+        "Read {} and summarize the runtime flow in three bullets.",
+        readme_path.display()
+    );
+    let response = agent.run(prompt.as_str(), ()).await?;
+    println!("{}", response.output());
+
+    Ok(())
+}

--- a/src/llm-coding-tools-serdesai/examples/serdesai-agents.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-agents.rs
@@ -1,15 +1,15 @@
-//! Markdown-agent runtime example.
+//! Markdown-agent runtime example using models.dev catalog.
 //!
 //! Loads markdown agents through [`AgentLoader`], builds one named agent through
 //! [`AgentRuntimeBuilder`], and runs it without Task/delegation.
 //!
+//! The model catalog is loaded from models.dev, which provides up-to-date
+//! provider and model information from <https://models.dev/api.json>.
+//!
 //! Run: cargo run --example serdesai-agents -p llm-coding-tools-serdesai
 
 use llm_coding_tools_agents::{AgentCatalog, AgentLoader, AgentRuntimeBuilder};
-use llm_coding_tools_core::models::{
-    Modality, ModelCatalog, ModelInfo, ProviderIdx, ProviderInfo, ProviderModelSource,
-    ProviderSource, ProviderType,
-};
+use llm_coding_tools_models_dev::ModelsDevCatalog;
 use llm_coding_tools_serdesai::{AgentDefaults, AgentRuntimeExt};
 use std::path::PathBuf;
 
@@ -18,54 +18,35 @@ const AGENT_NAME: &str = "basic/file-reader";
 // Set your OpenAI API key here or via OPENAI_API_KEY environment variable.
 /// Fallback API key if env var is not set. Leave empty to require env var.
 const OPENAI_API_KEY: &str = "";
-const OPENAI_MODEL: &str = "hf:zai-org/GLM-4.7";
 const OPENAI_BASE_URL: &str = "https://api.synthetic.new/openai/v1";
-
-fn get_openai_api_key() -> String {
-    std::env::var("OPENAI_API_KEY").unwrap_or_else(|_| OPENAI_API_KEY.to_string())
-}
-
-fn build_model_catalog() -> ModelCatalog {
-    let providers = vec![ProviderSource::new(
-        "synthetic",
-        ProviderInfo {
-            api_url: OPENAI_BASE_URL.into(),
-            env_vars: vec!["OPENAI_API_KEY".into()],
-            api_type: ProviderType::OpenAiResponses,
-        },
-    )];
-    let info = ModelInfo {
-        modalities: Modality::TEXT,
-        max_input: 128_000,
-        max_output: 16_384,
-        temperature: Some(1.0),
-        top_p: Some(0.95),
-    };
-    let models: Vec<ProviderModelSource<'_>> = vec![ProviderModelSource::new(
-        ProviderIdx::new(0),
-        OPENAI_MODEL,
-        info,
-    )];
-    ModelCatalog::build(&providers, &models).expect("model catalog should build")
-}
+const MODEL_ID: &str = "synthetic/hf:zai-org/GLM-4.7";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let examples_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples");
     let readme_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("README.md");
 
-    // SAFETY: Setting API key before async runtime operations; single-threaded startup.
-    unsafe { std::env::set_var("OPENAI_API_KEY", get_openai_api_key()) };
+    // SAFETY: Setting env vars before async runtime operations; single-threaded startup.
+    // serdes-ai's OpenAI provider reads OPENAI_BASE_URL to override the default endpoint.
+    unsafe {
+        std::env::set_var("OPENAI_API_KEY", OPENAI_API_KEY);
+        std::env::set_var("OPENAI_BASE_URL", OPENAI_BASE_URL);
+    }
+
+    // Load model catalog from models.dev (online-first with local cache fallback)
+    let load_result = ModelsDevCatalog::load().await?;
+    println!(
+        "Loaded model catalog from models.dev (source: {:?})",
+        load_result.source
+    );
 
     let mut catalog = AgentCatalog::new();
     AgentLoader::new().add_directory(&mut catalog, &examples_root)?;
 
-    let model_catalog = build_model_catalog();
-
     let runtime = AgentRuntimeBuilder::new()
         .catalog(catalog)
         .defaults(AgentDefaults {
-            model: Some(format!("synthetic/{OPENAI_MODEL}").into()),
+            model: Some(MODEL_ID.into()),
             temperature: Some(0.2),
             top_p: Some(0.95),
         })
@@ -75,7 +56,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Loading named agent `{AGENT_NAME}` from {}",
         examples_root.display()
     );
-    let agent = runtime.build(AGENT_NAME, &model_catalog)?;
+    let agent = runtime.build(AGENT_NAME, &load_result.catalog)?;
     println!(
         "Built `{AGENT_NAME}` on demand with {} tools.",
         agent.tools().len()

--- a/src/llm-coding-tools-serdesai/examples/serdesai-agents.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-agents.rs
@@ -6,7 +6,8 @@
 //! The model catalog is loaded from models.dev, which provides up-to-date
 //! provider and model information from <https://models.dev/api.json>.
 //!
-//! Run: cargo run --example serdesai-agents -p llm-coding-tools-serdesai
+//! Run: Edit the API_KEY_NAME and API_KEY_VALUE constants below, then:
+//!      cargo run --example serdesai-agents -p llm-coding-tools-serdesai
 
 use llm_coding_tools_agents::{AgentCatalog, AgentLoader, AgentRuntimeBuilder};
 use llm_coding_tools_models_dev::ModelsDevCatalog;
@@ -15,19 +16,15 @@ use std::path::PathBuf;
 
 const AGENT_NAME: &str = "basic/file-reader";
 const MODEL_ID: &str = "synthetic/hf:zai-org/GLM-4.7";
-const PROVIDER_ENV_VAR: &str = "SYNTHETIC_API_KEY";
+const API_KEY_NAME: &str = "SYNTHETIC_API_KEY";
+const API_KEY_VALUE: &str = ""; // <-- Set your API key here
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    unsafe { std::env::set_var(API_KEY_NAME, API_KEY_VALUE) };
+
     let examples_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples");
     let readme_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("README.md");
-
-    if std::env::var(PROVIDER_ENV_VAR).map_or(true, |value| value.is_empty()) {
-        return Err(format!(
-            "set {PROVIDER_ENV_VAR} before running this example; the runtime resolves provider credentials from the models.dev catalog"
-        )
-        .into());
-    }
 
     // Load model catalog from models.dev (online-first with local cache fallback)
     let load_result = ModelsDevCatalog::load().await?;
@@ -41,11 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let runtime = AgentRuntimeBuilder::new()
         .catalog(catalog)
-        .defaults(AgentDefaults {
-            model: Some(MODEL_ID.into()),
-            temperature: Some(0.2),
-            top_p: Some(0.95),
-        })
+        .defaults(AgentDefaults::with_model(MODEL_ID))
         .build();
 
     println!(

--- a/src/llm-coding-tools-serdesai/examples/serdesai-agents.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-agents.rs
@@ -15,18 +15,23 @@ use std::path::PathBuf;
 
 const AGENT_NAME: &str = "basic/file-reader";
 
-// API key below has a zero spend limit; it cannot incur charges.
-// If this no longer works, find a free model to use on OpenRouter for testing.
-const OPENROUTER_API_KEY: &str = "";
-const OPENROUTER_MODEL: &str = "z-ai/glm-4.5-air:free";
+// Set your OpenAI API key here or via OPENAI_API_KEY environment variable.
+/// Fallback API key if env var is not set. Leave empty to require env var.
+const OPENAI_API_KEY: &str = "";
+const OPENAI_MODEL: &str = "hf:zai-org/GLM-4.7";
+const OPENAI_BASE_URL: &str = "https://api.synthetic.new/openai/v1";
+
+fn get_openai_api_key() -> String {
+    std::env::var("OPENAI_API_KEY").unwrap_or_else(|_| OPENAI_API_KEY.to_string())
+}
 
 fn build_model_catalog() -> ModelCatalog {
     let providers = vec![ProviderSource::new(
-        "openrouter",
+        "synthetic",
         ProviderInfo {
-            api_url: "https://openrouter.ai/api/v1".into(),
-            env_vars: vec!["OPENROUTER_API_KEY".into()],
-            api_type: ProviderType::OpenRouter,
+            api_url: OPENAI_BASE_URL.into(),
+            env_vars: vec!["OPENAI_API_KEY".into()],
+            api_type: ProviderType::OpenAiResponses,
         },
     )];
     let info = ModelInfo {
@@ -38,7 +43,7 @@ fn build_model_catalog() -> ModelCatalog {
     };
     let models: Vec<ProviderModelSource<'_>> = vec![ProviderModelSource::new(
         ProviderIdx::new(0),
-        OPENROUTER_MODEL,
+        OPENAI_MODEL,
         info,
     )];
     ModelCatalog::build(&providers, &models).expect("model catalog should build")
@@ -50,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let readme_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("README.md");
 
     // SAFETY: Setting API key before async runtime operations; single-threaded startup.
-    unsafe { std::env::set_var("OPENROUTER_API_KEY", OPENROUTER_API_KEY) };
+    unsafe { std::env::set_var("OPENAI_API_KEY", get_openai_api_key()) };
 
     let mut catalog = AgentCatalog::new();
     AgentLoader::new().add_directory(&mut catalog, &examples_root)?;
@@ -60,7 +65,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let runtime = AgentRuntimeBuilder::new()
         .catalog(catalog)
         .defaults(AgentDefaults {
-            model: Some(format!("openrouter/{OPENROUTER_MODEL}").into()),
+            model: Some(format!("synthetic/{OPENAI_MODEL}").into()),
             temperature: Some(0.2),
             top_p: Some(0.95),
         })

--- a/src/llm-coding-tools-serdesai/examples/serdesai-agents.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-agents.rs
@@ -14,23 +14,19 @@ use llm_coding_tools_serdesai::{AgentDefaults, AgentRuntimeExt};
 use std::path::PathBuf;
 
 const AGENT_NAME: &str = "basic/file-reader";
-
-// Set your OpenAI API key here or via OPENAI_API_KEY environment variable.
-/// Fallback API key if env var is not set. Leave empty to require env var.
-const OPENAI_API_KEY: &str = "";
-const OPENAI_BASE_URL: &str = "https://api.synthetic.new/openai/v1";
 const MODEL_ID: &str = "synthetic/hf:zai-org/GLM-4.7";
+const PROVIDER_ENV_VAR: &str = "SYNTHETIC_API_KEY";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let examples_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples");
     let readme_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("README.md");
 
-    // SAFETY: Setting env vars before async runtime operations; single-threaded startup.
-    // serdes-ai's OpenAI provider reads OPENAI_BASE_URL to override the default endpoint.
-    unsafe {
-        std::env::set_var("OPENAI_API_KEY", OPENAI_API_KEY);
-        std::env::set_var("OPENAI_BASE_URL", OPENAI_BASE_URL);
+    if std::env::var(PROVIDER_ENV_VAR).map_or(true, |value| value.is_empty()) {
+        return Err(format!(
+            "set {PROVIDER_ENV_VAR} before running this example; the runtime resolves provider credentials from the models.dev catalog"
+        )
+        .into());
     }
 
     // Load model catalog from models.dev (online-first with local cache fallback)

--- a/src/llm-coding-tools-serdesai/examples/serdesai-basic.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-basic.rs
@@ -12,8 +12,8 @@ use futures::StreamExt;
 use llm_coding_tools_serdesai::absolute::{GlobTool, GrepTool, ReadTool};
 use llm_coding_tools_serdesai::agent_ext::AgentBuilderExt;
 use llm_coding_tools_serdesai::{BashTool, SystemPromptBuilder, WebFetchTool, create_todo_tools};
-use serdes_ai::models::openai::OpenAIChatModel;
 use serdes_ai::prelude::*;
+use serdes_ai_models::OpenAIChatModel;
 use std::fmt::Write;
 
 // Set your OpenAI API key here or via OPENAI_API_KEY environment variable.

--- a/src/llm-coding-tools-serdesai/examples/serdesai-basic.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-basic.rs
@@ -12,14 +12,19 @@ use futures::StreamExt;
 use llm_coding_tools_serdesai::absolute::{GlobTool, GrepTool, ReadTool};
 use llm_coding_tools_serdesai::agent_ext::AgentBuilderExt;
 use llm_coding_tools_serdesai::{BashTool, SystemPromptBuilder, WebFetchTool, create_todo_tools};
-use serdes_ai::models::openrouter::OpenRouterModel;
+use serdes_ai::models::openai::OpenAIChatModel;
 use serdes_ai::prelude::*;
 use std::fmt::Write;
 
-// API key below has a zero spend limit; it cannot incur charges.
-// If this no longer works, find a free model to use on OpenRouter for testing.
-const OPENROUTER_API_KEY: &str = "";
-const OPENROUTER_MODEL: &str = "z-ai/glm-4.5-air:free";
+// Set your OpenAI API key here or via OPENAI_API_KEY environment variable.
+/// Fallback API key if env var is not set. Leave empty to require env var.
+const OPENAI_API_KEY: &str = "";
+const OPENAI_MODEL: &str = "hf:zai-org/GLM-4.7";
+const OPENAI_BASE_URL: &str = "https://api.synthetic.new/openai/v1";
+
+fn get_openai_api_key() -> String {
+    std::env::var("OPENAI_API_KEY").unwrap_or_else(|_| OPENAI_API_KEY.to_string())
+}
 
 #[tokio::main]
 async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
@@ -31,7 +36,8 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let (todo_read, todo_write, _state) = create_todo_tools();
 
     // === Build agent with tools - call .system_prompt() last ===
-    let model = OpenRouterModel::new(OPENROUTER_MODEL, OPENROUTER_API_KEY);
+    let model =
+        OpenAIChatModel::new(OPENAI_MODEL, get_openai_api_key()).with_base_url(OPENAI_BASE_URL);
     let agent = AgentBuilder::<(), String>::new(model)
         .instructions("Use tools to answer; call at least one tool before responding.")
         // File operations

--- a/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed.rs
@@ -14,8 +14,8 @@ use llm_coding_tools_serdesai::AllowedPathResolver;
 use llm_coding_tools_serdesai::SystemPromptBuilder;
 use llm_coding_tools_serdesai::agent_ext::AgentBuilderExt;
 use llm_coding_tools_serdesai::allowed::{EditTool, GlobTool, GrepTool, ReadTool, WriteTool};
-use serdes_ai::models::openai::OpenAIChatModel;
 use serdes_ai::prelude::*;
+use serdes_ai_models::OpenAIChatModel;
 use std::fmt::Write;
 
 // Set your OpenAI API key here or via OPENAI_API_KEY environment variable.

--- a/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed.rs
@@ -14,14 +14,19 @@ use llm_coding_tools_serdesai::AllowedPathResolver;
 use llm_coding_tools_serdesai::SystemPromptBuilder;
 use llm_coding_tools_serdesai::agent_ext::AgentBuilderExt;
 use llm_coding_tools_serdesai::allowed::{EditTool, GlobTool, GrepTool, ReadTool, WriteTool};
-use serdes_ai::models::openrouter::OpenRouterModel;
+use serdes_ai::models::openai::OpenAIChatModel;
 use serdes_ai::prelude::*;
 use std::fmt::Write;
 
-// API key below has a zero spend limit; it cannot incur charges.
-// If this no longer works, find a free model to use on OpenRouter for testing.
-const OPENROUTER_API_KEY: &str = "";
-const OPENROUTER_MODEL: &str = "z-ai/glm-4.5-air:free";
+// Set your OpenAI API key here or via OPENAI_API_KEY environment variable.
+/// Fallback API key if env var is not set. Leave empty to require env var.
+const OPENAI_API_KEY: &str = "";
+const OPENAI_MODEL: &str = "hf:zai-org/GLM-4.7";
+const OPENAI_BASE_URL: &str = "https://api.synthetic.new/openai/v1";
+
+fn get_openai_api_key() -> String {
+    std::env::var("OPENAI_API_KEY").unwrap_or_else(|_| OPENAI_API_KEY.to_string())
+}
 
 #[tokio::main]
 async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
@@ -55,7 +60,8 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .working_directory(std::env::current_dir()?.display().to_string())
         .allowed_paths(&resolver);
 
-    let model = OpenRouterModel::new(OPENROUTER_MODEL, OPENROUTER_API_KEY);
+    let model =
+        OpenAIChatModel::new(OPENAI_MODEL, get_openai_api_key()).with_base_url(OPENAI_BASE_URL);
     let agent = AgentBuilder::<(), String>::new(model)
         .instructions("Use tools to answer; call at least one tool before responding.")
         .tool(pb.track(read))

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
@@ -3,7 +3,8 @@
 //! Use [`AgentRuntimeExt::build`] to create a runnable agent by name.
 //! The builder resolves the model, filters tools by permissions, and sets up the system prompt.
 
-use super::model::resolve_model_config;
+use super::model::resolve_model;
+use super::provider_bridge::build_serdes_model;
 use crate::agent_ext::AgentBuilderExt;
 use crate::{
     BashTool, EditTool, GlobTool, GrepTool, ReadTool, SystemPromptBuilder, WebFetchTool, WriteTool,
@@ -15,6 +16,7 @@ use llm_coding_tools_agents::{
 use llm_coding_tools_core::models::ModelCatalog;
 use llm_coding_tools_core::permissions::Ruleset;
 use serdes_ai::{Agent, AgentBuilder};
+use serdes_ai_models::BoxedModel;
 
 /// SerdesAI-specific runtime extension methods.
 pub trait AgentRuntimeExt {
@@ -33,18 +35,21 @@ impl AgentRuntimeExt for AgentRuntime {
         model_catalog: &ModelCatalog,
     ) -> Result<Agent<(), String>, AgentBuildError> {
         let prepared = prepare_build(self, name, model_catalog)?;
-        let builder = AgentBuilder::<(), String>::from_config(prepared.model_config.clone())?;
+        let builder = AgentBuilder::<(), String>::from_arc(prepared.model.clone());
         Ok(finish_builder(builder, &prepared)?.build())
     }
 }
 
 /// Resolved build parameters ready for agent construction.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct PreparedBuild {
     /// Agent name for [`AgentBuilder::name`].
     agent_name: Box<str>,
-    /// Resolved `provider:model` specification.
-    model_config: serdes_ai::ModelConfig,
+    /// Concrete SerdesAI model.
+    model: BoxedModel,
+    /// Normalized SerdesAI `provider:model` specification for diagnostics.
+    #[cfg_attr(not(test), allow(dead_code))]
+    model_spec: Box<str>,
     /// Agent system prompt template.
     prompt: Box<str>,
     /// Sampling temperature, if specified at agent or defaults level.
@@ -65,10 +70,12 @@ fn prepare_build(
         .catalog()
         .by_name(name)
         .ok_or_else(|| AgentBuildError::UnknownAgent { name: name.into() })?;
-    let model_config = resolve_model_config(model_catalog, runtime.defaults(), agent)?;
+    let resolved = resolve_model(model_catalog, runtime.defaults(), agent)?;
+    let serdes_model = build_serdes_model(model_catalog, &resolved)?;
     Ok(PreparedBuild {
         agent_name: agent.name.clone(),
-        model_config,
+        model: serdes_model.model,
+        model_spec: serdes_model.spec,
         prompt: agent.prompt.clone(),
         temperature: agent
             .temperature
@@ -152,7 +159,7 @@ pub enum AgentBuildError {
     ModelResolution(#[from] ModelResolutionError),
     /// Initializing the SerdesAI model failed.
     #[error("failed to initialize model: {0}")]
-    ModelInit(#[from] serdes_ai::models::ModelError),
+    ModelInit(#[from] serdes_ai_models::ModelError),
 }
 
 #[cfg(test)]
@@ -172,6 +179,44 @@ mod tests {
     use serdes_ai::AgentBuilder;
     use serdes_ai_models::MockModel;
     use std::collections::HashSet;
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn new(updates: &[(&'static str, Option<&'static str>)]) -> Self {
+            let lock = ENV_LOCK.lock().expect("env lock should be available");
+            let mut saved = Vec::with_capacity(updates.len());
+            for (name, value) in updates {
+                saved.push((*name, std::env::var(name).ok()));
+                unsafe {
+                    match value {
+                        Some(value) => std::env::set_var(name, value),
+                        None => std::env::remove_var(name),
+                    }
+                }
+            }
+            Self { _lock: lock, saved }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in self.saved.drain(..).rev() {
+                unsafe {
+                    match value {
+                        Some(value) => std::env::set_var(name, value),
+                        None => std::env::remove_var(name),
+                    }
+                }
+            }
+        }
+    }
 
     /// Builds an agent using a mock model instead of a real one.
     fn build_with_mock(
@@ -254,18 +299,17 @@ mod tests {
             temperature: Some(1.0),
             top_p: Some(0.95),
         };
-        let models: Vec<ProviderModelSource<'_>> = [
-            ("openai/gpt-4.1-mini", info.clone()),
-            ("openai/gpt-4o", info),
-        ]
-        .into_iter()
-        .map(|(key, i)| ProviderModelSource::new(ProviderIdx::new(0), key, i))
-        .collect();
+        let models: Vec<ProviderModelSource<'_>> =
+            [("openai/gpt-4.1-mini", info), ("openai/gpt-4o", info)]
+                .into_iter()
+                .map(|(key, i)| ProviderModelSource::new(ProviderIdx::new(0), key, i))
+                .collect();
         ModelCatalog::build(&providers, &models).expect("catalog fixture should build")
     }
 
     #[test]
     fn build_filters_tools_by_permission() {
+        let _env = EnvGuard::new(&[("OPENROUTER_API_KEY", Some("openrouter-key"))]);
         let catalog = catalog();
 
         // Create runtime with two agents: one with allowed tools, one with none
@@ -301,6 +345,7 @@ mod tests {
 
     #[test]
     fn build_uses_agent_model_and_sampling_over_defaults() {
+        let _env = EnvGuard::new(&[("OPENROUTER_API_KEY", Some("openrouter-key"))]);
         let catalog = catalog();
 
         // Agent overrides model (gpt-4o) and sampling (0.4, 0.8) vs defaults (gpt-4.1-mini, 1.0, 0.95)
@@ -322,13 +367,14 @@ mod tests {
 
         // Agent-level settings win over defaults
         let prepared = prepare_build(&runtime, "planner", &catalog).expect("should succeed");
-        assert_eq!(prepared.model_config.spec, "openrouter:openai/gpt-4o");
+        assert_eq!(prepared.model_spec.as_ref(), "openrouter:openai/gpt-4o");
         assert!((prepared.temperature.unwrap() - 0.4).abs() < 1e-6);
         assert!((prepared.top_p.unwrap() - 0.8).abs() < 1e-6);
     }
 
     #[test]
     fn build_handles_catalog_edge_cases() {
+        let _env = EnvGuard::new(&[("OPENROUTER_API_KEY", Some("openrouter-key"))]);
         let catalog = catalog();
 
         // Unknown agent name returns clear error
@@ -339,7 +385,9 @@ mod tests {
                 top_p: None,
             })
             .build();
-        let err = prepare_build(&runtime, "missing", &catalog).expect_err("should fail");
+        let err = prepare_build(&runtime, "missing", &catalog)
+            .err()
+            .expect("should fail");
         assert!(matches!(err, AgentBuildError::UnknownAgent { name } if &*name == "missing"));
 
         // Duplicate agent names: catalog retains the last entry
@@ -365,7 +413,7 @@ mod tests {
             .defaults(AgentDefaults::default())
             .build();
         let prepared = prepare_build(&runtime, "dupe", &catalog).expect("should succeed");
-        assert_eq!(prepared.model_config.spec, "openrouter:openai/gpt-4o");
+        assert_eq!(prepared.model_spec.as_ref(), "openrouter:openai/gpt-4o");
         let agent = build_with_mock(&prepared, "dupe");
         assert_eq!(agent.tools().len(), 1);
         assert_eq!(agent.tools()[0].name(), tool_names::GLOB);

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
@@ -1,7 +1,9 @@
 //! Build SerdesAI agents from an [`AgentRuntime`] catalog.
 //!
-//! Use [`AgentRuntimeExt::build`] to create a runnable agent by name.
-//! The builder resolves the model, filters tools by permissions, and sets up the system prompt.
+//! Use [`AgentRuntimeExt::build`] for the default environment-backed path, or
+//! [`build_agent_with_credentials`] when you want to provide explicit credential
+//! overrides. The builder resolves the model, filters tools by permissions, and
+//! sets up the system prompt.
 
 use super::model::resolve_model;
 use super::provider_bridge::build_serdes_model;
@@ -13,8 +15,8 @@ use crate::{
 use llm_coding_tools_agents::{
     AgentRuntime, ModelResolutionError, RulesetExt, ToolCatalogEntry, ToolCatalogKind,
 };
-use llm_coding_tools_core::models::ModelCatalog;
 use llm_coding_tools_core::permissions::Ruleset;
+use llm_coding_tools_core::{CredentialLookup, CredentialResolver, models::ModelCatalog};
 use serdes_ai::{Agent, AgentBuilder};
 use serdes_ai_models::BoxedModel;
 
@@ -34,10 +36,32 @@ impl AgentRuntimeExt for AgentRuntime {
         name: &str,
         model_catalog: &ModelCatalog,
     ) -> Result<Agent<(), String>, AgentBuildError> {
-        let prepared = prepare_build(self, name, model_catalog)?;
+        let credentials = CredentialResolver::new();
+        let prepared = prepare_build(self, name, model_catalog, &credentials)?;
         let builder = AgentBuilder::<(), String>::from_arc(prepared.model.clone());
         Ok(finish_builder(builder, &prepared)?.build())
     }
+}
+
+/// Builds a runnable SerdesAI agent using the provided credential resolver.
+///
+/// This is useful when your application wants to provide config-file or test
+/// overrides while keeping the catalog-driven provider lookup flow.
+///
+/// # Errors
+///
+/// Returns [`AgentBuildError`] when the named agent is missing, model selection
+/// fails, the adapter cannot create one of the requested tools, or the model
+/// backend rejects the resolved credentials or provider settings.
+pub fn build_agent_with_credentials(
+    runtime: &AgentRuntime,
+    name: &str,
+    model_catalog: &ModelCatalog,
+    credentials: &impl CredentialLookup,
+) -> Result<Agent<(), String>, AgentBuildError> {
+    let prepared = prepare_build(runtime, name, model_catalog, credentials)?;
+    let builder = AgentBuilder::<(), String>::from_arc(prepared.model.clone());
+    Ok(finish_builder(builder, &prepared)?.build())
 }
 
 /// Resolved build parameters ready for agent construction.
@@ -65,13 +89,14 @@ fn prepare_build(
     runtime: &AgentRuntime,
     name: &str,
     model_catalog: &ModelCatalog,
+    credentials: &impl CredentialLookup,
 ) -> Result<PreparedBuild, AgentBuildError> {
     let agent = runtime
         .catalog()
         .by_name(name)
         .ok_or_else(|| AgentBuildError::UnknownAgent { name: name.into() })?;
     let resolved = resolve_model(model_catalog, runtime.defaults(), agent)?;
-    let serdes_model = build_serdes_model(model_catalog, &resolved)?;
+    let serdes_model = build_serdes_model(model_catalog, &resolved, credentials)?;
     Ok(PreparedBuild {
         agent_name: agent.name.clone(),
         model: serdes_model.model,
@@ -170,6 +195,7 @@ mod tests {
     use llm_coding_tools_agents::{
         AgentCatalog, AgentConfig, AgentDefaults, AgentMode, AgentRuntimeBuilder, PermissionRule,
     };
+    use llm_coding_tools_core::CredentialResolver;
     use llm_coding_tools_core::models::{
         Modality, ModelCatalog, ModelInfo, ProviderIdx, ProviderInfo, ProviderModelSource,
         ProviderSource, ProviderType,
@@ -179,44 +205,6 @@ mod tests {
     use serdes_ai::AgentBuilder;
     use serdes_ai_models::MockModel;
     use std::collections::HashSet;
-    use std::sync::{Mutex, MutexGuard};
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct EnvGuard {
-        _lock: MutexGuard<'static, ()>,
-        saved: Vec<(&'static str, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        fn new(updates: &[(&'static str, Option<&'static str>)]) -> Self {
-            let lock = ENV_LOCK.lock().expect("env lock should be available");
-            let mut saved = Vec::with_capacity(updates.len());
-            for (name, value) in updates {
-                saved.push((*name, std::env::var(name).ok()));
-                unsafe {
-                    match value {
-                        Some(value) => std::env::set_var(name, value),
-                        None => std::env::remove_var(name),
-                    }
-                }
-            }
-            Self { _lock: lock, saved }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (name, value) in self.saved.drain(..).rev() {
-                unsafe {
-                    match value {
-                        Some(value) => std::env::set_var(name, value),
-                        None => std::env::remove_var(name),
-                    }
-                }
-            }
-        }
-    }
 
     /// Builds an agent using a mock model instead of a real one.
     fn build_with_mock(
@@ -307,9 +295,15 @@ mod tests {
         ModelCatalog::build(&providers, &models).expect("catalog fixture should build")
     }
 
+    fn credentials() -> CredentialResolver<false> {
+        let mut credentials = CredentialResolver::without_env();
+        credentials.set_override("OPENROUTER_API_KEY", "openrouter-key");
+        credentials
+    }
+
     #[test]
     fn build_filters_tools_by_permission() {
-        let _env = EnvGuard::new(&[("OPENROUTER_API_KEY", Some("openrouter-key"))]);
+        let credentials = credentials();
         let catalog = catalog();
 
         // Create runtime with two agents: one with allowed tools, one with none
@@ -330,7 +324,8 @@ mod tests {
             .build();
 
         // Agent with permissions gets only the allowed tools
-        let prepared = prepare_build(&runtime, "with-tools", &catalog).expect("should succeed");
+        let prepared =
+            prepare_build(&runtime, "with-tools", &catalog, &credentials).expect("should succeed");
         let agent = build_with_mock(&prepared, "with-tools");
         let names: HashSet<&str> = agent.tools().iter().map(|t| t.name()).collect();
         assert!(names.contains(tool_names::READ));
@@ -338,14 +333,15 @@ mod tests {
         assert_eq!(names.len(), 2);
 
         // Agent with empty permissions gets no tools
-        let prepared = prepare_build(&runtime, "no-tools", &catalog).expect("should succeed");
+        let prepared =
+            prepare_build(&runtime, "no-tools", &catalog, &credentials).expect("should succeed");
         let agent = build_with_mock(&prepared, "no-tools");
         assert!(agent.tools().is_empty());
     }
 
     #[test]
     fn build_uses_agent_model_and_sampling_over_defaults() {
-        let _env = EnvGuard::new(&[("OPENROUTER_API_KEY", Some("openrouter-key"))]);
+        let credentials = credentials();
         let catalog = catalog();
 
         // Agent overrides model (gpt-4o) and sampling (0.4, 0.8) vs defaults (gpt-4.1-mini, 1.0, 0.95)
@@ -366,7 +362,8 @@ mod tests {
             .build();
 
         // Agent-level settings win over defaults
-        let prepared = prepare_build(&runtime, "planner", &catalog).expect("should succeed");
+        let prepared =
+            prepare_build(&runtime, "planner", &catalog, &credentials).expect("should succeed");
         assert_eq!(prepared.model_spec.as_ref(), "openrouter:openai/gpt-4o");
         assert!((prepared.temperature.unwrap() - 0.4).abs() < 1e-6);
         assert!((prepared.top_p.unwrap() - 0.8).abs() < 1e-6);
@@ -374,7 +371,7 @@ mod tests {
 
     #[test]
     fn build_handles_catalog_edge_cases() {
-        let _env = EnvGuard::new(&[("OPENROUTER_API_KEY", Some("openrouter-key"))]);
+        let credentials = credentials();
         let catalog = catalog();
 
         // Unknown agent name returns clear error
@@ -385,7 +382,7 @@ mod tests {
                 top_p: None,
             })
             .build();
-        let err = prepare_build(&runtime, "missing", &catalog)
+        let err = prepare_build(&runtime, "missing", &catalog, &credentials)
             .err()
             .expect("should fail");
         assert!(matches!(err, AgentBuildError::UnknownAgent { name } if &*name == "missing"));
@@ -412,7 +409,8 @@ mod tests {
             ]))
             .defaults(AgentDefaults::default())
             .build();
-        let prepared = prepare_build(&runtime, "dupe", &catalog).expect("should succeed");
+        let prepared =
+            prepare_build(&runtime, "dupe", &catalog, &credentials).expect("should succeed");
         assert_eq!(prepared.model_spec.as_ref(), "openrouter:openai/gpt-4o");
         let agent = build_with_mock(&prepared, "dupe");
         assert_eq!(agent.tools().len(), 1);

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
@@ -316,11 +316,7 @@ mod tests {
                 ),
                 agent("no-tools", IndexMap::new(), "prompt"),
             ]))
-            .defaults(AgentDefaults {
-                model: Some("openrouter/openai/gpt-4.1-mini".into()),
-                temperature: None,
-                top_p: None,
-            })
+            .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
             .build();
 
         // Agent with permissions gets only the allowed tools
@@ -376,11 +372,7 @@ mod tests {
 
         // Unknown agent name returns clear error
         let runtime = AgentRuntimeBuilder::new()
-            .defaults(AgentDefaults {
-                model: Some("openrouter/openai/gpt-4.1-mini".into()),
-                temperature: None,
-                top_p: None,
-            })
+            .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
             .build();
         let err = prepare_build(&runtime, "missing", &catalog, &credentials)
             .err()

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
@@ -1,0 +1,373 @@
+//! Build SerdesAI agents from an [`AgentRuntime`] catalog.
+//!
+//! Use [`AgentRuntimeExt::build`] to create a runnable agent by name.
+//! The builder resolves the model, filters tools by permissions, and sets up the system prompt.
+
+use super::model::resolve_model_config;
+use crate::agent_ext::AgentBuilderExt;
+use crate::{
+    BashTool, EditTool, GlobTool, GrepTool, ReadTool, SystemPromptBuilder, WebFetchTool, WriteTool,
+    create_todo_tools,
+};
+use llm_coding_tools_agents::{
+    AgentRuntime, ModelResolutionError, RulesetExt, ToolCatalogEntry, ToolCatalogKind,
+};
+use llm_coding_tools_core::models::ModelCatalog;
+use llm_coding_tools_core::permissions::Ruleset;
+use serdes_ai::{Agent, AgentBuilder};
+
+/// SerdesAI-specific runtime extension methods.
+pub trait AgentRuntimeExt {
+    /// Builds a runnable SerdesAI agent for the named catalog entry.
+    fn build(
+        &self,
+        name: &str,
+        model_catalog: &ModelCatalog,
+    ) -> Result<Agent<(), String>, AgentBuildError>;
+}
+
+impl AgentRuntimeExt for AgentRuntime {
+    fn build(
+        &self,
+        name: &str,
+        model_catalog: &ModelCatalog,
+    ) -> Result<Agent<(), String>, AgentBuildError> {
+        let prepared = prepare_build(self, name, model_catalog)?;
+        let builder = AgentBuilder::<(), String>::from_config(prepared.model_config.clone())?;
+        Ok(finish_builder(builder, &prepared)?.build())
+    }
+}
+
+/// Resolved build parameters ready for agent construction.
+#[derive(Debug, Clone)]
+struct PreparedBuild {
+    /// Agent name for [`AgentBuilder::name`].
+    agent_name: Box<str>,
+    /// Resolved `provider:model` specification.
+    model_config: serdes_ai::ModelConfig,
+    /// Agent system prompt template.
+    prompt: Box<str>,
+    /// Sampling temperature, if specified at agent or defaults level.
+    temperature: Option<f64>,
+    /// Top-p sampling parameter, if specified at agent or defaults level.
+    top_p: Option<f64>,
+    /// Permission-filtered tool entries to materialize.
+    tools: Vec<ToolCatalogEntry>,
+}
+
+/// Resolves model configuration and collects build parameters for an agent.
+fn prepare_build(
+    runtime: &AgentRuntime,
+    name: &str,
+    model_catalog: &ModelCatalog,
+) -> Result<PreparedBuild, AgentBuildError> {
+    let agent = runtime
+        .catalog()
+        .by_name(name)
+        .ok_or_else(|| AgentBuildError::UnknownAgent { name: name.into() })?;
+    let model_config = resolve_model_config(model_catalog, runtime.defaults(), agent)?;
+    Ok(PreparedBuild {
+        agent_name: agent.name.clone(),
+        model_config,
+        prompt: agent.prompt.clone(),
+        temperature: agent
+            .temperature
+            .or(runtime.defaults().temperature)
+            .map(f64::from),
+        top_p: agent.top_p.or(runtime.defaults().top_p).map(f64::from),
+        tools: Ruleset::from_permission_config(&agent.permission)
+            .filter_allowed_tools(runtime.tools()),
+    })
+}
+
+/// Configures an [`AgentBuilder`] with name, prompt, tools, and sampling parameters.
+///
+/// Returns [`AgentBuildError::UnsupportedToolKind`] if a tool kind cannot be materialized.
+fn finish_builder(
+    mut builder: AgentBuilder<(), String>,
+    prepared: &PreparedBuild,
+) -> Result<AgentBuilder<(), String>, AgentBuildError> {
+    let mut prompt_builder = SystemPromptBuilder::new().system_prompt(prepared.prompt.as_ref());
+    let (todo_read, todo_write, _todo_state) = create_todo_tools();
+
+    builder = builder.name(prepared.agent_name.as_ref());
+    if let Some(temperature) = prepared.temperature {
+        builder = builder.temperature(temperature);
+    }
+    if let Some(top_p) = prepared.top_p {
+        builder = builder.top_p(top_p);
+    }
+
+    for entry in &prepared.tools {
+        match entry.kind {
+            ToolCatalogKind::Read => {
+                builder = builder.tool(prompt_builder.track(ReadTool::<true>::new()))
+            }
+            ToolCatalogKind::Write => {
+                builder = builder.tool(prompt_builder.track(WriteTool::new()))
+            }
+            ToolCatalogKind::Edit => builder = builder.tool(prompt_builder.track(EditTool::new())),
+            ToolCatalogKind::Glob => builder = builder.tool(prompt_builder.track(GlobTool::new())),
+            ToolCatalogKind::Grep => {
+                builder = builder.tool(prompt_builder.track(GrepTool::<true>::new()))
+            }
+            ToolCatalogKind::Bash => builder = builder.tool(prompt_builder.track(BashTool::new())),
+            ToolCatalogKind::WebFetch => {
+                builder = builder.tool(prompt_builder.track(WebFetchTool::new()))
+            }
+            ToolCatalogKind::TodoRead => {
+                builder = builder.tool(prompt_builder.track(todo_read.clone()))
+            }
+            ToolCatalogKind::TodoWrite => {
+                builder = builder.tool(prompt_builder.track(todo_write.clone()))
+            }
+            _ => {
+                return Err(AgentBuildError::UnsupportedToolKind {
+                    name: entry.name.into(),
+                });
+            }
+        }
+    }
+
+    Ok(builder.system_prompt(prompt_builder.build()))
+}
+
+/// Error returned when a build cannot produce a SerdesAI agent.
+#[derive(Debug, thiserror::Error)]
+pub enum AgentBuildError {
+    /// The requested agent name was not found in the runtime catalog.
+    #[error("unknown agent `{name}`")]
+    UnknownAgent {
+        /// The missing agent name.
+        name: Box<str>,
+    },
+    /// The runtime contains a tool kind this adapter cannot materialize.
+    #[error("tool `{name}` is not supported")]
+    UnsupportedToolKind {
+        /// The unsupported tool name.
+        name: Box<str>,
+    },
+    /// Resolving or validating the model configuration failed.
+    #[error(transparent)]
+    ModelResolution(#[from] ModelResolutionError),
+    /// Initializing the SerdesAI model failed.
+    #[error("failed to initialize model: {0}")]
+    ModelInit(#[from] serdes_ai::models::ModelError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AgentBuildError, prepare_build};
+    use ahash::AHashMap;
+    use indexmap::IndexMap;
+    use llm_coding_tools_agents::{
+        AgentCatalog, AgentConfig, AgentDefaults, AgentMode, AgentRuntimeBuilder, PermissionRule,
+    };
+    use llm_coding_tools_core::models::{
+        Modality, ModelCatalog, ModelInfo, ProviderIdx, ProviderInfo, ProviderModelSource,
+        ProviderSource, ProviderType,
+    };
+    use llm_coding_tools_core::permissions::PermissionAction;
+    use llm_coding_tools_core::tool_names;
+    use serdes_ai::AgentBuilder;
+    use serdes_ai_models::MockModel;
+    use std::collections::HashSet;
+
+    /// Builds an agent using a mock model instead of a real one.
+    fn build_with_mock(
+        prepared: &super::PreparedBuild,
+        name: &str,
+    ) -> serdes_ai::Agent<(), String> {
+        super::finish_builder(
+            AgentBuilder::<(), String>::new(MockModel::new(name)),
+            prepared,
+        )
+        .expect("build should succeed")
+        .build()
+    }
+
+    /// Creates a minimal agent config with no model or sampling overrides.
+    fn agent(
+        name: &str,
+        permission: IndexMap<String, PermissionRule>,
+        prompt: &str,
+    ) -> AgentConfig {
+        AgentConfig {
+            name: name.into(),
+            mode: AgentMode::All,
+            description: format!("{name} description").into(),
+            model: None,
+            hidden: false,
+            temperature: None,
+            top_p: None,
+            permission,
+            options: AHashMap::new(),
+            prompt: prompt.into(),
+        }
+    }
+
+    /// Creates an agent config with explicit model and sampling settings.
+    fn agent_with_sampling(
+        name: &str,
+        model: &str,
+        temperature: Option<f32>,
+        top_p: Option<f32>,
+        permission: IndexMap<String, PermissionRule>,
+        prompt: &str,
+    ) -> AgentConfig {
+        AgentConfig {
+            name: name.into(),
+            mode: AgentMode::All,
+            description: format!("{name} description").into(),
+            model: Some(model.into()),
+            hidden: false,
+            temperature,
+            top_p,
+            permission,
+            options: AHashMap::new(),
+            prompt: prompt.into(),
+        }
+    }
+
+    /// Creates permission rules that allow the specified tools.
+    fn allow_tools(names: &[&str]) -> IndexMap<String, PermissionRule> {
+        names
+            .iter()
+            .map(|n| ((*n).into(), PermissionRule::Action(PermissionAction::Allow)))
+            .collect()
+    }
+
+    /// Creates a model catalog with two OpenRouter models for testing.
+    fn catalog() -> ModelCatalog {
+        let providers = vec![ProviderSource::new(
+            "openrouter",
+            ProviderInfo {
+                api_url: "https://openrouter.ai/api/v1".into(),
+                env_vars: vec!["OPENROUTER_API_KEY".into()],
+                api_type: ProviderType::OpenRouter,
+            },
+        )];
+        let info = ModelInfo {
+            modalities: Modality::TEXT,
+            max_input: 128_000,
+            max_output: 16_384,
+            temperature: Some(1.0),
+            top_p: Some(0.95),
+        };
+        let models: Vec<ProviderModelSource<'_>> = [
+            ("openai/gpt-4.1-mini", info.clone()),
+            ("openai/gpt-4o", info),
+        ]
+        .into_iter()
+        .map(|(key, i)| ProviderModelSource::new(ProviderIdx::new(0), key, i))
+        .collect();
+        ModelCatalog::build(&providers, &models).expect("catalog fixture should build")
+    }
+
+    #[test]
+    fn build_filters_tools_by_permission() {
+        let catalog = catalog();
+
+        // Create runtime with two agents: one with allowed tools, one with none
+        let runtime = AgentRuntimeBuilder::new()
+            .catalog(AgentCatalog::from_entries([
+                agent(
+                    "with-tools",
+                    allow_tools(&[tool_names::READ, tool_names::BASH]),
+                    "prompt",
+                ),
+                agent("no-tools", IndexMap::new(), "prompt"),
+            ]))
+            .defaults(AgentDefaults {
+                model: Some("openrouter/openai/gpt-4.1-mini".into()),
+                temperature: None,
+                top_p: None,
+            })
+            .build();
+
+        // Agent with permissions gets only the allowed tools
+        let prepared = prepare_build(&runtime, "with-tools", &catalog).expect("should succeed");
+        let agent = build_with_mock(&prepared, "with-tools");
+        let names: HashSet<&str> = agent.tools().iter().map(|t| t.name()).collect();
+        assert!(names.contains(tool_names::READ));
+        assert!(names.contains(tool_names::BASH));
+        assert_eq!(names.len(), 2);
+
+        // Agent with empty permissions gets no tools
+        let prepared = prepare_build(&runtime, "no-tools", &catalog).expect("should succeed");
+        let agent = build_with_mock(&prepared, "no-tools");
+        assert!(agent.tools().is_empty());
+    }
+
+    #[test]
+    fn build_uses_agent_model_and_sampling_over_defaults() {
+        let catalog = catalog();
+
+        // Agent overrides model (gpt-4o) and sampling (0.4, 0.8) vs defaults (gpt-4.1-mini, 1.0, 0.95)
+        let runtime = AgentRuntimeBuilder::new()
+            .catalog(AgentCatalog::from_entries([agent_with_sampling(
+                "planner",
+                "openrouter/openai/gpt-4o",
+                Some(0.4),
+                Some(0.8),
+                allow_tools(&[tool_names::READ]),
+                "prompt",
+            )]))
+            .defaults(AgentDefaults {
+                model: Some("openrouter/openai/gpt-4.1-mini".into()),
+                temperature: Some(1.0),
+                top_p: Some(0.95),
+            })
+            .build();
+
+        // Agent-level settings win over defaults
+        let prepared = prepare_build(&runtime, "planner", &catalog).expect("should succeed");
+        assert_eq!(prepared.model_config.spec, "openrouter:openai/gpt-4o");
+        assert!((prepared.temperature.unwrap() - 0.4).abs() < 1e-6);
+        assert!((prepared.top_p.unwrap() - 0.8).abs() < 1e-6);
+    }
+
+    #[test]
+    fn build_handles_catalog_edge_cases() {
+        let catalog = catalog();
+
+        // Unknown agent name returns clear error
+        let runtime = AgentRuntimeBuilder::new()
+            .defaults(AgentDefaults {
+                model: Some("openrouter/openai/gpt-4.1-mini".into()),
+                temperature: None,
+                top_p: None,
+            })
+            .build();
+        let err = prepare_build(&runtime, "missing", &catalog).expect_err("should fail");
+        assert!(matches!(err, AgentBuildError::UnknownAgent { name } if &*name == "missing"));
+
+        // Duplicate agent names: catalog retains the last entry
+        let runtime = AgentRuntimeBuilder::new()
+            .catalog(AgentCatalog::from_entries([
+                agent_with_sampling(
+                    "dupe",
+                    "openrouter/openai/gpt-4.1-mini",
+                    None,
+                    None,
+                    allow_tools(&[tool_names::READ]),
+                    "old",
+                ),
+                agent_with_sampling(
+                    "dupe",
+                    "openrouter/openai/gpt-4o",
+                    None,
+                    None,
+                    allow_tools(&[tool_names::GLOB]),
+                    "new",
+                ),
+            ]))
+            .defaults(AgentDefaults::default())
+            .build();
+        let prepared = prepare_build(&runtime, "dupe", &catalog).expect("should succeed");
+        assert_eq!(prepared.model_config.spec, "openrouter:openai/gpt-4o");
+        let agent = build_with_mock(&prepared, "dupe");
+        assert_eq!(agent.tools().len(), 1);
+        assert_eq!(agent.tools()[0].name(), tool_names::GLOB);
+    }
+}

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/mod.rs
@@ -1,0 +1,15 @@
+//! SerdesAI adapter for the generic agent runtime.
+//!
+//! The data-only runtime foundation lives in [`llm_coding_tools_agents`]. This
+//! module re-exports those generic types and adds SerdesAI-specific agent
+//! materialization through [`AgentRuntimeExt`], which accepts a caller-provided
+//! [`llm_coding_tools_core::models::ModelCatalog`].
+
+mod build;
+mod model;
+
+pub use build::{AgentBuildError, AgentRuntimeExt};
+pub use llm_coding_tools_agents::{
+    AgentDefaults, AgentRuntime, AgentRuntimeBuilder, ModelResolutionError, ResolvedModel,
+    ToolCatalogEntry, ToolCatalogKind, default_tools, resolve_model_with_catalog,
+};

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/mod.rs
@@ -2,14 +2,14 @@
 //!
 //! The data-only runtime foundation lives in [`llm_coding_tools_agents`]. This
 //! module re-exports those generic types and adds SerdesAI-specific agent
-//! materialization through [`AgentRuntimeExt`], which accepts a caller-provided
-//! [`llm_coding_tools_core::models::ModelCatalog`].
+//! building through [`AgentRuntimeExt`] and [`build_agent_with_credentials`],
+//! both of which accept a caller-provided [`llm_coding_tools_core::models::ModelCatalog`].
 
 mod build;
 mod model;
 mod provider_bridge;
 
-pub use build::{AgentBuildError, AgentRuntimeExt};
+pub use build::{AgentBuildError, AgentRuntimeExt, build_agent_with_credentials};
 pub use llm_coding_tools_agents::{
     AgentDefaults, AgentRuntime, AgentRuntimeBuilder, ModelResolutionError, ResolvedModel,
     ToolCatalogEntry, ToolCatalogKind, default_tools, resolve_model_with_catalog,

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/mod.rs
@@ -7,6 +7,7 @@
 
 mod build;
 mod model;
+mod provider_bridge;
 
 pub use build::{AgentBuildError, AgentRuntimeExt};
 pub use llm_coding_tools_agents::{

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/model.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/model.rs
@@ -1,0 +1,168 @@
+//! Resolve models for SerdesAI agents.
+//!
+//! Converts an agent's model selection into the `provider:model` format that SerdesAI expects.
+//! The model is validated against a provided catalog to ensure it exists.
+
+use llm_coding_tools_agents::{
+    resolve_model_with_catalog, AgentConfig, AgentDefaults, ModelResolutionError,
+};
+use llm_coding_tools_core::models::ModelCatalog;
+use serdes_ai::ModelConfig;
+
+/// Resolves the model for an agent and returns a SerdesAI-compatible config.
+///
+/// Returns an error if the model is missing, malformed, or not in the catalog.
+pub(super) fn resolve_model_config(
+    catalog: &ModelCatalog,
+    defaults: &AgentDefaults,
+    agent: &AgentConfig,
+) -> Result<ModelConfig, ModelResolutionError> {
+    let resolved = resolve_model_with_catalog(catalog, defaults, agent)?;
+    Ok(ModelConfig::new(format!(
+        "{}:{}",
+        resolved.provider(),
+        resolved.model()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_model_config;
+    use ahash::AHashMap;
+    use indexmap::IndexMap;
+    use llm_coding_tools_agents::{AgentConfig, AgentDefaults, AgentMode, ModelResolutionError};
+    use llm_coding_tools_core::models::{
+        Modality, ModelCatalog, ModelInfo, ProviderIdx, ProviderInfo, ProviderModelSource,
+        ProviderSource, ProviderType,
+    };
+
+    /// Creates a minimal agent config with an optional model override.
+    fn config_with_model(name: &str, model: Option<&str>) -> AgentConfig {
+        AgentConfig {
+            name: name.into(),
+            mode: AgentMode::All,
+            description: Default::default(),
+            model: model.map(Into::into),
+            hidden: false,
+            temperature: None,
+            top_p: None,
+            permission: IndexMap::new(),
+            options: AHashMap::new(),
+            prompt: Default::default(),
+        }
+    }
+
+    /// Creates a provider info struct for the catalog.
+    fn provider(api_url: &str, env_vars: &[&str], api_type: ProviderType) -> ProviderInfo {
+        ProviderInfo {
+            api_url: api_url.to_string(),
+            env_vars: env_vars.iter().map(|v| (*v).to_string()).collect(),
+            api_type,
+        }
+    }
+
+    /// Creates model info with standard text modalities.
+    fn model_info(max_input: u32, max_output: u32) -> ModelInfo {
+        ModelInfo {
+            modalities: Modality::TEXT,
+            max_input,
+            max_output,
+            temperature: Some(1.0),
+            top_p: Some(0.95),
+        }
+    }
+
+    /// Builds a catalog from provider and model definitions.
+    fn build_catalog(
+        providers: Vec<(&str, ProviderInfo)>,
+        provider_models: Vec<(&str, &str, ModelInfo)>,
+    ) -> ModelCatalog {
+        let provider_sources: Vec<ProviderSource> = providers
+            .into_iter()
+            .map(|(key, info)| ProviderSource::new(key, info))
+            .collect();
+        let provider_model_sources: Vec<ProviderModelSource<'_>> = provider_models
+            .into_iter()
+            .map(|(provider_key, model_key, info)| {
+                let provider_idx = ProviderIdx::new(
+                    provider_sources
+                        .iter()
+                        .position(|p| p.provider_key == provider_key)
+                        .expect("provider key should exist") as u16,
+                );
+                ProviderModelSource::new(provider_idx, model_key, info)
+            })
+            .collect();
+        ModelCatalog::build(&provider_sources, &provider_model_sources)
+            .expect("catalog fixture should build")
+    }
+
+    #[test]
+    fn resolve_model_config_converts_to_provider_colon_model_format() {
+        // Catalog with one provider and model
+        let catalog = build_catalog(
+            vec![(
+                "openrouter",
+                provider(
+                    "https://openrouter.ai/api/v1",
+                    &["OPENROUTER_API_KEY"],
+                    ProviderType::OpenRouter,
+                ),
+            )],
+            vec![(
+                "openrouter",
+                "openai/gpt-4.1-mini",
+                model_info(128_000, 16_384),
+            )],
+        );
+
+        // Agent uses default model, no override
+        let defaults = AgentDefaults {
+            model: Some("openrouter/openai/gpt-4.1-mini".into()),
+            temperature: None,
+            top_p: None,
+        };
+        let agent = config_with_model("planner", None);
+
+        // Should resolve to "provider:model" format
+        let model_config =
+            resolve_model_config(&catalog, &defaults, &agent).expect("should resolve");
+        assert_eq!(model_config.spec, "openrouter:openai/gpt-4.1-mini");
+    }
+
+    #[test]
+    fn resolve_model_config_preserves_model_resolution_errors() {
+        // Catalog with openai provider and gpt-4o model
+        let catalog = build_catalog(
+            vec![(
+                "openai",
+                provider(
+                    "https://api.openai.com/v1",
+                    &["OPENAI_API_KEY"],
+                    ProviderType::OpenAiResponses,
+                ),
+            )],
+            vec![("openai", "gpt-4o", model_info(128_000, 16_384))],
+        );
+
+        // Agent requests a model that doesn't exist in catalog
+        let defaults = AgentDefaults::default();
+        let agent = config_with_model("planner", Some("openai/gpt-4.1-mini"));
+
+        // Should return unknown model error with details
+        let err = resolve_model_config(&catalog, &defaults, &agent).expect_err("should fail");
+        match err {
+            ModelResolutionError::UnknownModel {
+                location,
+                provider,
+                model,
+                ..
+            } => {
+                assert_eq!(location, "agent override");
+                assert_eq!(&*provider, "openai");
+                assert_eq!(&*model, "gpt-4.1-mini");
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+}

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/model.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/model.rs
@@ -112,11 +112,7 @@ mod tests {
             )],
         );
         // Agent uses default model, no override
-        let defaults = AgentDefaults {
-            model: Some("openrouter/openai/gpt-4.1-mini".into()),
-            temperature: None,
-            top_p: None,
-        };
+        let defaults = AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini");
         let agent = config_with_model("planner", None);
 
         // Should resolve to provider and model components

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/model.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/model.rs
@@ -1,33 +1,29 @@
-//! Resolve models for SerdesAI agents.
+//! Resolve effective runtime model selections for SerdesAI agents.
 //!
-//! Converts an agent's model selection into the `provider:model` format that SerdesAI expects.
-//! The model is validated against a provided catalog to ensure it exists.
+//! Converts an agent's model selection into a validated `provider:model` format.
+//! The model is resolved against a provided catalog to ensure it exists and is
+//! properly configured.
 
 use llm_coding_tools_agents::{
-    resolve_model_with_catalog, AgentConfig, AgentDefaults, ModelResolutionError,
+    AgentConfig, AgentDefaults, ModelResolutionError, ResolvedModel, resolve_model_with_catalog,
 };
 use llm_coding_tools_core::models::ModelCatalog;
-use serdes_ai::ModelConfig;
 
-/// Resolves the model for an agent and returns a SerdesAI-compatible config.
+/// Resolves the effective runtime model for an agent and validates it against the catalog.
 ///
-/// Returns an error if the model is missing, malformed, or not in the catalog.
-pub(super) fn resolve_model_config(
+/// Returns an error if the model is missing, malformed, or not found in the catalog.
+#[inline]
+pub(super) fn resolve_model(
     catalog: &ModelCatalog,
     defaults: &AgentDefaults,
     agent: &AgentConfig,
-) -> Result<ModelConfig, ModelResolutionError> {
-    let resolved = resolve_model_with_catalog(catalog, defaults, agent)?;
-    Ok(ModelConfig::new(format!(
-        "{}:{}",
-        resolved.provider(),
-        resolved.model()
-    )))
+) -> Result<ResolvedModel, ModelResolutionError> {
+    resolve_model_with_catalog(catalog, defaults, agent)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_model_config;
+    use super::resolve_model;
     use ahash::AHashMap;
     use indexmap::IndexMap;
     use llm_coding_tools_agents::{AgentConfig, AgentDefaults, AgentMode, ModelResolutionError};
@@ -98,7 +94,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_model_config_converts_to_provider_colon_model_format() {
+    fn resolve_model_accepts_valid_provider_model_pairs() {
         // Catalog with one provider and model
         let catalog = build_catalog(
             vec![(
@@ -115,7 +111,6 @@ mod tests {
                 model_info(128_000, 16_384),
             )],
         );
-
         // Agent uses default model, no override
         let defaults = AgentDefaults {
             model: Some("openrouter/openai/gpt-4.1-mini".into()),
@@ -124,14 +119,14 @@ mod tests {
         };
         let agent = config_with_model("planner", None);
 
-        // Should resolve to "provider:model" format
-        let model_config =
-            resolve_model_config(&catalog, &defaults, &agent).expect("should resolve");
-        assert_eq!(model_config.spec, "openrouter:openai/gpt-4.1-mini");
+        // Should resolve to provider and model components
+        let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
+        assert_eq!(resolved.provider(), "openrouter");
+        assert_eq!(resolved.model(), "openai/gpt-4.1-mini");
     }
 
     #[test]
-    fn resolve_model_config_preserves_model_resolution_errors() {
+    fn resolve_model_preserves_model_resolution_errors() {
         // Catalog with openai provider and gpt-4o model
         let catalog = build_catalog(
             vec![(
@@ -148,9 +143,9 @@ mod tests {
         // Agent requests a model that doesn't exist in catalog
         let defaults = AgentDefaults::default();
         let agent = config_with_model("planner", Some("openai/gpt-4.1-mini"));
-
         // Should return unknown model error with details
-        let err = resolve_model_config(&catalog, &defaults, &agent).expect_err("should fail");
+        let err = resolve_model(&catalog, &defaults, &agent).expect_err("should fail");
+
         match err {
             ModelResolutionError::UnknownModel {
                 location,

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
@@ -31,7 +31,7 @@ impl ResolvedSerdesModel {
     {
         let mut spec = String::with_capacity(provider_name.len() + model_name.len() + 1);
         spec.push_str(provider_name);
-        spec.push_str(":");
+        spec.push(':');
         spec.push_str(model_name);
         Self {
             model: Arc::new(model),

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
@@ -442,7 +442,9 @@ fn build_google(
     #[cfg(not(any(feature = "google", feature = "gemini")))]
     {
         let _ = (provider_key, model_name, api_url, env_vars);
-        Err(feature_disabled_error("google or gemini", "google"))
+        Err(ModelError::configuration(
+            "provider `google` is not enabled in llm-coding-tools-serdesai; rebuild with `--features google` or `--features gemini`"
+        ))
     }
 }
 

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
@@ -445,7 +445,7 @@ fn build_google(
     {
         let _ = (provider_key, model_name, api_url, env_vars);
         Err(ModelError::configuration(
-            "provider `google` is not enabled in llm-coding-tools-serdesai; rebuild with `--features google` or `--features gemini`"
+            "provider `google` is not enabled in llm-coding-tools-serdesai; rebuild with `--features google` or `--features gemini`",
         ))
     }
 }

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
@@ -3,9 +3,12 @@
 #![cfg_attr(not(test), allow(dead_code))]
 
 use llm_coding_tools_agents::ResolvedModel;
-use llm_coding_tools_core::models::{ModelCatalog, ProviderType};
+use llm_coding_tools_core::{
+    CredentialLookup,
+    models::{ModelCatalog, ProviderType},
+};
 use serdes_ai_models::{BoxedModel, Model as SerdesModel, ModelError};
-use std::{env, sync::Arc};
+use std::sync::Arc;
 
 const COHERE_BASE_URL: &str = "https://api.cohere.ai/v2";
 const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
@@ -14,44 +17,15 @@ const OPENAI_COMPATIBLE_PROVIDER: &str = "openai";
 /// Concrete SerdesAI model prepared from catalog metadata.
 #[derive(Clone)]
 pub(super) struct ResolvedSerdesModel {
-    /// Internal constructor path used to build the SerdesAI model.
-    #[cfg(test)]
-    pub(super) flavor: SerdesModelFlavor,
     /// Concrete model instance ready for [`serdes_ai::AgentBuilder::from_arc`].
     pub(super) model: BoxedModel,
     /// Normalized `provider:model` debug spec used by tests and diagnostics.
     pub(super) spec: Box<str>,
 }
 
-/// Concrete SerdesAI constructor chosen for a provider mapping.
-#[cfg(test)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum SerdesModelFlavor {
-    OpenAiChat,
-    OpenAiResponses,
-    Anthropic,
-    Google,
-    Groq,
-    Mistral,
-    Ollama,
-    Bedrock,
-    Azure,
-    OpenRouter,
-    HuggingFace,
-    Cohere,
-    ChatGptOAuth,
-    ClaudeCodeOAuth,
-    Antigravity,
-}
-
 impl ResolvedSerdesModel {
     #[inline]
-    fn new<M>(
-        provider_name: &'static str,
-        model_name: &str,
-        #[cfg(test)] flavor: SerdesModelFlavor,
-        model: M,
-    ) -> Self
+    fn new<M>(provider_name: &'static str, model_name: &str, model: M) -> Self
     where
         M: SerdesModel + 'static,
     {
@@ -60,8 +34,6 @@ impl ResolvedSerdesModel {
         spec.push(':');
         spec.push_str(model_name);
         Self {
-            #[cfg(test)]
-            flavor,
             model: Arc::new(model),
             spec: spec.into_boxed_str(),
         }
@@ -72,6 +44,7 @@ impl ResolvedSerdesModel {
 pub(super) fn build_serdes_model(
     catalog: &ModelCatalog,
     resolved: &ResolvedModel,
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     let provider = catalog
         .lookup_provider(resolved.provider())
@@ -89,49 +62,111 @@ pub(super) fn build_serdes_model(
             "provider `{}` has no SerdesAI mapping because its catalog provider type is unknown",
             resolved.provider()
         ))),
-        ProviderType::OpenAiCompletions => {
-            build_openai_chat(resolved.provider(), resolved.model(), api_url, env_vars)
-        }
-        ProviderType::OpenAiResponses => {
-            build_openai_responses(resolved.provider(), resolved.model(), api_url, env_vars)
-        }
-        ProviderType::Anthropic => {
-            build_anthropic(resolved.provider(), resolved.model(), api_url, env_vars)
-        }
-        ProviderType::Google => {
-            build_google(resolved.provider(), resolved.model(), api_url, env_vars)
-        }
-        ProviderType::Groq => build_groq(resolved.provider(), resolved.model(), api_url, env_vars),
-        ProviderType::Mistral => {
-            build_mistral(resolved.provider(), resolved.model(), api_url, env_vars)
-        }
-        ProviderType::Ollama => {
-            build_ollama(resolved.provider(), resolved.model(), api_url, env_vars)
-        }
-        ProviderType::Bedrock => {
-            build_bedrock(resolved.provider(), resolved.model(), api_url, env_vars)
-        }
-        ProviderType::Azure => {
-            build_azure(resolved.provider(), resolved.model(), api_url, env_vars)
-        }
-        ProviderType::OpenRouter => {
-            build_openrouter(resolved.provider(), resolved.model(), api_url, env_vars)
-        }
-        ProviderType::HuggingFace => {
-            build_huggingface(resolved.provider(), resolved.model(), api_url, env_vars)
-        }
-        ProviderType::Cohere => {
-            build_cohere(resolved.provider(), resolved.model(), api_url, env_vars)
-        }
-        ProviderType::ChatGptOAuth => {
-            build_chatgpt_oauth(resolved.provider(), resolved.model(), api_url, env_vars)
-        }
-        ProviderType::ClaudeCodeOAuth => {
-            build_claude_code_oauth(resolved.provider(), resolved.model(), api_url, env_vars)
-        }
-        ProviderType::Antigravity => {
-            build_antigravity(resolved.provider(), resolved.model(), api_url, env_vars)
-        }
+        ProviderType::OpenAiCompletions => build_openai_chat(
+            resolved.provider(),
+            resolved.model(),
+            api_url,
+            env_vars,
+            credentials,
+        ),
+        ProviderType::OpenAiResponses => build_openai_responses(
+            resolved.provider(),
+            resolved.model(),
+            api_url,
+            env_vars,
+            credentials,
+        ),
+        ProviderType::Anthropic => build_anthropic(
+            resolved.provider(),
+            resolved.model(),
+            api_url,
+            env_vars,
+            credentials,
+        ),
+        ProviderType::Google => build_google(
+            resolved.provider(),
+            resolved.model(),
+            api_url,
+            env_vars,
+            credentials,
+        ),
+        ProviderType::Groq => build_groq(
+            resolved.provider(),
+            resolved.model(),
+            api_url,
+            env_vars,
+            credentials,
+        ),
+        ProviderType::Mistral => build_mistral(
+            resolved.provider(),
+            resolved.model(),
+            api_url,
+            env_vars,
+            credentials,
+        ),
+        ProviderType::Ollama => build_ollama(
+            resolved.provider(),
+            resolved.model(),
+            api_url,
+            env_vars,
+            credentials,
+        ),
+        ProviderType::Bedrock => build_bedrock(
+            resolved.provider(),
+            resolved.model(),
+            api_url,
+            env_vars,
+            credentials,
+        ),
+        ProviderType::Azure => build_azure(
+            resolved.provider(),
+            resolved.model(),
+            api_url,
+            env_vars,
+            credentials,
+        ),
+        ProviderType::OpenRouter => build_openrouter(
+            resolved.provider(),
+            resolved.model(),
+            api_url,
+            env_vars,
+            credentials,
+        ),
+        ProviderType::HuggingFace => build_huggingface(
+            resolved.provider(),
+            resolved.model(),
+            api_url,
+            env_vars,
+            credentials,
+        ),
+        ProviderType::Cohere => build_cohere(
+            resolved.provider(),
+            resolved.model(),
+            api_url,
+            env_vars,
+            credentials,
+        ),
+        ProviderType::ChatGptOAuth => build_chatgpt_oauth(
+            resolved.provider(),
+            resolved.model(),
+            api_url,
+            env_vars,
+            credentials,
+        ),
+        ProviderType::ClaudeCodeOAuth => build_claude_code_oauth(
+            resolved.provider(),
+            resolved.model(),
+            api_url,
+            env_vars,
+            credentials,
+        ),
+        ProviderType::Antigravity => build_antigravity(
+            resolved.provider(),
+            resolved.model(),
+            api_url,
+            env_vars,
+            credentials,
+        ),
     }
 }
 
@@ -172,7 +207,11 @@ fn is_project_id_env_var(env_var: &str) -> bool {
     env_var.ends_with("_PROJECT_ID")
 }
 
-fn first_matching_env_value<P>(env_vars: &[&str], mut predicate: P) -> Option<String>
+fn first_matching_env_value<P>(
+    credentials: &impl CredentialLookup,
+    env_vars: &[&str],
+    mut predicate: P,
+) -> Option<String>
 where
     P: FnMut(&str) -> bool,
 {
@@ -180,7 +219,7 @@ where
         if !predicate(env_var) {
             return None;
         }
-        env::var(env_var).ok().filter(|value| !value.is_empty())
+        credentials.resolve(env_var)
     })
 }
 
@@ -206,6 +245,7 @@ where
 }
 
 fn require_env_value<P>(
+    credentials: &impl CredentialLookup,
     provider_key: &str,
     provider_name: &str,
     env_vars: &[&str],
@@ -215,7 +255,7 @@ fn require_env_value<P>(
 where
     P: Copy + Fn(&str) -> bool,
 {
-    if let Some(value) = first_matching_env_value(env_vars, predicate) {
+    if let Some(value) = first_matching_env_value(credentials, env_vars, predicate) {
         return Ok(value);
     }
 
@@ -274,6 +314,7 @@ fn azure_endpoint_from_resource(resource_name: &str) -> String {
 }
 
 fn resolve_azure_endpoint(
+    credentials: &impl CredentialLookup,
     provider_key: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
@@ -282,7 +323,9 @@ fn resolve_azure_endpoint(
         return Ok(normalize_azure_endpoint(api_url));
     }
 
-    if let Some(resource_name) = first_matching_env_value(env_vars, is_resource_name_env_var) {
+    if let Some(resource_name) =
+        first_matching_env_value(credentials, env_vars, is_resource_name_env_var)
+    {
         return Ok(azure_endpoint_from_resource(&resource_name));
     }
 
@@ -297,10 +340,12 @@ fn build_openai_chat(
     model_name: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "openai")]
     {
         let api_key = require_env_value(
+            credentials,
             provider_key,
             OPENAI_COMPATIBLE_PROVIDER,
             env_vars,
@@ -314,8 +359,6 @@ fn build_openai_chat(
         Ok(ResolvedSerdesModel::new(
             OPENAI_COMPATIBLE_PROVIDER,
             model_name,
-            #[cfg(test)]
-            SerdesModelFlavor::OpenAiChat,
             model,
         ))
     }
@@ -331,10 +374,12 @@ fn build_openai_responses(
     model_name: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "openai")]
     {
         let api_key = require_env_value(
+            credentials,
             provider_key,
             OPENAI_COMPATIBLE_PROVIDER,
             env_vars,
@@ -348,8 +393,6 @@ fn build_openai_responses(
         Ok(ResolvedSerdesModel::new(
             OPENAI_COMPATIBLE_PROVIDER,
             model_name,
-            #[cfg(test)]
-            SerdesModelFlavor::OpenAiResponses,
             model,
         ))
     }
@@ -365,10 +408,12 @@ fn build_anthropic(
     model_name: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "anthropic")]
     {
         let api_key = require_env_value(
+            credentials,
             provider_key,
             "anthropic",
             env_vars,
@@ -379,13 +424,7 @@ fn build_anthropic(
         if let Some(api_url) = api_url {
             model = model.with_base_url(api_url);
         }
-        Ok(ResolvedSerdesModel::new(
-            "anthropic",
-            model_name,
-            #[cfg(test)]
-            SerdesModelFlavor::Anthropic,
-            model,
-        ))
+        Ok(ResolvedSerdesModel::new("anthropic", model_name, model))
     }
     #[cfg(not(feature = "anthropic"))]
     {
@@ -399,10 +438,12 @@ fn build_google(
     model_name: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(any(feature = "google", feature = "gemini"))]
     {
         let api_key = require_env_value(
+            credentials,
             provider_key,
             "google",
             env_vars,
@@ -413,13 +454,7 @@ fn build_google(
         if let Some(api_url) = api_url {
             model = model.with_base_url(api_url);
         }
-        Ok(ResolvedSerdesModel::new(
-            "google",
-            model_name,
-            #[cfg(test)]
-            SerdesModelFlavor::Google,
-            model,
-        ))
+        Ok(ResolvedSerdesModel::new("google", model_name, model))
     }
     #[cfg(not(any(feature = "google", feature = "gemini")))]
     {
@@ -433,6 +468,7 @@ fn build_groq(
     model_name: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "groq")]
     {
@@ -443,6 +479,7 @@ fn build_groq(
             serdes_ai_models::GroqModel::BASE_URL,
         )?;
         let api_key = require_env_value(
+            credentials,
             provider_key,
             "groq",
             env_vars,
@@ -452,8 +489,6 @@ fn build_groq(
         Ok(ResolvedSerdesModel::new(
             "groq",
             model_name,
-            #[cfg(test)]
-            SerdesModelFlavor::Groq,
             serdes_ai_models::GroqModel::new(model_name, api_key),
         ))
     }
@@ -469,10 +504,12 @@ fn build_mistral(
     model_name: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "mistral")]
     {
         let api_key = require_env_value(
+            credentials,
             provider_key,
             "mistral",
             env_vars,
@@ -483,13 +520,7 @@ fn build_mistral(
         if let Some(api_url) = api_url {
             model = model.with_base_url(api_url);
         }
-        Ok(ResolvedSerdesModel::new(
-            "mistral",
-            model_name,
-            #[cfg(test)]
-            SerdesModelFlavor::Mistral,
-            model,
-        ))
+        Ok(ResolvedSerdesModel::new("mistral", model_name, model))
     }
     #[cfg(not(feature = "mistral"))]
     {
@@ -503,49 +534,49 @@ fn build_ollama(
     model_name: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "ollama")]
     {
-        let _ = (provider_key, env_vars);
+        let _ = (provider_key, env_vars, credentials);
         let mut model = serdes_ai_models::OllamaModel::new(model_name);
         if let Some(api_url) = api_url {
             model = model.with_base_url(api_url);
         }
-        Ok(ResolvedSerdesModel::new(
-            "ollama",
-            model_name,
-            #[cfg(test)]
-            SerdesModelFlavor::Ollama,
-            model,
-        ))
+        Ok(ResolvedSerdesModel::new("ollama", model_name, model))
     }
     #[cfg(not(feature = "ollama"))]
     {
-        let _ = (provider_key, model_name, api_url, env_vars);
+        let _ = (provider_key, model_name, api_url, env_vars, credentials);
         Err(feature_disabled_error("ollama", "ollama"))
     }
 }
 
+/// Build a Bedrock model.
+///
+/// Unlike other providers, Bedrock does not accept credentials as parameters. The AWS SDK
+/// reads them directly from environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+/// AWS_REGION) or from the standard AWS credential chain (instance profiles, credential files, etc.).
+/// The `credentials` parameter is therefore unused but kept for API consistency with other builders.
 fn build_bedrock(
     provider_key: &str,
     model_name: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "bedrock")]
     {
-        let _ = (provider_key, api_url, env_vars);
+        let _ = (provider_key, api_url, env_vars, credentials);
         Ok(ResolvedSerdesModel::new(
             "bedrock",
             model_name,
-            #[cfg(test)]
-            SerdesModelFlavor::Bedrock,
             serdes_ai_models::BedrockModel::new(model_name)?,
         ))
     }
     #[cfg(not(feature = "bedrock"))]
     {
-        let _ = (provider_key, model_name, api_url, env_vars);
+        let _ = (provider_key, model_name, api_url, env_vars, credentials);
         Err(feature_disabled_error("bedrock", "bedrock"))
     }
 }
@@ -555,11 +586,13 @@ fn build_azure(
     model_name: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "azure")]
     {
-        let endpoint = resolve_azure_endpoint(provider_key, api_url, env_vars)?;
+        let endpoint = resolve_azure_endpoint(credentials, provider_key, api_url, env_vars)?;
         let api_key = require_env_value(
+            credentials,
             provider_key,
             "azure",
             env_vars,
@@ -569,8 +602,6 @@ fn build_azure(
         Ok(ResolvedSerdesModel::new(
             "azure",
             model_name,
-            #[cfg(test)]
-            SerdesModelFlavor::Azure,
             serdes_ai_models::AzureOpenAIModel::new(
                 model_name,
                 endpoint,
@@ -591,11 +622,13 @@ fn build_openrouter(
     model_name: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "openrouter")]
     {
         validate_fixed_api_url(provider_key, "openrouter", api_url, OPENROUTER_BASE_URL)?;
         let api_key = require_env_value(
+            credentials,
             provider_key,
             "openrouter",
             env_vars,
@@ -605,8 +638,6 @@ fn build_openrouter(
         Ok(ResolvedSerdesModel::new(
             "openrouter",
             model_name,
-            #[cfg(test)]
-            SerdesModelFlavor::OpenRouter,
             serdes_ai_models::OpenRouterModel::new(model_name, api_key),
         ))
     }
@@ -622,10 +653,12 @@ fn build_huggingface(
     model_name: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "huggingface")]
     {
         let token = require_env_value(
+            credentials,
             provider_key,
             "huggingface",
             env_vars,
@@ -636,13 +669,7 @@ fn build_huggingface(
         if let Some(api_url) = api_url {
             model = model.with_endpoint(api_url);
         }
-        Ok(ResolvedSerdesModel::new(
-            "huggingface",
-            model_name,
-            #[cfg(test)]
-            SerdesModelFlavor::HuggingFace,
-            model,
-        ))
+        Ok(ResolvedSerdesModel::new("huggingface", model_name, model))
     }
     #[cfg(not(feature = "huggingface"))]
     {
@@ -656,11 +683,13 @@ fn build_cohere(
     model_name: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "cohere")]
     {
         validate_fixed_api_url(provider_key, "cohere", api_url, COHERE_BASE_URL)?;
         let api_key = require_env_value(
+            credentials,
             provider_key,
             "cohere",
             env_vars,
@@ -670,8 +699,6 @@ fn build_cohere(
         Ok(ResolvedSerdesModel::new(
             "cohere",
             model_name,
-            #[cfg(test)]
-            SerdesModelFlavor::Cohere,
             serdes_ai_models::CohereModel::new(model_name, api_key),
         ))
     }
@@ -687,10 +714,12 @@ fn build_chatgpt_oauth(
     model_name: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "chatgpt-oauth")]
     {
         let access_token = require_env_value(
+            credentials,
             provider_key,
             "chatgpt-oauth",
             env_vars,
@@ -704,16 +733,12 @@ fn build_chatgpt_oauth(
                 ..serdes_ai_models::chatgpt_oauth::ChatGptConfig::default()
             });
         }
-        if let Some(account_id) = first_matching_env_value(env_vars, is_account_id_env_var) {
+        if let Some(account_id) =
+            first_matching_env_value(credentials, env_vars, is_account_id_env_var)
+        {
             model = model.with_account_id(account_id);
         }
-        Ok(ResolvedSerdesModel::new(
-            "chatgpt-oauth",
-            model_name,
-            #[cfg(test)]
-            SerdesModelFlavor::ChatGptOAuth,
-            model,
-        ))
+        Ok(ResolvedSerdesModel::new("chatgpt-oauth", model_name, model))
     }
     #[cfg(not(feature = "chatgpt-oauth"))]
     {
@@ -727,10 +752,12 @@ fn build_claude_code_oauth(
     model_name: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "claude-code-oauth")]
     {
         let access_token = require_env_value(
+            credentials,
             provider_key,
             "claude-code-oauth",
             env_vars,
@@ -747,8 +774,6 @@ fn build_claude_code_oauth(
         Ok(ResolvedSerdesModel::new(
             "claude-code-oauth",
             model_name,
-            #[cfg(test)]
-            SerdesModelFlavor::ClaudeCodeOAuth,
             model,
         ))
     }
@@ -767,17 +792,19 @@ fn build_antigravity(
     model_name: &str,
     api_url: Option<&str>,
     env_vars: &[&str],
+    credentials: &impl CredentialLookup,
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "antigravity")]
     {
         let access_token = require_env_value(
+            credentials,
             provider_key,
             "antigravity",
             env_vars,
             "an access token",
             is_credential_env_var,
         )?;
-        let project_id = first_matching_env_value(env_vars, is_project_id_env_var)
+        let project_id = first_matching_env_value(credentials, env_vars, is_project_id_env_var)
             .unwrap_or_else(|| serdes_ai_models::antigravity::DEFAULT_PROJECT_ID.to_owned());
         let mut model =
             serdes_ai_models::AntigravityModel::new(model_name, access_token, project_id);
@@ -787,13 +814,7 @@ fn build_antigravity(
                 ..serdes_ai_models::antigravity::AntigravityConfig::default()
             });
         }
-        Ok(ResolvedSerdesModel::new(
-            "antigravity",
-            model_name,
-            #[cfg(test)]
-            SerdesModelFlavor::Antigravity,
-            model,
-        ))
+        Ok(ResolvedSerdesModel::new("antigravity", model_name, model))
     }
     #[cfg(not(feature = "antigravity"))]
     {

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
@@ -31,13 +31,119 @@ impl ResolvedSerdesModel {
     {
         let mut spec = String::with_capacity(provider_name.len() + model_name.len() + 1);
         spec.push_str(provider_name);
-        spec.push(':');
+        spec.push_str(":");
         spec.push_str(model_name);
         Self {
             model: Arc::new(model),
             spec: spec.into_boxed_str(),
         }
     }
+}
+
+/// Normalizes an API URL from the catalog by trimming whitespace and trailing slashes.
+///
+/// Returns `None` if the result is empty, allowing callers to treat missing/empty URLs
+/// uniformly as "use the provider's default endpoint".
+#[inline]
+fn normalized_api_url(api_url: &str) -> Option<&str> {
+    let trimmed = api_url.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+/// Checks if an environment variable name represents an authentication credential.
+///
+/// Providers list environment variable names in their catalog entry. This predicate
+/// identifies which ones contain secrets like API keys or tokens, used to extract
+/// credentials for model construction.
+#[inline]
+fn is_credential_env_var(env_var: &str) -> bool {
+    env_var.ends_with("_API_KEY")
+        || env_var.ends_with("_ACCESS_TOKEN")
+        || env_var.ends_with("_TOKEN")
+}
+
+/// Finds the first environment variable matching a predicate that has a non-empty value.
+///
+/// The catalog lists possible environment variable names for a provider. This function
+/// searches through them in order and returns the resolved value of the first one that
+/// both matches the predicate and is actually set.
+fn first_matching_env_value<P>(
+    credentials: &impl CredentialLookup,
+    env_vars: &[&str],
+    mut predicate: P,
+) -> Option<String>
+where
+    P: FnMut(&str) -> bool,
+{
+    env_vars.iter().copied().find_map(|env_var| {
+        if !predicate(env_var) {
+            return None;
+        }
+        credentials.resolve(env_var)
+    })
+}
+
+/// Formats a comma-separated list of environment variable names matching a predicate.
+///
+/// Used in error messages to tell users which environment variables they can set
+/// to provide a required value (credential, endpoint, etc.).
+fn matching_env_names<P>(env_vars: &[&str], mut predicate: P) -> String
+where
+    P: FnMut(&str) -> bool,
+{
+    let mut names = String::new();
+    for env_var in env_vars
+        .iter()
+        .copied()
+        .filter(|env_var| predicate(env_var))
+    {
+        if !names.is_empty() {
+            names.push_str(", ");
+        }
+        names.push_str(env_var);
+    }
+    if names.is_empty() {
+        names.push_str("<none listed in catalog>");
+    }
+    names
+}
+
+/// Requires an environment variable matching a predicate to have a value.
+///
+/// Returns the resolved value if found, otherwise returns a configuration error
+/// that lists the available environment variable names for user guidance.
+fn require_env_value<P>(
+    credentials: &impl CredentialLookup,
+    provider_key: &str,
+    provider_name: &str,
+    env_vars: &[&str],
+    kind: &str,
+    predicate: P,
+) -> Result<String, ModelError>
+where
+    P: Copy + Fn(&str) -> bool,
+{
+    if let Some(value) = first_matching_env_value(credentials, env_vars, predicate) {
+        return Ok(value);
+    }
+
+    Err(ModelError::configuration(format!(
+        "provider `{provider_key}` mapped to serdes `{provider_name}` requires {kind}; set one of: {}",
+        matching_env_names(env_vars, predicate)
+    )))
+}
+
+/// Creates an error for a provider whose feature flag is disabled at compile time.
+#[allow(dead_code)]
+#[inline]
+fn feature_disabled_error(feature: &str, provider_name: &str) -> ModelError {
+    ModelError::configuration(format!(
+        "provider `{provider_name}` is not enabled in llm-coding-tools-serdesai; rebuild with `--features {feature}`"
+    ))
 }
 
 /// Builds the concrete SerdesAI model for a validated runtime model selection.
@@ -170,170 +276,9 @@ pub(super) fn build_serdes_model(
     }
 }
 
-#[inline]
-fn normalized_api_url(api_url: &str) -> Option<&str> {
-    let trimmed = api_url.trim().trim_end_matches('/');
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed)
-    }
-}
-
-#[inline]
-fn is_same_url(lhs: &str, rhs: &str) -> bool {
-    lhs.trim_end_matches('/') == rhs.trim_end_matches('/')
-}
-
-#[inline]
-fn is_credential_env_var(env_var: &str) -> bool {
-    env_var.ends_with("_API_KEY")
-        || env_var.ends_with("_ACCESS_TOKEN")
-        || env_var.ends_with("_TOKEN")
-}
-
-#[inline]
-fn is_resource_name_env_var(env_var: &str) -> bool {
-    env_var.ends_with("_RESOURCE_NAME")
-}
-
-#[inline]
-fn is_account_id_env_var(env_var: &str) -> bool {
-    env_var.ends_with("_ACCOUNT_ID")
-}
-
-#[inline]
-fn is_project_id_env_var(env_var: &str) -> bool {
-    env_var.ends_with("_PROJECT_ID")
-}
-
-fn first_matching_env_value<P>(
-    credentials: &impl CredentialLookup,
-    env_vars: &[&str],
-    mut predicate: P,
-) -> Option<String>
-where
-    P: FnMut(&str) -> bool,
-{
-    env_vars.iter().copied().find_map(|env_var| {
-        if !predicate(env_var) {
-            return None;
-        }
-        credentials.resolve(env_var)
-    })
-}
-
-fn matching_env_names<P>(env_vars: &[&str], mut predicate: P) -> String
-where
-    P: FnMut(&str) -> bool,
-{
-    let mut names = String::new();
-    for env_var in env_vars
-        .iter()
-        .copied()
-        .filter(|env_var| predicate(env_var))
-    {
-        if !names.is_empty() {
-            names.push_str(", ");
-        }
-        names.push_str(env_var);
-    }
-    if names.is_empty() {
-        names.push_str("<none listed in catalog>");
-    }
-    names
-}
-
-fn require_env_value<P>(
-    credentials: &impl CredentialLookup,
-    provider_key: &str,
-    provider_name: &str,
-    env_vars: &[&str],
-    kind: &str,
-    predicate: P,
-) -> Result<String, ModelError>
-where
-    P: Copy + Fn(&str) -> bool,
-{
-    if let Some(value) = first_matching_env_value(credentials, env_vars, predicate) {
-        return Ok(value);
-    }
-
-    Err(ModelError::configuration(format!(
-        "provider `{provider_key}` mapped to serdes `{provider_name}` requires {kind}; set one of: {}",
-        matching_env_names(env_vars, predicate)
-    )))
-}
-
-#[allow(dead_code)]
-#[inline]
-fn feature_disabled_error(feature: &str, provider_name: &str) -> ModelError {
-    ModelError::configuration(format!(
-        "provider `{provider_name}` is not enabled in llm-coding-tools-serdesai; rebuild with `--features {feature}`"
-    ))
-}
-
-fn validate_fixed_api_url(
-    provider_key: &str,
-    provider_name: &str,
-    api_url: Option<&str>,
-    expected_url: &str,
-) -> Result<(), ModelError> {
-    if let Some(api_url) = api_url
-        && !is_same_url(api_url, expected_url)
-    {
-        return Err(ModelError::configuration(format!(
-            "provider `{provider_key}` mapped to serdes `{provider_name}` uses catalog api url `{api_url}`, but the SerdesAI `{provider_name}` model does not support overriding its built-in endpoint `{expected_url}`"
-        )));
-    }
-    Ok(())
-}
-
-fn normalize_azure_endpoint(endpoint: &str) -> String {
-    let trimmed = endpoint.trim().trim_end_matches('/');
-    if let Some(stripped) = trimmed.strip_suffix("/openai/v1") {
-        stripped.to_owned()
-    } else if let Some(stripped) = trimmed.strip_suffix("/openai") {
-        stripped.to_owned()
-    } else {
-        trimmed.to_owned()
-    }
-}
-
-fn azure_endpoint_from_resource(resource_name: &str) -> String {
-    let trimmed = resource_name.trim().trim_end_matches('/');
-    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
-        return normalize_azure_endpoint(trimmed);
-    }
-
-    let mut endpoint = String::with_capacity(trimmed.len() + 27);
-    endpoint.push_str("https://");
-    endpoint.push_str(trimmed);
-    endpoint.push_str(".openai.azure.com");
-    endpoint
-}
-
-fn resolve_azure_endpoint(
-    credentials: &impl CredentialLookup,
-    provider_key: &str,
-    api_url: Option<&str>,
-    env_vars: &[&str],
-) -> Result<String, ModelError> {
-    if let Some(api_url) = api_url {
-        return Ok(normalize_azure_endpoint(api_url));
-    }
-
-    if let Some(resource_name) =
-        first_matching_env_value(credentials, env_vars, is_resource_name_env_var)
-    {
-        return Ok(azure_endpoint_from_resource(&resource_name));
-    }
-
-    Err(ModelError::configuration(format!(
-        "provider `{provider_key}` mapped to serdes `azure` requires an Azure endpoint or resource name; set one of: {}",
-        matching_env_names(env_vars, is_resource_name_env_var)
-    )))
-}
+// =============================================================================
+// OpenAI (Chat and Responses)
+// =============================================================================
 
 fn build_openai_chat(
     provider_key: &str,
@@ -403,6 +348,10 @@ fn build_openai_responses(
     }
 }
 
+// =============================================================================
+// Anthropic
+// =============================================================================
+
 fn build_anthropic(
     provider_key: &str,
     model_name: &str,
@@ -432,6 +381,10 @@ fn build_anthropic(
         Err(feature_disabled_error("anthropic", "anthropic"))
     }
 }
+
+// =============================================================================
+// Google
+// =============================================================================
 
 fn build_google(
     provider_key: &str,
@@ -463,6 +416,40 @@ fn build_google(
     }
 }
 
+// =============================================================================
+// Groq (fixed endpoint - no URL override allowed)
+// =============================================================================
+
+/// Compares two URLs for equality, ignoring trailing slashes.
+///
+/// URLs often include or omit trailing slashes inconsistently, but represent the same
+/// endpoint. This normalizes both sides before comparison.
+#[inline]
+fn urls_equal_ignoring_slash(lhs: &str, rhs: &str) -> bool {
+    lhs.trim_end_matches('/') == rhs.trim_end_matches('/')
+}
+
+/// Validates that a provider with a fixed endpoint isn't configured with a different URL.
+///
+/// Some providers (Groq, Cohere, OpenRouter) have hardcoded base URLs in their model
+/// implementations and don't support custom endpoints. If the catalog specifies a URL
+/// that differs from the expected one, this returns a configuration error.
+fn validate_fixed_endpoint(
+    provider_key: &str,
+    provider_name: &str,
+    api_url: Option<&str>,
+    expected_url: &str,
+) -> Result<(), ModelError> {
+    if let Some(api_url) = api_url
+        && !urls_equal_ignoring_slash(api_url, expected_url)
+    {
+        return Err(ModelError::configuration(format!(
+            "provider `{provider_key}` mapped to serdes `{provider_name}` uses catalog api url `{api_url}`, but the SerdesAI `{provider_name}` model does not support overriding its built-in endpoint `{expected_url}`"
+        )));
+    }
+    Ok(())
+}
+
 fn build_groq(
     provider_key: &str,
     model_name: &str,
@@ -472,7 +459,7 @@ fn build_groq(
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "groq")]
     {
-        validate_fixed_api_url(
+        validate_fixed_endpoint(
             provider_key,
             "groq",
             api_url,
@@ -498,6 +485,10 @@ fn build_groq(
         Err(feature_disabled_error("groq", "groq"))
     }
 }
+
+// =============================================================================
+// Mistral
+// =============================================================================
 
 fn build_mistral(
     provider_key: &str,
@@ -529,6 +520,10 @@ fn build_mistral(
     }
 }
 
+// =============================================================================
+// Ollama
+// =============================================================================
+
 fn build_ollama(
     provider_key: &str,
     model_name: &str,
@@ -551,6 +546,10 @@ fn build_ollama(
         Err(feature_disabled_error("ollama", "ollama"))
     }
 }
+
+// =============================================================================
+// Bedrock
+// =============================================================================
 
 /// Build a Bedrock model.
 ///
@@ -579,6 +578,84 @@ fn build_bedrock(
         let _ = (provider_key, model_name, api_url, env_vars, credentials);
         Err(feature_disabled_error("bedrock", "bedrock"))
     }
+}
+
+// =============================================================================
+// Azure OpenAI
+// =============================================================================
+
+/// Checks if an environment variable name represents an Azure resource name.
+///
+/// Azure OpenAI can be identified by either a full endpoint URL or just the resource
+/// name (e.g., "my-resource" becomes "https://my-resource.openai.azure.com").
+/// This identifies catalog env vars that contain resource names rather than full URLs.
+#[inline]
+fn is_azure_resource_name_env_var(env_var: &str) -> bool {
+    env_var.ends_with("_RESOURCE_NAME")
+}
+
+/// Normalizes an Azure endpoint URL by removing common redundant path suffixes.
+///
+/// Users may copy endpoints from the Azure portal that include `/openai` or `/openai/v1`
+/// suffixes, but the Azure SDK constructs the full path internally as
+/// `{endpoint}/openai/deployments/{deployment}`. This function strips those suffixes
+/// to prevent double paths like `/openai/openai/deployments/...`.
+fn normalize_azure_endpoint(endpoint: &str) -> String {
+    let trimmed = endpoint.trim().trim_end_matches('/');
+    if let Some(stripped) = trimmed.strip_suffix("/openai/v1") {
+        stripped.to_owned()
+    } else if let Some(stripped) = trimmed.strip_suffix("/openai") {
+        stripped.to_owned()
+    } else {
+        trimmed.to_owned()
+    }
+}
+
+/// Constructs a full Azure endpoint URL from a resource name.
+///
+/// If the input is already a full URL (starts with http:// or https://), it's normalized.
+/// Otherwise, the resource name is converted to the standard Azure format:
+/// `https://{resource_name}.openai.azure.com`
+fn azure_endpoint_from_resource(resource_name: &str) -> String {
+    let trimmed = resource_name.trim().trim_end_matches('/');
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        return normalize_azure_endpoint(trimmed);
+    }
+
+    let mut endpoint = String::with_capacity(trimmed.len() + 27);
+    endpoint.push_str("https://");
+    endpoint.push_str(trimmed);
+    endpoint.push_str(".openai.azure.com");
+    endpoint
+}
+
+/// Resolves the Azure endpoint from catalog configuration or environment variables.
+///
+/// Priority:
+/// 1. Explicit `api_url` from catalog (normalized)
+/// 2. `*_RESOURCE_NAME` environment variable (converted to full URL)
+///
+/// Returns an error if neither is available.
+fn resolve_azure_endpoint(
+    credentials: &impl CredentialLookup,
+    provider_key: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<String, ModelError> {
+    if let Some(api_url) = api_url {
+        return Ok(normalize_azure_endpoint(api_url));
+    }
+
+    if let Some(resource_name) =
+        first_matching_env_value(credentials, env_vars, is_azure_resource_name_env_var)
+    {
+        return Ok(azure_endpoint_from_resource(&resource_name));
+    }
+
+    Err(ModelError::configuration(format!(
+        "provider `{provider_key}` mapped to serdes `azure` requires an Azure endpoint or resource name; set one of: {}",
+        matching_env_names(env_vars, is_azure_resource_name_env_var)
+    )))
 }
 
 fn build_azure(
@@ -617,6 +694,10 @@ fn build_azure(
     }
 }
 
+// =============================================================================
+// OpenRouter (fixed endpoint - no URL override allowed)
+// =============================================================================
+
 fn build_openrouter(
     provider_key: &str,
     model_name: &str,
@@ -626,7 +707,7 @@ fn build_openrouter(
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "openrouter")]
     {
-        validate_fixed_api_url(provider_key, "openrouter", api_url, OPENROUTER_BASE_URL)?;
+        validate_fixed_endpoint(provider_key, "openrouter", api_url, OPENROUTER_BASE_URL)?;
         let api_key = require_env_value(
             credentials,
             provider_key,
@@ -647,6 +728,10 @@ fn build_openrouter(
         Err(feature_disabled_error("openrouter", "openrouter"))
     }
 }
+
+// =============================================================================
+// HuggingFace
+// =============================================================================
 
 fn build_huggingface(
     provider_key: &str,
@@ -678,6 +763,10 @@ fn build_huggingface(
     }
 }
 
+// =============================================================================
+// Cohere (fixed endpoint - no URL override allowed)
+// =============================================================================
+
 fn build_cohere(
     provider_key: &str,
     model_name: &str,
@@ -687,7 +776,7 @@ fn build_cohere(
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "cohere")]
     {
-        validate_fixed_api_url(provider_key, "cohere", api_url, COHERE_BASE_URL)?;
+        validate_fixed_endpoint(provider_key, "cohere", api_url, COHERE_BASE_URL)?;
         let api_key = require_env_value(
             credentials,
             provider_key,
@@ -707,6 +796,19 @@ fn build_cohere(
         let _ = (provider_key, model_name, api_url, env_vars);
         Err(feature_disabled_error("cohere", "cohere"))
     }
+}
+
+// =============================================================================
+// ChatGPT OAuth
+// =============================================================================
+
+/// Checks if an environment variable name represents a ChatGPT OAuth account ID.
+///
+/// ChatGPT OAuth supports multiple accounts; this identifies env vars containing
+/// an account ID to associate requests with a specific account.
+#[inline]
+fn is_chatgpt_oauth_account_id_env_var(env_var: &str) -> bool {
+    env_var.ends_with("_ACCOUNT_ID")
 }
 
 fn build_chatgpt_oauth(
@@ -734,7 +836,7 @@ fn build_chatgpt_oauth(
             });
         }
         if let Some(account_id) =
-            first_matching_env_value(credentials, env_vars, is_account_id_env_var)
+            first_matching_env_value(credentials, env_vars, is_chatgpt_oauth_account_id_env_var)
         {
             model = model.with_account_id(account_id);
         }
@@ -746,6 +848,10 @@ fn build_chatgpt_oauth(
         Err(feature_disabled_error("chatgpt-oauth", "chatgpt-oauth"))
     }
 }
+
+// =============================================================================
+// Claude Code OAuth
+// =============================================================================
 
 fn build_claude_code_oauth(
     provider_key: &str,
@@ -787,6 +893,19 @@ fn build_claude_code_oauth(
     }
 }
 
+// =============================================================================
+// Antigravity
+// =============================================================================
+
+/// Checks if an environment variable name represents an Antigravity project ID.
+///
+/// Antigravity organizes resources into projects; this identifies env vars containing
+/// the project ID for scoping API requests. Falls back to a default if not provided.
+#[inline]
+fn is_antigravity_project_id_env_var(env_var: &str) -> bool {
+    env_var.ends_with("_PROJECT_ID")
+}
+
 fn build_antigravity(
     provider_key: &str,
     model_name: &str,
@@ -804,7 +923,7 @@ fn build_antigravity(
             "an access token",
             is_credential_env_var,
         )?;
-        let project_id = first_matching_env_value(credentials, env_vars, is_project_id_env_var)
+        let project_id = first_matching_env_value(credentials, env_vars, is_antigravity_project_id_env_var)
             .unwrap_or_else(|| serdes_ai_models::antigravity::DEFAULT_PROJECT_ID.to_owned());
         let mut model =
             serdes_ai_models::AntigravityModel::new(model_name, access_token, project_id);

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
@@ -13,6 +13,11 @@ use std::sync::Arc;
 const COHERE_BASE_URL: &str = "https://api.cohere.ai/v2";
 const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
 const OPENAI_COMPATIBLE_PROVIDER: &str = "openai";
+const AWS_ACCESS_KEY_ID_ENV_VAR: &str = "AWS_ACCESS_KEY_ID";
+const AWS_SECRET_ACCESS_KEY_ENV_VAR: &str = "AWS_SECRET_ACCESS_KEY";
+const AWS_SESSION_TOKEN_ENV_VAR: &str = "AWS_SESSION_TOKEN";
+const AWS_REGION_ENV_VAR: &str = "AWS_REGION";
+const AWS_DEFAULT_REGION_ENV_VAR: &str = "AWS_DEFAULT_REGION";
 
 /// Concrete SerdesAI model prepared from catalog metadata.
 #[derive(Clone)]
@@ -112,6 +117,14 @@ where
     names
 }
 
+/// Finds the first resolved value among explicit credential names.
+fn first_resolved_name(credentials: &impl CredentialLookup, names: &[&str]) -> Option<String> {
+    names
+        .iter()
+        .copied()
+        .find_map(|name| credentials.resolve(name))
+}
+
 /// Requires an environment variable matching a predicate to have a value.
 ///
 /// Returns the resolved value if found, otherwise returns a configuration error
@@ -134,6 +147,23 @@ where
     Err(ModelError::configuration(format!(
         "provider `{provider_key}` mapped to serdes `{provider_name}` requires {kind}; set one of: {}",
         matching_env_names(env_vars, predicate)
+    )))
+}
+
+/// Requires a specific named credential to have a value.
+fn require_named_value(
+    credentials: &impl CredentialLookup,
+    provider_key: &str,
+    provider_name: &str,
+    name: &str,
+    kind: &str,
+) -> Result<String, ModelError> {
+    if let Some(value) = credentials.resolve(name) {
+        return Ok(value);
+    }
+
+    Err(ModelError::configuration(format!(
+        "provider `{provider_key}` mapped to serdes `{provider_name}` requires {kind}; set `{name}`"
     )))
 }
 
@@ -553,10 +583,9 @@ fn build_ollama(
 
 /// Build a Bedrock model.
 ///
-/// Unlike other providers, Bedrock does not accept credentials as parameters. The AWS SDK
-/// reads them directly from environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
-/// AWS_REGION) or from the standard AWS credential chain (instance profiles, credential files, etc.).
-/// The `credentials` parameter is therefore unused but kept for API consistency with other builders.
+/// Bedrock resolves the standard AWS credential names through [`CredentialLookup`] and passes
+/// them into the SerdesAI model constructor. Region remains optional and falls back to the model
+/// default when neither `AWS_REGION` nor `AWS_DEFAULT_REGION` is provided.
 fn build_bedrock(
     provider_key: &str,
     model_name: &str,
@@ -566,12 +595,37 @@ fn build_bedrock(
 ) -> Result<ResolvedSerdesModel, ModelError> {
     #[cfg(feature = "bedrock")]
     {
-        let _ = (provider_key, api_url, env_vars, credentials);
-        Ok(ResolvedSerdesModel::new(
+        let _ = (api_url, env_vars);
+        let access_key_id = require_named_value(
+            credentials,
+            provider_key,
             "bedrock",
-            model_name,
-            serdes_ai_models::BedrockModel::new(model_name)?,
-        ))
+            AWS_ACCESS_KEY_ID_ENV_VAR,
+            "an AWS access key ID",
+        )?;
+        let secret_access_key = require_named_value(
+            credentials,
+            provider_key,
+            "bedrock",
+            AWS_SECRET_ACCESS_KEY_ENV_VAR,
+            "an AWS secret access key",
+        )?;
+        let mut aws_credentials =
+            serdes_ai_models::bedrock::AwsCredentials::new(access_key_id, secret_access_key);
+        if let Some(session_token) = credentials.resolve(AWS_SESSION_TOKEN_ENV_VAR) {
+            aws_credentials = aws_credentials.with_session_token(session_token);
+        }
+
+        let mut model =
+            serdes_ai_models::BedrockModel::with_credentials(model_name, aws_credentials);
+        if let Some(region) = first_resolved_name(
+            credentials,
+            &[AWS_REGION_ENV_VAR, AWS_DEFAULT_REGION_ENV_VAR],
+        ) {
+            model = model.with_region(region);
+        }
+
+        Ok(ResolvedSerdesModel::new("bedrock", model_name, model))
     }
     #[cfg(not(feature = "bedrock"))]
     {

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
@@ -923,8 +923,9 @@ fn build_antigravity(
             "an access token",
             is_credential_env_var,
         )?;
-        let project_id = first_matching_env_value(credentials, env_vars, is_antigravity_project_id_env_var)
-            .unwrap_or_else(|| serdes_ai_models::antigravity::DEFAULT_PROJECT_ID.to_owned());
+        let project_id =
+            first_matching_env_value(credentials, env_vars, is_antigravity_project_id_env_var)
+                .unwrap_or_else(|| serdes_ai_models::antigravity::DEFAULT_PROJECT_ID.to_owned());
         let mut model =
             serdes_ai_models::AntigravityModel::new(model_name, access_token, project_id);
         if let Some(api_url) = api_url {

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
@@ -96,11 +96,13 @@ where
 ///
 /// Used in error messages to tell users which environment variables they can set
 /// to provide a required value (credential, endpoint, etc.).
+///
+/// Preallocates 64 bytes, enough for ~3 typical env var names (e.g., `OPENROUTER_API_KEY`).
 fn matching_env_names<P>(env_vars: &[&str], mut predicate: P) -> String
 where
     P: FnMut(&str) -> bool,
 {
-    let mut names = String::new();
+    let mut names = String::with_capacity(64);
     for env_var in env_vars
         .iter()
         .copied()

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
@@ -587,7 +587,7 @@ fn build_bedrock(
 /// Checks if an environment variable name represents an Azure resource name.
 ///
 /// Azure OpenAI can be identified by either a full endpoint URL or just the resource
-/// name (e.g., "my-resource" becomes "https://my-resource.openai.azure.com").
+/// name (e.g., "my-resource" becomes `https://my-resource.openai.azure.com`).
 /// This identifies catalog env vars that contain resource names rather than full URLs.
 #[inline]
 fn is_azure_resource_name_env_var(env_var: &str) -> bool {

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/mod.rs
@@ -1,0 +1,806 @@
+//! Map catalog [`ProviderType`] values to concrete SerdesAI model constructors.
+
+#![cfg_attr(not(test), allow(dead_code))]
+
+use llm_coding_tools_agents::ResolvedModel;
+use llm_coding_tools_core::models::{ModelCatalog, ProviderType};
+use serdes_ai_models::{BoxedModel, Model as SerdesModel, ModelError};
+use std::{env, sync::Arc};
+
+const COHERE_BASE_URL: &str = "https://api.cohere.ai/v2";
+const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
+const OPENAI_COMPATIBLE_PROVIDER: &str = "openai";
+
+/// Concrete SerdesAI model prepared from catalog metadata.
+#[derive(Clone)]
+pub(super) struct ResolvedSerdesModel {
+    /// Internal constructor path used to build the SerdesAI model.
+    #[cfg(test)]
+    pub(super) flavor: SerdesModelFlavor,
+    /// Concrete model instance ready for [`serdes_ai::AgentBuilder::from_arc`].
+    pub(super) model: BoxedModel,
+    /// Normalized `provider:model` debug spec used by tests and diagnostics.
+    pub(super) spec: Box<str>,
+}
+
+/// Concrete SerdesAI constructor chosen for a provider mapping.
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SerdesModelFlavor {
+    OpenAiChat,
+    OpenAiResponses,
+    Anthropic,
+    Google,
+    Groq,
+    Mistral,
+    Ollama,
+    Bedrock,
+    Azure,
+    OpenRouter,
+    HuggingFace,
+    Cohere,
+    ChatGptOAuth,
+    ClaudeCodeOAuth,
+    Antigravity,
+}
+
+impl ResolvedSerdesModel {
+    #[inline]
+    fn new<M>(
+        provider_name: &'static str,
+        model_name: &str,
+        #[cfg(test)] flavor: SerdesModelFlavor,
+        model: M,
+    ) -> Self
+    where
+        M: SerdesModel + 'static,
+    {
+        let mut spec = String::with_capacity(provider_name.len() + model_name.len() + 1);
+        spec.push_str(provider_name);
+        spec.push(':');
+        spec.push_str(model_name);
+        Self {
+            #[cfg(test)]
+            flavor,
+            model: Arc::new(model),
+            spec: spec.into_boxed_str(),
+        }
+    }
+}
+
+/// Builds the concrete SerdesAI model for a validated runtime model selection.
+pub(super) fn build_serdes_model(
+    catalog: &ModelCatalog,
+    resolved: &ResolvedModel,
+) -> Result<ResolvedSerdesModel, ModelError> {
+    let provider = catalog
+        .lookup_provider(resolved.provider())
+        .ok_or_else(|| {
+            ModelError::configuration(format!(
+                "effective provider `{}` disappeared from the model catalog after validation",
+                resolved.provider()
+            ))
+        })?;
+    let api_url = normalized_api_url(provider.api_url);
+    let env_vars = provider.env_vars();
+
+    match provider.api_type {
+        ProviderType::Unknown => Err(ModelError::configuration(format!(
+            "provider `{}` has no SerdesAI mapping because its catalog provider type is unknown",
+            resolved.provider()
+        ))),
+        ProviderType::OpenAiCompletions => {
+            build_openai_chat(resolved.provider(), resolved.model(), api_url, env_vars)
+        }
+        ProviderType::OpenAiResponses => {
+            build_openai_responses(resolved.provider(), resolved.model(), api_url, env_vars)
+        }
+        ProviderType::Anthropic => {
+            build_anthropic(resolved.provider(), resolved.model(), api_url, env_vars)
+        }
+        ProviderType::Google => {
+            build_google(resolved.provider(), resolved.model(), api_url, env_vars)
+        }
+        ProviderType::Groq => build_groq(resolved.provider(), resolved.model(), api_url, env_vars),
+        ProviderType::Mistral => {
+            build_mistral(resolved.provider(), resolved.model(), api_url, env_vars)
+        }
+        ProviderType::Ollama => {
+            build_ollama(resolved.provider(), resolved.model(), api_url, env_vars)
+        }
+        ProviderType::Bedrock => {
+            build_bedrock(resolved.provider(), resolved.model(), api_url, env_vars)
+        }
+        ProviderType::Azure => {
+            build_azure(resolved.provider(), resolved.model(), api_url, env_vars)
+        }
+        ProviderType::OpenRouter => {
+            build_openrouter(resolved.provider(), resolved.model(), api_url, env_vars)
+        }
+        ProviderType::HuggingFace => {
+            build_huggingface(resolved.provider(), resolved.model(), api_url, env_vars)
+        }
+        ProviderType::Cohere => {
+            build_cohere(resolved.provider(), resolved.model(), api_url, env_vars)
+        }
+        ProviderType::ChatGptOAuth => {
+            build_chatgpt_oauth(resolved.provider(), resolved.model(), api_url, env_vars)
+        }
+        ProviderType::ClaudeCodeOAuth => {
+            build_claude_code_oauth(resolved.provider(), resolved.model(), api_url, env_vars)
+        }
+        ProviderType::Antigravity => {
+            build_antigravity(resolved.provider(), resolved.model(), api_url, env_vars)
+        }
+    }
+}
+
+#[inline]
+fn normalized_api_url(api_url: &str) -> Option<&str> {
+    let trimmed = api_url.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+#[inline]
+fn is_same_url(lhs: &str, rhs: &str) -> bool {
+    lhs.trim_end_matches('/') == rhs.trim_end_matches('/')
+}
+
+#[inline]
+fn is_credential_env_var(env_var: &str) -> bool {
+    env_var.ends_with("_API_KEY")
+        || env_var.ends_with("_ACCESS_TOKEN")
+        || env_var.ends_with("_TOKEN")
+}
+
+#[inline]
+fn is_resource_name_env_var(env_var: &str) -> bool {
+    env_var.ends_with("_RESOURCE_NAME")
+}
+
+#[inline]
+fn is_account_id_env_var(env_var: &str) -> bool {
+    env_var.ends_with("_ACCOUNT_ID")
+}
+
+#[inline]
+fn is_project_id_env_var(env_var: &str) -> bool {
+    env_var.ends_with("_PROJECT_ID")
+}
+
+fn first_matching_env_value<P>(env_vars: &[&str], mut predicate: P) -> Option<String>
+where
+    P: FnMut(&str) -> bool,
+{
+    env_vars.iter().copied().find_map(|env_var| {
+        if !predicate(env_var) {
+            return None;
+        }
+        env::var(env_var).ok().filter(|value| !value.is_empty())
+    })
+}
+
+fn matching_env_names<P>(env_vars: &[&str], mut predicate: P) -> String
+where
+    P: FnMut(&str) -> bool,
+{
+    let mut names = String::new();
+    for env_var in env_vars
+        .iter()
+        .copied()
+        .filter(|env_var| predicate(env_var))
+    {
+        if !names.is_empty() {
+            names.push_str(", ");
+        }
+        names.push_str(env_var);
+    }
+    if names.is_empty() {
+        names.push_str("<none listed in catalog>");
+    }
+    names
+}
+
+fn require_env_value<P>(
+    provider_key: &str,
+    provider_name: &str,
+    env_vars: &[&str],
+    kind: &str,
+    predicate: P,
+) -> Result<String, ModelError>
+where
+    P: Copy + Fn(&str) -> bool,
+{
+    if let Some(value) = first_matching_env_value(env_vars, predicate) {
+        return Ok(value);
+    }
+
+    Err(ModelError::configuration(format!(
+        "provider `{provider_key}` mapped to serdes `{provider_name}` requires {kind}; set one of: {}",
+        matching_env_names(env_vars, predicate)
+    )))
+}
+
+#[allow(dead_code)]
+#[inline]
+fn feature_disabled_error(feature: &str, provider_name: &str) -> ModelError {
+    ModelError::configuration(format!(
+        "provider `{provider_name}` is not enabled in llm-coding-tools-serdesai; rebuild with `--features {feature}`"
+    ))
+}
+
+fn validate_fixed_api_url(
+    provider_key: &str,
+    provider_name: &str,
+    api_url: Option<&str>,
+    expected_url: &str,
+) -> Result<(), ModelError> {
+    if let Some(api_url) = api_url
+        && !is_same_url(api_url, expected_url)
+    {
+        return Err(ModelError::configuration(format!(
+            "provider `{provider_key}` mapped to serdes `{provider_name}` uses catalog api url `{api_url}`, but the SerdesAI `{provider_name}` model does not support overriding its built-in endpoint `{expected_url}`"
+        )));
+    }
+    Ok(())
+}
+
+fn normalize_azure_endpoint(endpoint: &str) -> String {
+    let trimmed = endpoint.trim().trim_end_matches('/');
+    if let Some(stripped) = trimmed.strip_suffix("/openai/v1") {
+        stripped.to_owned()
+    } else if let Some(stripped) = trimmed.strip_suffix("/openai") {
+        stripped.to_owned()
+    } else {
+        trimmed.to_owned()
+    }
+}
+
+fn azure_endpoint_from_resource(resource_name: &str) -> String {
+    let trimmed = resource_name.trim().trim_end_matches('/');
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        return normalize_azure_endpoint(trimmed);
+    }
+
+    let mut endpoint = String::with_capacity(trimmed.len() + 27);
+    endpoint.push_str("https://");
+    endpoint.push_str(trimmed);
+    endpoint.push_str(".openai.azure.com");
+    endpoint
+}
+
+fn resolve_azure_endpoint(
+    provider_key: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<String, ModelError> {
+    if let Some(api_url) = api_url {
+        return Ok(normalize_azure_endpoint(api_url));
+    }
+
+    if let Some(resource_name) = first_matching_env_value(env_vars, is_resource_name_env_var) {
+        return Ok(azure_endpoint_from_resource(&resource_name));
+    }
+
+    Err(ModelError::configuration(format!(
+        "provider `{provider_key}` mapped to serdes `azure` requires an Azure endpoint or resource name; set one of: {}",
+        matching_env_names(env_vars, is_resource_name_env_var)
+    )))
+}
+
+fn build_openai_chat(
+    provider_key: &str,
+    model_name: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<ResolvedSerdesModel, ModelError> {
+    #[cfg(feature = "openai")]
+    {
+        let api_key = require_env_value(
+            provider_key,
+            OPENAI_COMPATIBLE_PROVIDER,
+            env_vars,
+            "a credential",
+            is_credential_env_var,
+        )?;
+        let mut model = serdes_ai_models::OpenAIChatModel::new(model_name, api_key);
+        if let Some(api_url) = api_url {
+            model = model.with_base_url(api_url);
+        }
+        Ok(ResolvedSerdesModel::new(
+            OPENAI_COMPATIBLE_PROVIDER,
+            model_name,
+            #[cfg(test)]
+            SerdesModelFlavor::OpenAiChat,
+            model,
+        ))
+    }
+    #[cfg(not(feature = "openai"))]
+    {
+        let _ = (provider_key, model_name, api_url, env_vars);
+        Err(feature_disabled_error("openai", OPENAI_COMPATIBLE_PROVIDER))
+    }
+}
+
+fn build_openai_responses(
+    provider_key: &str,
+    model_name: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<ResolvedSerdesModel, ModelError> {
+    #[cfg(feature = "openai")]
+    {
+        let api_key = require_env_value(
+            provider_key,
+            OPENAI_COMPATIBLE_PROVIDER,
+            env_vars,
+            "a credential",
+            is_credential_env_var,
+        )?;
+        let mut model = serdes_ai_models::OpenAIResponsesModel::new(model_name, api_key);
+        if let Some(api_url) = api_url {
+            model = model.with_base_url(api_url);
+        }
+        Ok(ResolvedSerdesModel::new(
+            OPENAI_COMPATIBLE_PROVIDER,
+            model_name,
+            #[cfg(test)]
+            SerdesModelFlavor::OpenAiResponses,
+            model,
+        ))
+    }
+    #[cfg(not(feature = "openai"))]
+    {
+        let _ = (provider_key, model_name, api_url, env_vars);
+        Err(feature_disabled_error("openai", OPENAI_COMPATIBLE_PROVIDER))
+    }
+}
+
+fn build_anthropic(
+    provider_key: &str,
+    model_name: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<ResolvedSerdesModel, ModelError> {
+    #[cfg(feature = "anthropic")]
+    {
+        let api_key = require_env_value(
+            provider_key,
+            "anthropic",
+            env_vars,
+            "an API key",
+            is_credential_env_var,
+        )?;
+        let mut model = serdes_ai_models::AnthropicModel::new(model_name, api_key);
+        if let Some(api_url) = api_url {
+            model = model.with_base_url(api_url);
+        }
+        Ok(ResolvedSerdesModel::new(
+            "anthropic",
+            model_name,
+            #[cfg(test)]
+            SerdesModelFlavor::Anthropic,
+            model,
+        ))
+    }
+    #[cfg(not(feature = "anthropic"))]
+    {
+        let _ = (provider_key, model_name, api_url, env_vars);
+        Err(feature_disabled_error("anthropic", "anthropic"))
+    }
+}
+
+fn build_google(
+    provider_key: &str,
+    model_name: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<ResolvedSerdesModel, ModelError> {
+    #[cfg(any(feature = "google", feature = "gemini"))]
+    {
+        let api_key = require_env_value(
+            provider_key,
+            "google",
+            env_vars,
+            "an API key",
+            is_credential_env_var,
+        )?;
+        let mut model = serdes_ai_models::google::GoogleModel::new(model_name, api_key);
+        if let Some(api_url) = api_url {
+            model = model.with_base_url(api_url);
+        }
+        Ok(ResolvedSerdesModel::new(
+            "google",
+            model_name,
+            #[cfg(test)]
+            SerdesModelFlavor::Google,
+            model,
+        ))
+    }
+    #[cfg(not(any(feature = "google", feature = "gemini")))]
+    {
+        let _ = (provider_key, model_name, api_url, env_vars);
+        Err(feature_disabled_error("google or gemini", "google"))
+    }
+}
+
+fn build_groq(
+    provider_key: &str,
+    model_name: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<ResolvedSerdesModel, ModelError> {
+    #[cfg(feature = "groq")]
+    {
+        validate_fixed_api_url(
+            provider_key,
+            "groq",
+            api_url,
+            serdes_ai_models::GroqModel::BASE_URL,
+        )?;
+        let api_key = require_env_value(
+            provider_key,
+            "groq",
+            env_vars,
+            "an API key",
+            is_credential_env_var,
+        )?;
+        Ok(ResolvedSerdesModel::new(
+            "groq",
+            model_name,
+            #[cfg(test)]
+            SerdesModelFlavor::Groq,
+            serdes_ai_models::GroqModel::new(model_name, api_key),
+        ))
+    }
+    #[cfg(not(feature = "groq"))]
+    {
+        let _ = (provider_key, model_name, api_url, env_vars);
+        Err(feature_disabled_error("groq", "groq"))
+    }
+}
+
+fn build_mistral(
+    provider_key: &str,
+    model_name: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<ResolvedSerdesModel, ModelError> {
+    #[cfg(feature = "mistral")]
+    {
+        let api_key = require_env_value(
+            provider_key,
+            "mistral",
+            env_vars,
+            "an API key",
+            is_credential_env_var,
+        )?;
+        let mut model = serdes_ai_models::MistralModel::new(model_name, api_key);
+        if let Some(api_url) = api_url {
+            model = model.with_base_url(api_url);
+        }
+        Ok(ResolvedSerdesModel::new(
+            "mistral",
+            model_name,
+            #[cfg(test)]
+            SerdesModelFlavor::Mistral,
+            model,
+        ))
+    }
+    #[cfg(not(feature = "mistral"))]
+    {
+        let _ = (provider_key, model_name, api_url, env_vars);
+        Err(feature_disabled_error("mistral", "mistral"))
+    }
+}
+
+fn build_ollama(
+    provider_key: &str,
+    model_name: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<ResolvedSerdesModel, ModelError> {
+    #[cfg(feature = "ollama")]
+    {
+        let _ = (provider_key, env_vars);
+        let mut model = serdes_ai_models::OllamaModel::new(model_name);
+        if let Some(api_url) = api_url {
+            model = model.with_base_url(api_url);
+        }
+        Ok(ResolvedSerdesModel::new(
+            "ollama",
+            model_name,
+            #[cfg(test)]
+            SerdesModelFlavor::Ollama,
+            model,
+        ))
+    }
+    #[cfg(not(feature = "ollama"))]
+    {
+        let _ = (provider_key, model_name, api_url, env_vars);
+        Err(feature_disabled_error("ollama", "ollama"))
+    }
+}
+
+fn build_bedrock(
+    provider_key: &str,
+    model_name: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<ResolvedSerdesModel, ModelError> {
+    #[cfg(feature = "bedrock")]
+    {
+        let _ = (provider_key, api_url, env_vars);
+        Ok(ResolvedSerdesModel::new(
+            "bedrock",
+            model_name,
+            #[cfg(test)]
+            SerdesModelFlavor::Bedrock,
+            serdes_ai_models::BedrockModel::new(model_name)?,
+        ))
+    }
+    #[cfg(not(feature = "bedrock"))]
+    {
+        let _ = (provider_key, model_name, api_url, env_vars);
+        Err(feature_disabled_error("bedrock", "bedrock"))
+    }
+}
+
+fn build_azure(
+    provider_key: &str,
+    model_name: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<ResolvedSerdesModel, ModelError> {
+    #[cfg(feature = "azure")]
+    {
+        let endpoint = resolve_azure_endpoint(provider_key, api_url, env_vars)?;
+        let api_key = require_env_value(
+            provider_key,
+            "azure",
+            env_vars,
+            "an API key",
+            is_credential_env_var,
+        )?;
+        Ok(ResolvedSerdesModel::new(
+            "azure",
+            model_name,
+            #[cfg(test)]
+            SerdesModelFlavor::Azure,
+            serdes_ai_models::AzureOpenAIModel::new(
+                model_name,
+                endpoint,
+                serdes_ai_models::AzureOpenAIModel::DEFAULT_API_VERSION,
+                api_key,
+            ),
+        ))
+    }
+    #[cfg(not(feature = "azure"))]
+    {
+        let _ = (provider_key, model_name, api_url, env_vars);
+        Err(feature_disabled_error("azure", "azure"))
+    }
+}
+
+fn build_openrouter(
+    provider_key: &str,
+    model_name: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<ResolvedSerdesModel, ModelError> {
+    #[cfg(feature = "openrouter")]
+    {
+        validate_fixed_api_url(provider_key, "openrouter", api_url, OPENROUTER_BASE_URL)?;
+        let api_key = require_env_value(
+            provider_key,
+            "openrouter",
+            env_vars,
+            "an API key",
+            is_credential_env_var,
+        )?;
+        Ok(ResolvedSerdesModel::new(
+            "openrouter",
+            model_name,
+            #[cfg(test)]
+            SerdesModelFlavor::OpenRouter,
+            serdes_ai_models::OpenRouterModel::new(model_name, api_key),
+        ))
+    }
+    #[cfg(not(feature = "openrouter"))]
+    {
+        let _ = (provider_key, model_name, api_url, env_vars);
+        Err(feature_disabled_error("openrouter", "openrouter"))
+    }
+}
+
+fn build_huggingface(
+    provider_key: &str,
+    model_name: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<ResolvedSerdesModel, ModelError> {
+    #[cfg(feature = "huggingface")]
+    {
+        let token = require_env_value(
+            provider_key,
+            "huggingface",
+            env_vars,
+            "a token",
+            is_credential_env_var,
+        )?;
+        let mut model = serdes_ai_models::HuggingFaceModel::new(model_name, token);
+        if let Some(api_url) = api_url {
+            model = model.with_endpoint(api_url);
+        }
+        Ok(ResolvedSerdesModel::new(
+            "huggingface",
+            model_name,
+            #[cfg(test)]
+            SerdesModelFlavor::HuggingFace,
+            model,
+        ))
+    }
+    #[cfg(not(feature = "huggingface"))]
+    {
+        let _ = (provider_key, model_name, api_url, env_vars);
+        Err(feature_disabled_error("huggingface", "huggingface"))
+    }
+}
+
+fn build_cohere(
+    provider_key: &str,
+    model_name: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<ResolvedSerdesModel, ModelError> {
+    #[cfg(feature = "cohere")]
+    {
+        validate_fixed_api_url(provider_key, "cohere", api_url, COHERE_BASE_URL)?;
+        let api_key = require_env_value(
+            provider_key,
+            "cohere",
+            env_vars,
+            "an API key",
+            is_credential_env_var,
+        )?;
+        Ok(ResolvedSerdesModel::new(
+            "cohere",
+            model_name,
+            #[cfg(test)]
+            SerdesModelFlavor::Cohere,
+            serdes_ai_models::CohereModel::new(model_name, api_key),
+        ))
+    }
+    #[cfg(not(feature = "cohere"))]
+    {
+        let _ = (provider_key, model_name, api_url, env_vars);
+        Err(feature_disabled_error("cohere", "cohere"))
+    }
+}
+
+fn build_chatgpt_oauth(
+    provider_key: &str,
+    model_name: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<ResolvedSerdesModel, ModelError> {
+    #[cfg(feature = "chatgpt-oauth")]
+    {
+        let access_token = require_env_value(
+            provider_key,
+            "chatgpt-oauth",
+            env_vars,
+            "an access token",
+            is_credential_env_var,
+        )?;
+        let mut model = serdes_ai_models::ChatGptOAuthModel::new(model_name, access_token);
+        if let Some(api_url) = api_url {
+            model = model.with_config(serdes_ai_models::chatgpt_oauth::ChatGptConfig {
+                api_base_url: api_url.to_owned(),
+                ..serdes_ai_models::chatgpt_oauth::ChatGptConfig::default()
+            });
+        }
+        if let Some(account_id) = first_matching_env_value(env_vars, is_account_id_env_var) {
+            model = model.with_account_id(account_id);
+        }
+        Ok(ResolvedSerdesModel::new(
+            "chatgpt-oauth",
+            model_name,
+            #[cfg(test)]
+            SerdesModelFlavor::ChatGptOAuth,
+            model,
+        ))
+    }
+    #[cfg(not(feature = "chatgpt-oauth"))]
+    {
+        let _ = (provider_key, model_name, api_url, env_vars);
+        Err(feature_disabled_error("chatgpt-oauth", "chatgpt-oauth"))
+    }
+}
+
+fn build_claude_code_oauth(
+    provider_key: &str,
+    model_name: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<ResolvedSerdesModel, ModelError> {
+    #[cfg(feature = "claude-code-oauth")]
+    {
+        let access_token = require_env_value(
+            provider_key,
+            "claude-code-oauth",
+            env_vars,
+            "an access token",
+            is_credential_env_var,
+        )?;
+        let mut model = serdes_ai_models::ClaudeCodeOAuthModel::new(model_name, access_token);
+        if let Some(api_url) = api_url {
+            model = model.with_config(serdes_ai_models::claude_code_oauth::ClaudeCodeConfig {
+                api_base_url: api_url.to_owned(),
+                ..serdes_ai_models::claude_code_oauth::ClaudeCodeConfig::default()
+            });
+        }
+        Ok(ResolvedSerdesModel::new(
+            "claude-code-oauth",
+            model_name,
+            #[cfg(test)]
+            SerdesModelFlavor::ClaudeCodeOAuth,
+            model,
+        ))
+    }
+    #[cfg(not(feature = "claude-code-oauth"))]
+    {
+        let _ = (provider_key, model_name, api_url, env_vars);
+        Err(feature_disabled_error(
+            "claude-code-oauth",
+            "claude-code-oauth",
+        ))
+    }
+}
+
+fn build_antigravity(
+    provider_key: &str,
+    model_name: &str,
+    api_url: Option<&str>,
+    env_vars: &[&str],
+) -> Result<ResolvedSerdesModel, ModelError> {
+    #[cfg(feature = "antigravity")]
+    {
+        let access_token = require_env_value(
+            provider_key,
+            "antigravity",
+            env_vars,
+            "an access token",
+            is_credential_env_var,
+        )?;
+        let project_id = first_matching_env_value(env_vars, is_project_id_env_var)
+            .unwrap_or_else(|| serdes_ai_models::antigravity::DEFAULT_PROJECT_ID.to_owned());
+        let mut model =
+            serdes_ai_models::AntigravityModel::new(model_name, access_token, project_id);
+        if let Some(api_url) = api_url {
+            model = model.with_config(serdes_ai_models::antigravity::AntigravityConfig {
+                endpoint: api_url.to_owned(),
+                ..serdes_ai_models::antigravity::AntigravityConfig::default()
+            });
+        }
+        Ok(ResolvedSerdesModel::new(
+            "antigravity",
+            model_name,
+            #[cfg(test)]
+            SerdesModelFlavor::Antigravity,
+            model,
+        ))
+    }
+    #[cfg(not(feature = "antigravity"))]
+    {
+        let _ = (provider_key, model_name, api_url, env_vars);
+        Err(feature_disabled_error("antigravity", "antigravity"))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/tests.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/tests.rs
@@ -91,25 +91,45 @@ fn resolve_case(case: &Case) -> ResolvedSerdesModel {
     let defaults = AgentDefaults::with_model(&*model);
     let agent = config_with_model("planner", None);
     let mut credentials = CredentialResolver::without_env();
-    // Bedrock is special: the AWS SDK reads credentials directly from environment variables
-    // (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION) rather than accepting them
-    // as function parameters. Other providers use CredentialResolver to pass credentials
-    // explicitly to their constructors. See `build_bedrock` in mod.rs for details.
-    if matches!(case.provider.api_type, ProviderType::Bedrock) {
-        temp_env::with_vars(case.credential_updates, || {
+    for (name, value) in case.credential_updates {
+        if let Some(value) = value {
+            credentials.set_override(*name, *value);
+        }
+    }
+    let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
+    build_serdes_model(&catalog, &resolved, &credentials).expect("model should build")
+}
+
+#[cfg(feature = "bedrock")]
+#[test]
+fn build_bedrock_ignores_process_env_when_resolver_disables_env_fallback() {
+    let catalog = build_catalog(
+        vec![("bedrock", provider("", &[], ProviderType::Bedrock))],
+        vec![(
+            "bedrock",
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            model_info(128_000, 16_384),
+        )],
+    );
+    let defaults = AgentDefaults::with_model("bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0");
+    let agent = config_with_model("planner", None);
+    let credentials = CredentialResolver::without_env();
+
+    temp_env::with_vars(
+        [
+            ("AWS_ACCESS_KEY_ID", Some("ambient-access-key")),
+            ("AWS_SECRET_ACCESS_KEY", Some("ambient-secret-key")),
+            ("AWS_REGION", Some("us-east-1")),
+        ],
+        || {
             let resolved =
                 resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
-            build_serdes_model(&catalog, &resolved, &credentials).expect("model should build")
-        })
-    } else {
-        for (name, value) in case.credential_updates {
-            if let Some(value) = value {
-                credentials.set_override(*name, *value);
-            }
-        }
-        let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
-        build_serdes_model(&catalog, &resolved, &credentials).expect("model should build")
-    }
+            let err = build_serdes_model(&catalog, &resolved, &credentials)
+                .err()
+                .expect("model should fail");
+            assert!(err.to_string().contains("AWS_ACCESS_KEY_ID"));
+        },
+    );
 }
 
 #[test]

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/tests.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/tests.rs
@@ -88,11 +88,7 @@ fn resolve_case(case: &Case) -> ResolvedSerdesModel {
         )],
     );
     let model = format!("{}/{}", case.provider_key, case.model_name);
-    let defaults = AgentDefaults {
-        model: Some(model.into()),
-        temperature: None,
-        top_p: None,
-    };
+    let defaults = AgentDefaults::with_model(&*model);
     let agent = config_with_model("planner", None);
     let mut credentials = CredentialResolver::without_env();
     // Bedrock is special: the AWS SDK reads credentials directly from environment variables
@@ -348,11 +344,7 @@ fn build_serdes_model_skips_empty_credential_env_vars() {
             model_info(128_000, 16_384),
         )],
     );
-    let defaults = AgentDefaults {
-        model: Some("synthetic/hf:zai-org/GLM-4.7".into()),
-        temperature: None,
-        top_p: None,
-    };
+    let defaults = AgentDefaults::with_model("synthetic/hf:zai-org/GLM-4.7");
     let agent = config_with_model("planner", None);
     let mut credentials = CredentialResolver::without_env();
     credentials.set_override("PRIMARY_API_KEY", "");
@@ -381,11 +373,7 @@ fn build_serdes_model_returns_clear_error_when_required_credential_missing() {
             model_info(128_000, 16_384),
         )],
     );
-    let defaults = AgentDefaults {
-        model: Some("synthetic/hf:zai-org/GLM-4.7".into()),
-        temperature: None,
-        top_p: None,
-    };
+    let defaults = AgentDefaults::with_model("synthetic/hf:zai-org/GLM-4.7");
     let agent = config_with_model("planner", None);
     let credentials = CredentialResolver::without_env();
 
@@ -406,11 +394,7 @@ fn build_serdes_model_rejects_unknown_provider_type() {
         vec![("mystery", provider("", &[], ProviderType::Unknown))],
         vec![("mystery", "m1", model_info(1, 1))],
     );
-    let defaults = AgentDefaults {
-        model: Some("mystery/m1".into()),
-        temperature: None,
-        top_p: None,
-    };
+    let defaults = AgentDefaults::with_model("mystery/m1");
     let agent = config_with_model("planner", None);
     let credentials = CredentialResolver::without_env();
 

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/tests.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/tests.rs
@@ -1,0 +1,459 @@
+use super::{build_serdes_model, ResolvedSerdesModel, SerdesModelFlavor};
+use crate::agent_runtime::model::resolve_model;
+use ahash::AHashMap;
+use indexmap::IndexMap;
+use llm_coding_tools_agents::{AgentConfig, AgentDefaults, AgentMode};
+use llm_coding_tools_core::models::{
+    Modality, ModelCatalog, ModelInfo, ProviderIdx, ProviderInfo, ProviderModelSource,
+    ProviderSource, ProviderType,
+};
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    saved: Vec<(&'static str, Option<String>)>,
+}
+
+impl EnvGuard {
+    fn new(updates: &[(&'static str, Option<&'static str>)]) -> Self {
+        let lock = ENV_LOCK.lock().expect("env lock should be available");
+        let mut saved = Vec::with_capacity(updates.len());
+        for (name, value) in updates {
+            saved.push((*name, std::env::var(name).ok()));
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+        Self { _lock: lock, saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (name, value) in self.saved.drain(..).rev() {
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+}
+
+struct Case {
+    provider_key: &'static str,
+    provider: ProviderInfo,
+    model_name: &'static str,
+    env_updates: &'static [(&'static str, Option<&'static str>)],
+    expected_spec: &'static str,
+    expected_system: &'static str,
+    expected_flavor: SerdesModelFlavor,
+}
+
+fn config_with_model(name: &str, model: Option<&str>) -> AgentConfig {
+    AgentConfig {
+        name: name.into(),
+        mode: AgentMode::All,
+        description: Default::default(),
+        model: model.map(Into::into),
+        hidden: false,
+        temperature: None,
+        top_p: None,
+        permission: IndexMap::new(),
+        options: AHashMap::new(),
+        prompt: Default::default(),
+    }
+}
+
+fn provider(api_url: &str, env_vars: &[&str], api_type: ProviderType) -> ProviderInfo {
+    ProviderInfo {
+        api_url: api_url.to_string(),
+        env_vars: env_vars
+            .iter()
+            .map(|env_var| (*env_var).to_string())
+            .collect(),
+        api_type,
+    }
+}
+
+fn model_info(max_input: u32, max_output: u32) -> ModelInfo {
+    ModelInfo {
+        modalities: Modality::TEXT,
+        max_input,
+        max_output,
+        temperature: Some(1.0),
+        top_p: Some(0.95),
+    }
+}
+
+fn build_catalog(
+    providers: Vec<(&str, ProviderInfo)>,
+    provider_models: Vec<(&str, &str, ModelInfo)>,
+) -> ModelCatalog {
+    let provider_sources: Vec<ProviderSource> = providers
+        .into_iter()
+        .map(|(key, info)| ProviderSource::new(key, info))
+        .collect();
+    let provider_model_sources: Vec<ProviderModelSource<'_>> = provider_models
+        .into_iter()
+        .map(|(provider_key, model_key, info)| {
+            let provider_idx = ProviderIdx::new(
+                provider_sources
+                    .iter()
+                    .position(|provider| provider.provider_key == provider_key)
+                    .expect("provider key should exist") as u16,
+            );
+            ProviderModelSource::new(provider_idx, model_key, info)
+        })
+        .collect();
+    ModelCatalog::build(&provider_sources, &provider_model_sources)
+        .expect("catalog fixture should build")
+}
+
+fn resolve_case(case: &Case) -> ResolvedSerdesModel {
+    let catalog = build_catalog(
+        vec![(case.provider_key, case.provider.clone())],
+        vec![(
+            case.provider_key,
+            case.model_name,
+            model_info(128_000, 16_384),
+        )],
+    );
+    let model = format!("{}/{}", case.provider_key, case.model_name);
+    let defaults = AgentDefaults {
+        model: Some(model.into()),
+        temperature: None,
+        top_p: None,
+    };
+    let agent = config_with_model("planner", None);
+    let _env = EnvGuard::new(case.env_updates);
+    let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
+    build_serdes_model(&catalog, &resolved).expect("model should build")
+}
+
+#[test]
+fn build_serdes_model_covers_every_provider_mapping() {
+    let mut cases = Vec::with_capacity(15);
+
+    #[cfg(feature = "openai")]
+    {
+        cases.push(Case {
+            provider_key: "synthetic",
+            provider: provider(
+                "https://api.synthetic.new/v1",
+                &["SYNTHETIC_API_KEY"],
+                ProviderType::OpenAiCompletions,
+            ),
+            model_name: "hf:zai-org/GLM-4.7",
+            env_updates: &[("SYNTHETIC_API_KEY", Some("synthetic-key"))],
+            expected_spec: "openai:hf:zai-org/GLM-4.7",
+            expected_system: "openai",
+            expected_flavor: SerdesModelFlavor::OpenAiChat,
+        });
+        cases.push(Case {
+            provider_key: "openai",
+            provider: provider("", &["OPENAI_API_KEY"], ProviderType::OpenAiResponses),
+            model_name: "o3-mini",
+            env_updates: &[("OPENAI_API_KEY", Some("openai-key"))],
+            expected_spec: "openai:o3-mini",
+            expected_system: "openai",
+            expected_flavor: SerdesModelFlavor::OpenAiResponses,
+        });
+    }
+
+    #[cfg(feature = "anthropic")]
+    cases.push(Case {
+        provider_key: "anthropic",
+        provider: provider("", &["ANTHROPIC_API_KEY"], ProviderType::Anthropic),
+        model_name: "claude-3-5-sonnet-20241022",
+        env_updates: &[("ANTHROPIC_API_KEY", Some("anthropic-key"))],
+        expected_spec: "anthropic:claude-3-5-sonnet-20241022",
+        expected_system: "anthropic",
+        expected_flavor: SerdesModelFlavor::Anthropic,
+    });
+
+    #[cfg(any(feature = "google", feature = "gemini"))]
+    cases.push(Case {
+        provider_key: "google",
+        provider: provider(
+            "",
+            &["GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY"],
+            ProviderType::Google,
+        ),
+        model_name: "gemini-2.5-flash",
+        env_updates: &[("GOOGLE_GENERATIVE_AI_API_KEY", Some("google-key"))],
+        expected_spec: "google:gemini-2.5-flash",
+        expected_system: "google",
+        expected_flavor: SerdesModelFlavor::Google,
+    });
+
+    #[cfg(feature = "groq")]
+    cases.push(Case {
+        provider_key: "groq",
+        provider: provider(
+            serdes_ai_models::GroqModel::BASE_URL,
+            &["GROQ_API_KEY"],
+            ProviderType::Groq,
+        ),
+        model_name: "llama-3.3-70b-versatile",
+        env_updates: &[("GROQ_API_KEY", Some("groq-key"))],
+        expected_spec: "groq:llama-3.3-70b-versatile",
+        expected_system: "groq",
+        expected_flavor: SerdesModelFlavor::Groq,
+    });
+
+    #[cfg(feature = "mistral")]
+    cases.push(Case {
+        provider_key: "mistral",
+        provider: provider(
+            "https://api.mistral.ai/v1",
+            &["MISTRAL_API_KEY"],
+            ProviderType::Mistral,
+        ),
+        model_name: "mistral-large-latest",
+        env_updates: &[("MISTRAL_API_KEY", Some("mistral-key"))],
+        expected_spec: "mistral:mistral-large-latest",
+        expected_system: "mistral",
+        expected_flavor: SerdesModelFlavor::Mistral,
+    });
+
+    #[cfg(feature = "ollama")]
+    cases.push(Case {
+        provider_key: "ollama",
+        provider: provider("http://localhost:11434", &[], ProviderType::Ollama),
+        model_name: "llama3.2",
+        env_updates: &[],
+        expected_spec: "ollama:llama3.2",
+        expected_system: "ollama",
+        expected_flavor: SerdesModelFlavor::Ollama,
+    });
+
+    #[cfg(feature = "bedrock")]
+    cases.push(Case {
+        provider_key: "bedrock",
+        provider: provider("", &[], ProviderType::Bedrock),
+        model_name: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        env_updates: &[
+            ("AWS_ACCESS_KEY_ID", Some("test-access-key")),
+            ("AWS_SECRET_ACCESS_KEY", Some("test-secret-key")),
+            ("AWS_REGION", Some("us-east-1")),
+        ],
+        expected_spec: "bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0",
+        expected_system: "bedrock",
+        expected_flavor: SerdesModelFlavor::Bedrock,
+    });
+
+    #[cfg(feature = "azure")]
+    cases.push(Case {
+        provider_key: "azure",
+        provider: provider(
+            "",
+            &["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+            ProviderType::Azure,
+        ),
+        model_name: "gpt-4.1-mini",
+        env_updates: &[
+            ("AZURE_RESOURCE_NAME", Some("my-resource")),
+            ("AZURE_API_KEY", Some("azure-key")),
+        ],
+        expected_spec: "azure:gpt-4.1-mini",
+        expected_system: "azure",
+        expected_flavor: SerdesModelFlavor::Azure,
+    });
+
+    #[cfg(feature = "openrouter")]
+    cases.push(Case {
+        provider_key: "openrouter",
+        provider: provider(
+            "https://openrouter.ai/api/v1",
+            &["OPENROUTER_API_KEY"],
+            ProviderType::OpenRouter,
+        ),
+        model_name: "openai/gpt-4.1-mini",
+        env_updates: &[("OPENROUTER_API_KEY", Some("openrouter-key"))],
+        expected_spec: "openrouter:openai/gpt-4.1-mini",
+        expected_system: "openrouter",
+        expected_flavor: SerdesModelFlavor::OpenRouter,
+    });
+
+    #[cfg(feature = "huggingface")]
+    cases.push(Case {
+        provider_key: "huggingface",
+        provider: provider(
+            "https://router.huggingface.co/v1",
+            &["HF_TOKEN"],
+            ProviderType::HuggingFace,
+        ),
+        model_name: "meta-llama/Llama-3.3-70B-Instruct",
+        env_updates: &[("HF_TOKEN", Some("hf-token"))],
+        expected_spec: "huggingface:meta-llama/Llama-3.3-70B-Instruct",
+        expected_system: "huggingface",
+        expected_flavor: SerdesModelFlavor::HuggingFace,
+    });
+
+    #[cfg(feature = "cohere")]
+    cases.push(Case {
+        provider_key: "cohere",
+        provider: provider("", &["COHERE_API_KEY"], ProviderType::Cohere),
+        model_name: "command-r-plus",
+        env_updates: &[("COHERE_API_KEY", Some("cohere-key"))],
+        expected_spec: "cohere:command-r-plus",
+        expected_system: "cohere",
+        expected_flavor: SerdesModelFlavor::Cohere,
+    });
+
+    #[cfg(feature = "chatgpt-oauth")]
+    cases.push(Case {
+        provider_key: "chatgpt-oauth",
+        provider: provider(
+            "https://chatgpt.com/backend-api/codex",
+            &["CHATGPT_ACCESS_TOKEN", "CHATGPT_ACCOUNT_ID"],
+            ProviderType::ChatGptOAuth,
+        ),
+        model_name: "chatgpt-4o-codex",
+        env_updates: &[
+            ("CHATGPT_ACCESS_TOKEN", Some("chatgpt-token")),
+            ("CHATGPT_ACCOUNT_ID", Some("acct_123")),
+        ],
+        expected_spec: "chatgpt-oauth:chatgpt-4o-codex",
+        expected_system: "chatgpt-oauth",
+        expected_flavor: SerdesModelFlavor::ChatGptOAuth,
+    });
+
+    #[cfg(feature = "claude-code-oauth")]
+    cases.push(Case {
+        provider_key: "claude-code-oauth",
+        provider: provider(
+            "https://api.anthropic.com",
+            &["CLAUDE_CODE_ACCESS_TOKEN"],
+            ProviderType::ClaudeCodeOAuth,
+        ),
+        model_name: "claude-sonnet-4-20250514",
+        env_updates: &[("CLAUDE_CODE_ACCESS_TOKEN", Some("claude-token"))],
+        expected_spec: "claude-code-oauth:claude-sonnet-4-20250514",
+        expected_system: "claude-code-oauth",
+        expected_flavor: SerdesModelFlavor::ClaudeCodeOAuth,
+    });
+
+    #[cfg(feature = "antigravity")]
+    cases.push(Case {
+        provider_key: "antigravity",
+        provider: provider(
+            "https://cloudcode-pa.googleapis.com",
+            &["ANTIGRAVITY_ACCESS_TOKEN", "ANTIGRAVITY_PROJECT_ID"],
+            ProviderType::Antigravity,
+        ),
+        model_name: "gemini-3-flash",
+        env_updates: &[
+            ("ANTIGRAVITY_ACCESS_TOKEN", Some("antigravity-token")),
+            ("ANTIGRAVITY_PROJECT_ID", Some("project-123")),
+        ],
+        expected_spec: "antigravity:gemini-3-flash",
+        expected_system: "antigravity",
+        expected_flavor: SerdesModelFlavor::Antigravity,
+    });
+
+    for case in cases {
+        let resolved = resolve_case(&case);
+        assert_eq!(resolved.spec.as_ref(), case.expected_spec);
+        assert_eq!(resolved.flavor, case.expected_flavor);
+        assert_eq!(resolved.model.system(), case.expected_system);
+        assert_eq!(resolved.model.name(), case.model_name);
+    }
+}
+
+#[test]
+fn build_serdes_model_skips_empty_credential_env_vars() {
+    let catalog = build_catalog(
+        vec![(
+            "synthetic",
+            provider(
+                "https://api.synthetic.new/v1",
+                &["PRIMARY_API_KEY", "SECONDARY_API_KEY"],
+                ProviderType::OpenAiCompletions,
+            ),
+        )],
+        vec![(
+            "synthetic",
+            "hf:zai-org/GLM-4.7",
+            model_info(128_000, 16_384),
+        )],
+    );
+    let defaults = AgentDefaults {
+        model: Some("synthetic/hf:zai-org/GLM-4.7".into()),
+        temperature: None,
+        top_p: None,
+    };
+    let agent = config_with_model("planner", None);
+    let _env = EnvGuard::new(&[
+        ("PRIMARY_API_KEY", Some("")),
+        ("SECONDARY_API_KEY", Some("fallback-key")),
+    ]);
+
+    let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
+    let serdes_model = build_serdes_model(&catalog, &resolved).expect("model should build");
+    assert_eq!(serdes_model.spec.as_ref(), "openai:hf:zai-org/GLM-4.7");
+}
+
+#[test]
+fn build_serdes_model_returns_clear_error_when_required_credential_missing() {
+    let catalog = build_catalog(
+        vec![(
+            "synthetic",
+            provider(
+                "https://api.synthetic.new/v1",
+                &["SYNTHETIC_API_KEY"],
+                ProviderType::OpenAiCompletions,
+            ),
+        )],
+        vec![(
+            "synthetic",
+            "hf:zai-org/GLM-4.7",
+            model_info(128_000, 16_384),
+        )],
+    );
+    let defaults = AgentDefaults {
+        model: Some("synthetic/hf:zai-org/GLM-4.7".into()),
+        temperature: None,
+        top_p: None,
+    };
+    let agent = config_with_model("planner", None);
+    let _env = EnvGuard::new(&[("SYNTHETIC_API_KEY", None)]);
+
+    let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
+    let err = build_serdes_model(&catalog, &resolved)
+        .err()
+        .expect("model should fail");
+    assert!(err
+        .to_string()
+        .contains("provider `synthetic` mapped to serdes `openai` requires a credential"));
+    assert!(err.to_string().contains("SYNTHETIC_API_KEY"));
+}
+
+#[test]
+fn build_serdes_model_rejects_unknown_provider_type() {
+    let catalog = build_catalog(
+        vec![("mystery", provider("", &[], ProviderType::Unknown))],
+        vec![("mystery", "m1", model_info(1, 1))],
+    );
+    let defaults = AgentDefaults {
+        model: Some("mystery/m1".into()),
+        temperature: None,
+        top_p: None,
+    };
+    let agent = config_with_model("planner", None);
+
+    let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
+    let err = build_serdes_model(&catalog, &resolved)
+        .err()
+        .expect("model should fail");
+    assert!(err
+        .to_string()
+        .contains("provider `mystery` has no SerdesAI mapping"));
+}

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/tests.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/tests.rs
@@ -7,45 +7,6 @@ use llm_coding_tools_core::models::{
     Modality, ModelCatalog, ModelInfo, ProviderIdx, ProviderInfo, ProviderModelSource,
     ProviderSource, ProviderType,
 };
-use std::sync::{Mutex, MutexGuard};
-
-static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-struct EnvGuard {
-    _lock: MutexGuard<'static, ()>,
-    saved: Vec<(&'static str, Option<String>)>,
-}
-
-impl EnvGuard {
-    fn new(updates: &[(&'static str, Option<&'static str>)]) -> Self {
-        let lock = ENV_LOCK.lock().expect("env lock should be available");
-        let mut saved = Vec::with_capacity(updates.len());
-        for (name, value) in updates {
-            saved.push((*name, std::env::var(name).ok()));
-            unsafe {
-                match value {
-                    Some(value) => std::env::set_var(name, value),
-                    None => std::env::remove_var(name),
-                }
-            }
-        }
-        Self { _lock: lock, saved }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        for (name, value) in self.saved.drain(..).rev() {
-            unsafe {
-                match value {
-                    Some(value) => std::env::set_var(name, value),
-                    None => std::env::remove_var(name),
-                }
-            }
-        }
-    }
-}
-
 struct Case {
     provider_key: &'static str,
     provider: ProviderInfo,
@@ -132,9 +93,10 @@ fn resolve_case(case: &Case) -> ResolvedSerdesModel {
         top_p: None,
     };
     let agent = config_with_model("planner", None);
-    let _env = EnvGuard::new(case.env_updates);
-    let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
-    build_serdes_model(&catalog, &resolved).expect("model should build")
+    temp_env::with_vars(case.env_updates, || {
+        let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
+        build_serdes_model(&catalog, &resolved).expect("model should build")
+    })
 }
 
 #[test]
@@ -391,14 +353,17 @@ fn build_serdes_model_skips_empty_credential_env_vars() {
         top_p: None,
     };
     let agent = config_with_model("planner", None);
-    let _env = EnvGuard::new(&[
-        ("PRIMARY_API_KEY", Some("")),
-        ("SECONDARY_API_KEY", Some("fallback-key")),
-    ]);
-
-    let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
-    let serdes_model = build_serdes_model(&catalog, &resolved).expect("model should build");
-    assert_eq!(serdes_model.spec.as_ref(), "openai:hf:zai-org/GLM-4.7");
+    temp_env::with_vars(
+        [
+            ("PRIMARY_API_KEY", Some("")),
+            ("SECONDARY_API_KEY", Some("fallback-key")),
+        ],
+        || {
+            let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
+            let serdes_model = build_serdes_model(&catalog, &resolved).expect("model should build");
+            assert_eq!(serdes_model.spec.as_ref(), "openai:hf:zai-org/GLM-4.7");
+        },
+    );
 }
 
 #[test]
@@ -424,16 +389,16 @@ fn build_serdes_model_returns_clear_error_when_required_credential_missing() {
         top_p: None,
     };
     let agent = config_with_model("planner", None);
-    let _env = EnvGuard::new(&[("SYNTHETIC_API_KEY", None)]);
-
-    let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
-    let err = build_serdes_model(&catalog, &resolved)
-        .err()
-        .expect("model should fail");
-    assert!(err
-        .to_string()
-        .contains("provider `synthetic` mapped to serdes `openai` requires a credential"));
-    assert!(err.to_string().contains("SYNTHETIC_API_KEY"));
+    temp_env::with_var("SYNTHETIC_API_KEY", None::<&str>, || {
+        let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
+        let err = build_serdes_model(&catalog, &resolved)
+            .err()
+            .expect("model should fail");
+        assert!(err
+            .to_string()
+            .contains("provider `synthetic` mapped to serdes `openai` requires a credential"));
+        assert!(err.to_string().contains("SYNTHETIC_API_KEY"));
+    });
 }
 
 #[test]

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/tests.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/provider_bridge/tests.rs
@@ -1,20 +1,21 @@
-use super::{build_serdes_model, ResolvedSerdesModel, SerdesModelFlavor};
+use super::{ResolvedSerdesModel, build_serdes_model};
 use crate::agent_runtime::model::resolve_model;
 use ahash::AHashMap;
 use indexmap::IndexMap;
 use llm_coding_tools_agents::{AgentConfig, AgentDefaults, AgentMode};
+use llm_coding_tools_core::CredentialResolver;
 use llm_coding_tools_core::models::{
     Modality, ModelCatalog, ModelInfo, ProviderIdx, ProviderInfo, ProviderModelSource,
     ProviderSource, ProviderType,
 };
+
 struct Case {
     provider_key: &'static str,
     provider: ProviderInfo,
     model_name: &'static str,
-    env_updates: &'static [(&'static str, Option<&'static str>)],
+    credential_updates: &'static [(&'static str, Option<&'static str>)],
     expected_spec: &'static str,
     expected_system: &'static str,
-    expected_flavor: SerdesModelFlavor,
 }
 
 fn config_with_model(name: &str, model: Option<&str>) -> AgentConfig {
@@ -93,10 +94,26 @@ fn resolve_case(case: &Case) -> ResolvedSerdesModel {
         top_p: None,
     };
     let agent = config_with_model("planner", None);
-    temp_env::with_vars(case.env_updates, || {
+    let mut credentials = CredentialResolver::without_env();
+    // Bedrock is special: the AWS SDK reads credentials directly from environment variables
+    // (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION) rather than accepting them
+    // as function parameters. Other providers use CredentialResolver to pass credentials
+    // explicitly to their constructors. See `build_bedrock` in mod.rs for details.
+    if matches!(case.provider.api_type, ProviderType::Bedrock) {
+        temp_env::with_vars(case.credential_updates, || {
+            let resolved =
+                resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
+            build_serdes_model(&catalog, &resolved, &credentials).expect("model should build")
+        })
+    } else {
+        for (name, value) in case.credential_updates {
+            if let Some(value) = value {
+                credentials.set_override(*name, *value);
+            }
+        }
         let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
-        build_serdes_model(&catalog, &resolved).expect("model should build")
-    })
+        build_serdes_model(&catalog, &resolved, &credentials).expect("model should build")
+    }
 }
 
 #[test]
@@ -113,19 +130,17 @@ fn build_serdes_model_covers_every_provider_mapping() {
                 ProviderType::OpenAiCompletions,
             ),
             model_name: "hf:zai-org/GLM-4.7",
-            env_updates: &[("SYNTHETIC_API_KEY", Some("synthetic-key"))],
+            credential_updates: &[("SYNTHETIC_API_KEY", Some("synthetic-key"))],
             expected_spec: "openai:hf:zai-org/GLM-4.7",
             expected_system: "openai",
-            expected_flavor: SerdesModelFlavor::OpenAiChat,
         });
         cases.push(Case {
             provider_key: "openai",
             provider: provider("", &["OPENAI_API_KEY"], ProviderType::OpenAiResponses),
             model_name: "o3-mini",
-            env_updates: &[("OPENAI_API_KEY", Some("openai-key"))],
+            credential_updates: &[("OPENAI_API_KEY", Some("openai-key"))],
             expected_spec: "openai:o3-mini",
             expected_system: "openai",
-            expected_flavor: SerdesModelFlavor::OpenAiResponses,
         });
     }
 
@@ -134,10 +149,9 @@ fn build_serdes_model_covers_every_provider_mapping() {
         provider_key: "anthropic",
         provider: provider("", &["ANTHROPIC_API_KEY"], ProviderType::Anthropic),
         model_name: "claude-3-5-sonnet-20241022",
-        env_updates: &[("ANTHROPIC_API_KEY", Some("anthropic-key"))],
+        credential_updates: &[("ANTHROPIC_API_KEY", Some("anthropic-key"))],
         expected_spec: "anthropic:claude-3-5-sonnet-20241022",
         expected_system: "anthropic",
-        expected_flavor: SerdesModelFlavor::Anthropic,
     });
 
     #[cfg(any(feature = "google", feature = "gemini"))]
@@ -149,10 +163,9 @@ fn build_serdes_model_covers_every_provider_mapping() {
             ProviderType::Google,
         ),
         model_name: "gemini-2.5-flash",
-        env_updates: &[("GOOGLE_GENERATIVE_AI_API_KEY", Some("google-key"))],
+        credential_updates: &[("GOOGLE_GENERATIVE_AI_API_KEY", Some("google-key"))],
         expected_spec: "google:gemini-2.5-flash",
         expected_system: "google",
-        expected_flavor: SerdesModelFlavor::Google,
     });
 
     #[cfg(feature = "groq")]
@@ -164,10 +177,9 @@ fn build_serdes_model_covers_every_provider_mapping() {
             ProviderType::Groq,
         ),
         model_name: "llama-3.3-70b-versatile",
-        env_updates: &[("GROQ_API_KEY", Some("groq-key"))],
+        credential_updates: &[("GROQ_API_KEY", Some("groq-key"))],
         expected_spec: "groq:llama-3.3-70b-versatile",
         expected_system: "groq",
-        expected_flavor: SerdesModelFlavor::Groq,
     });
 
     #[cfg(feature = "mistral")]
@@ -179,10 +191,9 @@ fn build_serdes_model_covers_every_provider_mapping() {
             ProviderType::Mistral,
         ),
         model_name: "mistral-large-latest",
-        env_updates: &[("MISTRAL_API_KEY", Some("mistral-key"))],
+        credential_updates: &[("MISTRAL_API_KEY", Some("mistral-key"))],
         expected_spec: "mistral:mistral-large-latest",
         expected_system: "mistral",
-        expected_flavor: SerdesModelFlavor::Mistral,
     });
 
     #[cfg(feature = "ollama")]
@@ -190,10 +201,9 @@ fn build_serdes_model_covers_every_provider_mapping() {
         provider_key: "ollama",
         provider: provider("http://localhost:11434", &[], ProviderType::Ollama),
         model_name: "llama3.2",
-        env_updates: &[],
+        credential_updates: &[],
         expected_spec: "ollama:llama3.2",
         expected_system: "ollama",
-        expected_flavor: SerdesModelFlavor::Ollama,
     });
 
     #[cfg(feature = "bedrock")]
@@ -201,14 +211,13 @@ fn build_serdes_model_covers_every_provider_mapping() {
         provider_key: "bedrock",
         provider: provider("", &[], ProviderType::Bedrock),
         model_name: "anthropic.claude-3-5-sonnet-20241022-v2:0",
-        env_updates: &[
+        credential_updates: &[
             ("AWS_ACCESS_KEY_ID", Some("test-access-key")),
             ("AWS_SECRET_ACCESS_KEY", Some("test-secret-key")),
             ("AWS_REGION", Some("us-east-1")),
         ],
         expected_spec: "bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0",
         expected_system: "bedrock",
-        expected_flavor: SerdesModelFlavor::Bedrock,
     });
 
     #[cfg(feature = "azure")]
@@ -220,13 +229,12 @@ fn build_serdes_model_covers_every_provider_mapping() {
             ProviderType::Azure,
         ),
         model_name: "gpt-4.1-mini",
-        env_updates: &[
+        credential_updates: &[
             ("AZURE_RESOURCE_NAME", Some("my-resource")),
             ("AZURE_API_KEY", Some("azure-key")),
         ],
         expected_spec: "azure:gpt-4.1-mini",
         expected_system: "azure",
-        expected_flavor: SerdesModelFlavor::Azure,
     });
 
     #[cfg(feature = "openrouter")]
@@ -238,10 +246,9 @@ fn build_serdes_model_covers_every_provider_mapping() {
             ProviderType::OpenRouter,
         ),
         model_name: "openai/gpt-4.1-mini",
-        env_updates: &[("OPENROUTER_API_KEY", Some("openrouter-key"))],
+        credential_updates: &[("OPENROUTER_API_KEY", Some("openrouter-key"))],
         expected_spec: "openrouter:openai/gpt-4.1-mini",
         expected_system: "openrouter",
-        expected_flavor: SerdesModelFlavor::OpenRouter,
     });
 
     #[cfg(feature = "huggingface")]
@@ -253,10 +260,9 @@ fn build_serdes_model_covers_every_provider_mapping() {
             ProviderType::HuggingFace,
         ),
         model_name: "meta-llama/Llama-3.3-70B-Instruct",
-        env_updates: &[("HF_TOKEN", Some("hf-token"))],
+        credential_updates: &[("HF_TOKEN", Some("hf-token"))],
         expected_spec: "huggingface:meta-llama/Llama-3.3-70B-Instruct",
         expected_system: "huggingface",
-        expected_flavor: SerdesModelFlavor::HuggingFace,
     });
 
     #[cfg(feature = "cohere")]
@@ -264,10 +270,9 @@ fn build_serdes_model_covers_every_provider_mapping() {
         provider_key: "cohere",
         provider: provider("", &["COHERE_API_KEY"], ProviderType::Cohere),
         model_name: "command-r-plus",
-        env_updates: &[("COHERE_API_KEY", Some("cohere-key"))],
+        credential_updates: &[("COHERE_API_KEY", Some("cohere-key"))],
         expected_spec: "cohere:command-r-plus",
         expected_system: "cohere",
-        expected_flavor: SerdesModelFlavor::Cohere,
     });
 
     #[cfg(feature = "chatgpt-oauth")]
@@ -279,13 +284,12 @@ fn build_serdes_model_covers_every_provider_mapping() {
             ProviderType::ChatGptOAuth,
         ),
         model_name: "chatgpt-4o-codex",
-        env_updates: &[
+        credential_updates: &[
             ("CHATGPT_ACCESS_TOKEN", Some("chatgpt-token")),
             ("CHATGPT_ACCOUNT_ID", Some("acct_123")),
         ],
         expected_spec: "chatgpt-oauth:chatgpt-4o-codex",
         expected_system: "chatgpt-oauth",
-        expected_flavor: SerdesModelFlavor::ChatGptOAuth,
     });
 
     #[cfg(feature = "claude-code-oauth")]
@@ -297,10 +301,9 @@ fn build_serdes_model_covers_every_provider_mapping() {
             ProviderType::ClaudeCodeOAuth,
         ),
         model_name: "claude-sonnet-4-20250514",
-        env_updates: &[("CLAUDE_CODE_ACCESS_TOKEN", Some("claude-token"))],
+        credential_updates: &[("CLAUDE_CODE_ACCESS_TOKEN", Some("claude-token"))],
         expected_spec: "claude-code-oauth:claude-sonnet-4-20250514",
         expected_system: "claude-code-oauth",
-        expected_flavor: SerdesModelFlavor::ClaudeCodeOAuth,
     });
 
     #[cfg(feature = "antigravity")]
@@ -312,19 +315,17 @@ fn build_serdes_model_covers_every_provider_mapping() {
             ProviderType::Antigravity,
         ),
         model_name: "gemini-3-flash",
-        env_updates: &[
+        credential_updates: &[
             ("ANTIGRAVITY_ACCESS_TOKEN", Some("antigravity-token")),
             ("ANTIGRAVITY_PROJECT_ID", Some("project-123")),
         ],
         expected_spec: "antigravity:gemini-3-flash",
         expected_system: "antigravity",
-        expected_flavor: SerdesModelFlavor::Antigravity,
     });
 
     for case in cases {
         let resolved = resolve_case(&case);
         assert_eq!(resolved.spec.as_ref(), case.expected_spec);
-        assert_eq!(resolved.flavor, case.expected_flavor);
         assert_eq!(resolved.model.system(), case.expected_system);
         assert_eq!(resolved.model.name(), case.model_name);
     }
@@ -353,17 +354,14 @@ fn build_serdes_model_skips_empty_credential_env_vars() {
         top_p: None,
     };
     let agent = config_with_model("planner", None);
-    temp_env::with_vars(
-        [
-            ("PRIMARY_API_KEY", Some("")),
-            ("SECONDARY_API_KEY", Some("fallback-key")),
-        ],
-        || {
-            let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
-            let serdes_model = build_serdes_model(&catalog, &resolved).expect("model should build");
-            assert_eq!(serdes_model.spec.as_ref(), "openai:hf:zai-org/GLM-4.7");
-        },
-    );
+    let mut credentials = CredentialResolver::without_env();
+    credentials.set_override("PRIMARY_API_KEY", "");
+    credentials.set_override("SECONDARY_API_KEY", "fallback-key");
+
+    let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
+    let serdes_model =
+        build_serdes_model(&catalog, &resolved, &credentials).expect("model should build");
+    assert_eq!(serdes_model.spec.as_ref(), "openai:hf:zai-org/GLM-4.7");
 }
 
 #[test]
@@ -389,16 +387,17 @@ fn build_serdes_model_returns_clear_error_when_required_credential_missing() {
         top_p: None,
     };
     let agent = config_with_model("planner", None);
-    temp_env::with_var("SYNTHETIC_API_KEY", None::<&str>, || {
-        let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
-        let err = build_serdes_model(&catalog, &resolved)
-            .err()
-            .expect("model should fail");
-        assert!(err
-            .to_string()
-            .contains("provider `synthetic` mapped to serdes `openai` requires a credential"));
-        assert!(err.to_string().contains("SYNTHETIC_API_KEY"));
-    });
+    let credentials = CredentialResolver::without_env();
+
+    let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
+    let err = build_serdes_model(&catalog, &resolved, &credentials)
+        .err()
+        .expect("model should fail");
+    assert!(
+        err.to_string()
+            .contains("provider `synthetic` mapped to serdes `openai` requires a credential")
+    );
+    assert!(err.to_string().contains("SYNTHETIC_API_KEY"));
 }
 
 #[test]
@@ -413,12 +412,14 @@ fn build_serdes_model_rejects_unknown_provider_type() {
         top_p: None,
     };
     let agent = config_with_model("planner", None);
+    let credentials = CredentialResolver::without_env();
 
     let resolved = resolve_model(&catalog, &defaults, &agent).expect("model should resolve");
-    let err = build_serdes_model(&catalog, &resolved)
+    let err = build_serdes_model(&catalog, &resolved, &credentials)
         .err()
         .expect("model should fail");
-    assert!(err
-        .to_string()
-        .contains("provider `mystery` has no SerdesAI mapping"));
+    assert!(
+        err.to_string()
+            .contains("provider `mystery` has no SerdesAI mapping")
+    );
 }

--- a/src/llm-coding-tools-serdesai/src/lib.rs
+++ b/src/llm-coding-tools-serdesai/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod absolute;
 pub mod agent_ext;
+pub mod agent_runtime;
 pub mod allowed;
 pub mod bash;
 mod common;
@@ -44,7 +45,12 @@ pub use llm_coding_tools_core::{
     TodoPriority, TodoState, TodoStatus, WebFetchOutput,
 };
 
-// Re-export standalone tools
+// Re-export standalone tools and runtime helpers
+pub use agent_runtime::{AgentBuildError, AgentRuntimeExt};
 pub use bash::BashTool;
+pub use llm_coding_tools_agents::{
+    AgentDefaults, AgentRuntime, AgentRuntimeBuilder, ModelResolutionError, ResolvedModel,
+    ToolCatalogEntry, ToolCatalogKind, default_tools, resolve_model_with_catalog,
+};
 pub use todo::{TodoReadTool, TodoWriteTool, create_todo_tools};
 pub use webfetch::WebFetchTool;

--- a/src/llm-coding-tools-serdesai/src/lib.rs
+++ b/src/llm-coding-tools-serdesai/src/lib.rs
@@ -46,7 +46,7 @@ pub use llm_coding_tools_core::{
 };
 
 // Re-export standalone tools and runtime helpers
-pub use agent_runtime::{AgentBuildError, AgentRuntimeExt};
+pub use agent_runtime::{AgentBuildError, AgentRuntimeExt, build_agent_with_credentials};
 pub use bash::BashTool;
 pub use llm_coding_tools_agents::{
     AgentDefaults, AgentRuntime, AgentRuntimeBuilder, ModelResolutionError, ResolvedModel,


### PR DESCRIPTION
## Summary

This PR adds support for running AI agents using the SerdesAI framework.

- **Agent runtime**: A builder pattern for configuring and running agents with tools (read, write, edit, bash, etc.)
- **Provider support**: Connect to different AI providers (OpenAI, Anthropic, Azure, Bedrock, Groq, and more) via feature flags
- **Credential management**: A simple way to provide API keys, with support for overriding environment variables
- **Model catalog integration**: Automatically look up model details (context limits, pricing) from the models.dev catalog
- **Simplified defaults**: New `AgentDefaults::with_model("openai/gpt-4o")` helper for common setups

## Example

```rust
let runtime = AgentRuntimeBuilder::new()
    .catalog(catalog)
    .defaults(AgentDefaults::with_model("openai/gpt-4o-mini"))
    .build();
```