### PR TITLE
Changed: Move crate version and docs badges to per-crate READMEs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,10 +1,5 @@
 # llm-coding-tools
 
-[![Crates.io - llm-coding-tools-core](https://img.shields.io/crates/v/llm-coding-tools-core.svg)](https://crates.io/crates/llm-coding-tools-core)
-[![Crates.io - llm-coding-tools-agents](https://img.shields.io/crates/v/llm-coding-tools-agents.svg)](https://crates.io/crates/llm-coding-tools-agents)
-[![Crates.io - llm-coding-tools-serdesai](https://img.shields.io/crates/v/llm-coding-tools-serdesai.svg)](https://crates.io/crates/llm-coding-tools-serdesai)
-[![Crates.io - llm-coding-tools-models-dev](https://img.shields.io/crates/v/llm-coding-tools-models-dev.svg)](https://crates.io/crates/llm-coding-tools-models-dev)
-[![Docs.rs](https://docs.rs/llm-coding-tools-serdesai/badge.svg)](https://docs.rs/llm-coding-tools-serdesai)
 [![CI](https://github.com/Sewer56/llm-coding-tools/actions/workflows/rust.yml/badge.svg)](https://github.com/Sewer56/llm-coding-tools/actions)
 
 Lightweight, heavily optimized coding tool implementations for LLM-powered

--- a/src/llm-coding-tools-agents/README.md
+++ b/src/llm-coding-tools-agents/README.md
@@ -1,5 +1,7 @@
 # llm-coding-tools-agents
 
+[![Crates.io](https://img.shields.io/crates/v/llm-coding-tools-agents.svg)](https://crates.io/crates/llm-coding-tools-agents) [![Docs.rs](https://docs.rs/llm-coding-tools-agents/badge.svg)](https://docs.rs/llm-coding-tools-agents)
+
 Load OpenCode agent markdown files into Rust.
 
 This crate reads agent definitions from markdown files with YAML frontmatter,

--- a/src/llm-coding-tools-core/README.md
+++ b/src/llm-coding-tools-core/README.md
@@ -1,5 +1,7 @@
 # llm-coding-tools-core
 
+[![Crates.io](https://img.shields.io/crates/v/llm-coding-tools-core.svg)](https://crates.io/crates/llm-coding-tools-core) [![Docs.rs](https://docs.rs/llm-coding-tools-core/badge.svg)](https://docs.rs/llm-coding-tools-core)
+
 Framework-agnostic core library of standard tools used by coding agents - headless, TUI, or anything in between.
 
 `llm-coding-tools-core` provides reviewed, production-grade implementations of common coding-agent tools, plus shared safety, prompt, and policy primitives.

--- a/src/llm-coding-tools-models-dev/README.md
+++ b/src/llm-coding-tools-models-dev/README.md
@@ -1,5 +1,7 @@
 # llm-coding-tools-models-dev
 
+[![Crates.io](https://img.shields.io/crates/v/llm-coding-tools-models-dev.svg)](https://crates.io/crates/llm-coding-tools-models-dev) [![Docs.rs](https://docs.rs/llm-coding-tools-models-dev/badge.svg)](https://docs.rs/llm-coding-tools-models-dev)
+
 Reads the online models.dev catalog into llm-coding-tools-core; with support
 for a cached fallback and caching via ETag(s).
 

--- a/src/llm-coding-tools-serdesai/README.md
+++ b/src/llm-coding-tools-serdesai/README.md
@@ -1,7 +1,6 @@
 # llm-coding-tools-serdesai
 
-[![Crates.io](https://img.shields.io/crates/v/llm-coding-tools-serdesai.svg)](https://crates.io/crates/llm-coding-tools-serdesai)
-[![Docs.rs](https://docs.rs/llm-coding-tools-serdesai/badge.svg)](https://docs.rs/llm-coding-tools-serdesai)
+[![Crates.io](https://img.shields.io/crates/v/llm-coding-tools-serdesai.svg)](https://crates.io/crates/llm-coding-tools-serdesai) [![Docs.rs](https://docs.rs/llm-coding-tools-serdesai/badge.svg)](https://docs.rs/llm-coding-tools-serdesai)
 
 Lightweight, high-performance serdesAI framework Tool implementations for coding tools.
 


### PR DESCRIPTION
## Summary

Each crate now owns its own Crates.io and Docs.rs badges in its README header. This removes visual clutter from the root README and gives each badge clear context next to the crate it describes.

## Changes

- Added Crates.io + Docs.rs badges to `llm-coding-tools-core`, `llm-coding-tools-agents`, and `llm-coding-tools-models-dev` READMEs
- Consolidated existing badges in `llm-coding-tools-serdesai` onto a single line for consistency
- Removed per-crate version badges and the standalone Docs.rs badge from the root `README.MD`
- Root README retains only the CI badge