### PR TITLE
Changed: Trim hot path overhead across bash and sandbox tools

### DIFF
--- a/src/llm-coding-tools-bubblewrap/src/probe.rs
+++ b/src/llm-coding-tools-bubblewrap/src/probe.rs
@@ -5,6 +5,7 @@
 use crate::path_util::normalize_path;
 use crate::{Availability, LinuxBwrapError, Preset};
 use parking_lot::RwLock;
+use std::collections::HashSet;
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
@@ -124,7 +125,7 @@ fn first_shell_candidate_with_in<F, R>(
 where
     F: FnMut(&Path) -> Option<R>,
 {
-    let mut seen = std::collections::HashSet::with_capacity(10);
+    let mut seen = HashSet::with_capacity(10);
 
     for name in ["bash", "sh"] {
         if let Some(shell_path) = find_binary_on_path_in(name, env_path) {
@@ -150,7 +151,7 @@ where
 
 fn classify_shell_candidate<F, R>(
     classify: &mut F,
-    seen: &mut std::collections::HashSet<Box<Path>>,
+    seen: &mut HashSet<Box<Path>>,
     path: Box<Path>,
 ) -> Option<(Box<Path>, R)>
 where

--- a/src/llm-coding-tools-bubblewrap/src/probe.rs
+++ b/src/llm-coding-tools-bubblewrap/src/probe.rs
@@ -6,7 +6,7 @@ use crate::path_util::normalize_path;
 use crate::{Availability, LinuxBwrapError, Preset};
 use parking_lot::RwLock;
 use std::env;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::Arc;
@@ -91,10 +91,9 @@ fn profile_name(preset: Option<Preset>) -> &'static str {
     }
 }
 
-/// Searches `PATH` directories for a file named `name` and returns the first match.
-pub(crate) fn find_binary_on_path(name: &str) -> Option<Box<Path>> {
-    let path = env::var_os("PATH")?;
-    for dir in env::split_paths(&path) {
+fn find_binary_on_path_in(name: &str, path: Option<&OsStr>) -> Option<Box<Path>> {
+    let path = path?;
+    for dir in env::split_paths(path) {
         if !dir.is_absolute() || dir.as_os_str().is_empty() {
             continue;
         }
@@ -115,29 +114,57 @@ pub(crate) fn first_shell_candidate_with<F, R>(mut classify: F) -> Option<(Box<P
 where
     F: FnMut(&Path) -> Option<R>,
 {
+    first_shell_candidate_with_in(env::var_os("PATH").as_deref(), &mut classify)
+}
+
+fn first_shell_candidate_with_in<F, R>(
+    env_path: Option<&OsStr>,
+    classify: &mut F,
+) -> Option<(Box<Path>, R)>
+where
+    F: FnMut(&Path) -> Option<R>,
+{
+    let mut seen = std::collections::HashSet::with_capacity(10);
+
     for name in ["bash", "sh"] {
-        if let Some(path) = find_binary_on_path(name) {
-            let path = normalize_path(path.as_ref());
-            if let Some(r) = classify(path.as_ref()) {
-                return Some((path, r));
+        if let Some(shell_path) = find_binary_on_path_in(name, env_path) {
+            if let Some(result) = classify_shell_candidate(classify, &mut seen, shell_path) {
+                return Some(result);
             }
         }
     }
+
     for candidate in SHELL_CANDIDATES {
-        let path = PathBuf::from(candidate);
-        if path.is_file() {
-            let path = normalize_path(&path);
-            if let Some(r) = classify(path.as_ref()) {
-                return Some((path, r));
+        let candidate_path = PathBuf::from(candidate);
+        if candidate_path.is_file() {
+            if let Some(result) =
+                classify_shell_candidate(classify, &mut seen, candidate_path.into_boxed_path())
+            {
+                return Some(result);
             }
         }
     }
+
     None
 }
 
-/// Returns any available host shell (`bash` preferred, then `sh`).
-pub(crate) fn resolve_host_shell() -> Option<Box<Path>> {
-    first_shell_candidate_with(|_| Some(())).map(|(path, _)| path)
+fn classify_shell_candidate<F, R>(
+    classify: &mut F,
+    seen: &mut std::collections::HashSet<Box<Path>>,
+    path: Box<Path>,
+) -> Option<(Box<Path>, R)>
+where
+    F: FnMut(&Path) -> Option<R>,
+{
+    let path = normalize_path(path.as_ref());
+    if !seen.insert(path.clone()) {
+        return None;
+    }
+    classify(path.as_ref()).map(|result| (path, result))
+}
+
+fn resolve_host_shell_in(path: Option<&OsStr>) -> Option<Box<Path>> {
+    first_shell_candidate_with_in(path, &mut |_| Some(())).map(|(path, _)| path)
 }
 
 fn probe_backend() -> LinuxBwrapBackend {
@@ -157,7 +184,7 @@ fn probe_backend() -> LinuxBwrapBackend {
         }
     }
 
-    let backend = probe_backend_uncached();
+    let backend = probe_backend_uncached(path.as_deref());
     *cache.write() = Some((path, backend.clone()));
     backend
 }
@@ -166,31 +193,14 @@ fn probe_backend() -> LinuxBwrapBackend {
 ///
 /// The probe binds the host root read-only and runs a tiny shell command. That
 /// checks both namespace support and shell visibility on FHS and Nix systems.
-fn probe_backend_uncached() -> LinuxBwrapBackend {
-    let Some(bwrap) = find_binary_on_path("bwrap") else {
+fn probe_backend_uncached(path: Option<&OsStr>) -> LinuxBwrapBackend {
+    let Some(bwrap) = find_binary_on_path_in("bwrap", path) else {
         return LinuxBwrapBackend::MissingBinary {
             reason: Box::from("`bwrap` was not found on PATH"),
         };
     };
 
-    let version = Command::new(bwrap.as_os_str())
-        .arg("--version")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .output();
-    let Ok(version) = version else {
-        return LinuxBwrapBackend::MissingBinary {
-            reason: format!("failed to execute {}", bwrap.display()).into_boxed_str(),
-        };
-    };
-    if !version.status.success() {
-        return LinuxBwrapBackend::Unusable {
-            reason: probe_failure_reason(&version, "`bwrap --version` failed"),
-        };
-    }
-
-    let Some(shell) = resolve_host_shell() else {
+    let Some(shell) = resolve_host_shell_in(path) else {
         return LinuxBwrapBackend::Unusable {
             reason: Box::from("no usable host shell (`bash` or `sh`) was found"),
         };
@@ -257,6 +267,11 @@ mod tests {
     use serial_test::serial;
     use tempfile::TempDir;
 
+    /// Searches `PATH` directories for a file named `name` and returns the first match.
+    fn find_binary_on_path(name: &str) -> Option<Box<Path>> {
+        find_binary_on_path_in(name, env::var_os("PATH").as_deref())
+    }
+
     // These tests swap PATH and exercise a process-wide availability cache, so
     // cases that probe `bwrap` run serially to avoid cross-test contamination.
 
@@ -298,14 +313,6 @@ mod tests {
         // Make `bwrap` look installed, then fail the "can it sandbox?" probe.
         let script = format!(
             r#"#!/bin/sh
-# Handle --version probe
-for arg in "$@"; do
-    if [ "$arg" = "--version" ]; then
-        echo "bubblewrap 0.8.0"
-        exit 0
-    fi
-done
-# Fail the "can it sandbox?" probe
 echo "{}" >&2
 exit 1
 "#,

--- a/src/llm-coding-tools-bubblewrap/src/probe.rs
+++ b/src/llm-coding-tools-bubblewrap/src/probe.rs
@@ -92,6 +92,7 @@ fn profile_name(preset: Option<Preset>) -> &'static str {
     }
 }
 
+#[inline]
 fn find_binary_on_path_in(name: &str, path: Option<&OsStr>) -> Option<Box<Path>> {
     let path = path?;
     for dir in env::split_paths(path) {
@@ -149,6 +150,7 @@ where
     None
 }
 
+#[inline]
 fn classify_shell_candidate<F, R>(
     classify: &mut F,
     seen: &mut HashSet<Box<Path>>,
@@ -164,6 +166,7 @@ where
     classify(path.as_ref()).map(|result| (path, result))
 }
 
+#[inline]
 fn resolve_host_shell_in(path: Option<&OsStr>) -> Option<Box<Path>> {
     first_shell_candidate_with_in(path, &mut |_| Some(())).map(|(path, _)| path)
 }

--- a/src/llm-coding-tools-bubblewrap/src/profile/types.rs
+++ b/src/llm-coding-tools-bubblewrap/src/profile/types.rs
@@ -468,6 +468,10 @@ impl Profile {
         )))
     }
 
+    /// Returns true only for exact path matches against prevalidated directories:
+    /// workspace(), synthetic_home(), cache_root() (when mount_cache_root()),
+    /// TmpBacking::BindHost host_dir, and entries in read_only_mounts() and read_write_mounts().
+    #[inline]
     pub(crate) fn is_prevalidated_workdir(&self, workdir: &Path) -> bool {
         workdir == self.workspace()
             || workdir == self.synthetic_home()

--- a/src/llm-coding-tools-bubblewrap/src/profile/types.rs
+++ b/src/llm-coding-tools-bubblewrap/src/profile/types.rs
@@ -468,6 +468,21 @@ impl Profile {
         )))
     }
 
+    pub(crate) fn is_prevalidated_workdir(&self, workdir: &Path) -> bool {
+        workdir == self.workspace()
+            || workdir == self.synthetic_home()
+            || (self.mount_cache_root() && workdir == self.cache_root())
+            || matches!(self.tmp_backing(), TmpBacking::BindHost(host_dir) if workdir == host_dir.as_ref())
+            || self
+                .read_only_mounts()
+                .iter()
+                .any(|mount| workdir == mount.as_ref())
+            || self
+                .read_write_mounts()
+                .iter()
+                .any(|mount| workdir == mount.as_ref())
+    }
+
     fn sandbox_layout(&self) -> SandboxLayout<'_> {
         SandboxLayout {
             workspace: self.workspace(),
@@ -540,5 +555,51 @@ mod tests {
             Cow::Borrowed(mapped) => panic!("expected owned path, got {}", mapped.display()),
             Cow::Owned(mapped) => assert_eq!(mapped, Path::new("/workspace/subdir")),
         }
+    }
+
+    #[test]
+    fn is_prevalidated_workdir_accepts_exact_profile_owned_roots() {
+        let profile = Profile {
+            preset: None,
+            workspace: Box::from(Path::new("/host/workspace")),
+            workspace_dest: Box::from(Path::new("/workspace")),
+            synthetic_home: Box::from(Path::new("/host/home")),
+            synthetic_home_dest: Box::from(Path::new("/home/sandbox")),
+            cache_root: Box::from(Path::new("/host/cache")),
+            tmp_backing: TmpBacking::BindHost(Box::from(Path::new("/host/tmp"))),
+            mount_cache_root: true,
+            compat_symlinks: Arc::new([]),
+            read_only_mounts: Arc::from([Box::from(Path::new("/host/ro"))]),
+            read_write_mounts: Arc::from([Box::from(Path::new("/host/rw"))]),
+            tmpfs_overlays: Arc::new([]),
+            file_overlays: Arc::new([]),
+            credential_file_mounts: Arc::new([]),
+            read_only_host_rootfs: false,
+            network_policy: NetworkPolicy::Disabled,
+            clear_env: false,
+            default_env: Arc::new([]),
+            extra_env: Arc::new([]),
+            availability: Availability::Unknown,
+            bwrap_program: Arc::from(Box::from(Path::new("/usr/bin/bwrap"))),
+            shell: Box::from(Path::new("/bin/sh")),
+            static_args: Arc::<[OsString]>::from([]),
+        };
+
+        assert!(profile.is_prevalidated_workdir(Path::new("/host/workspace")));
+        assert!(profile.is_prevalidated_workdir(Path::new("/host/home")));
+        assert!(profile.is_prevalidated_workdir(Path::new("/host/cache")));
+        assert!(profile.is_prevalidated_workdir(Path::new("/host/tmp")));
+        assert!(profile.is_prevalidated_workdir(Path::new("/host/ro")));
+        assert!(profile.is_prevalidated_workdir(Path::new("/host/rw")));
+    }
+
+    #[test]
+    fn is_prevalidated_workdir_rejects_nested_or_unmounted_paths() {
+        let profile = profile_with_workspace_dest("/workspace");
+
+        assert!(!profile.is_prevalidated_workdir(Path::new("/host/workspace/subdir")));
+        assert!(!profile.is_prevalidated_workdir(Path::new("/host/home/subdir")));
+        assert!(!profile.is_prevalidated_workdir(Path::new("/host/cache/subdir")));
+        assert!(!profile.is_prevalidated_workdir(Path::new("/outside")));
     }
 }

--- a/src/llm-coding-tools-bubblewrap/src/wrap/command.rs
+++ b/src/llm-coding-tools-bubblewrap/src/wrap/command.rs
@@ -62,7 +62,11 @@ fn resolve_sandbox_cwd<'a>(
     profile: &'a Profile,
     workdir: Option<&'a Path>,
 ) -> Result<Cow<'a, Path>, LinuxBwrapError> {
-    validate_workdir(workdir)?;
+    if let Some(dir) = workdir {
+        if !profile.is_prevalidated_workdir(dir) {
+            validate_workdir(Some(dir))?;
+        }
+    }
     profile.map_workdir_to_sandbox(workdir)
 }
 

--- a/src/llm-coding-tools-core/src/tools/bash/blocking_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/bash/blocking_impl.rs
@@ -1,8 +1,9 @@
 //! Blocking shell command execution.
 
 use super::{
-    timeout_error_with_kill_failure, timeout_message_with_buffered_output, validate_workdir,
-    BashExecutionMode, BashOutput, PIPE_BUFFER_CAPACITY,
+    string_from_utf8_or_lossy, timeout_error_with_kill_failure,
+    timeout_message_with_buffered_output, validate_workdir, BashExecutionMode, BashOutput,
+    PIPE_BUFFER_CAPACITY,
 };
 use crate::error::{ToolError, ToolResult};
 #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
@@ -13,6 +14,11 @@ use std::path::Path;
 use std::process::Stdio;
 use std::thread;
 use std::time::{Duration, Instant};
+
+/// Initial sleep between non-blocking wait polls.
+const INITIAL_POLL_INTERVAL_MS: u64 = 1;
+/// Upper bound for wait poll backoff.
+const MAX_POLL_INTERVAL_MS: u64 = 10;
 
 enum WaitOutcome {
     Exited(std::process::ExitStatus),
@@ -96,19 +102,24 @@ pub(in crate::tools::bash) fn run_wrapped_command(
     });
 
     let start = Instant::now();
+    let mut poll_interval_ms = INITIAL_POLL_INTERVAL_MS;
 
     // Poll for completion with timeout.
     let wait_outcome = loop {
         match child.try_wait() {
             Ok(Some(status)) => break WaitOutcome::Exited(status),
             Ok(None) => {
-                if start.elapsed() >= timeout {
+                let elapsed = start.elapsed();
+                if elapsed >= timeout {
                     // Kill entire process tree via Job Object (Windows) or process group (Unix)
                     break WaitOutcome::TimedOut {
                         kill_error: child.kill().err(),
                     };
                 }
-                thread::sleep(Duration::from_millis(10));
+
+                let remaining = timeout.saturating_sub(elapsed);
+                thread::sleep(remaining.min(Duration::from_millis(poll_interval_ms)));
+                poll_interval_ms = (poll_interval_ms << 1).min(MAX_POLL_INTERVAL_MS);
             }
             Err(e) => break WaitOutcome::WaitError(e),
         }
@@ -126,8 +137,8 @@ pub(in crate::tools::bash) fn run_wrapped_command(
     match wait_outcome {
         WaitOutcome::Exited(status) => Ok(BashOutput {
             exit_code: status.code(),
-            stdout: String::from_utf8_lossy(&stdout_data).into_owned(),
-            stderr: String::from_utf8_lossy(&stderr_data).into_owned(),
+            stdout: string_from_utf8_or_lossy(stdout_data),
+            stderr: string_from_utf8_or_lossy(stderr_data),
         }),
         WaitOutcome::TimedOut { kill_error } => Err(timeout_error_with_kill_failure(
             timeout_message_with_buffered_output(timeout, &stdout_data, &stderr_data),

--- a/src/llm-coding-tools-core/src/tools/bash/mod.rs
+++ b/src/llm-coding-tools-core/src/tools/bash/mod.rs
@@ -35,6 +35,7 @@ use crate::error::{ToolError, ToolResult};
 use crate::ToolOutput;
 use core::fmt::Write;
 use serde::Serialize;
+use std::borrow::Cow;
 use std::path::Path;
 use std::time::Duration;
 #[cfg(feature = "tokio")]
@@ -64,6 +65,17 @@ pub enum BashExecutionMode {
 /// Default buffer capacity for stdout/stderr pipe reads.
 /// 32KB covers typical command output without reallocations.
 const PIPE_BUFFER_CAPACITY: usize = 32 * 1024;
+
+#[inline]
+fn string_from_utf8_or_lossy(bytes: Vec<u8>) -> String {
+    match String::from_utf8(bytes) {
+        Ok(text) => text,
+        Err(error) => match String::from_utf8_lossy(&error.into_bytes()) {
+            Cow::Borrowed(text) => text.to_owned(),
+            Cow::Owned(text) => text,
+        },
+    }
+}
 
 #[inline]
 fn timeout_message_with_buffered_output(

--- a/src/llm-coding-tools-core/src/tools/bash/tokio_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/bash/tokio_impl.rs
@@ -56,7 +56,7 @@ where
 fn take_pipe_buffer(buffer: SharedPipeBuffer) -> Vec<u8> {
     match Arc::try_unwrap(buffer) {
         Ok(mutex) => mutex.into_inner(),
-        Err(shared) => std::mem::take(&mut *shared.lock()),
+        Err(shared) => core::mem::take(&mut *shared.lock()),
     }
 }
 

--- a/src/llm-coding-tools-core/src/tools/bash/tokio_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/bash/tokio_impl.rs
@@ -1,8 +1,9 @@
 //! Tokio-based async shell command execution.
 
 use super::{
-    timeout_error_with_kill_failure, timeout_message_with_buffered_output, validate_workdir,
-    BashExecutionMode, BashOutput, PIPE_BUFFER_CAPACITY,
+    string_from_utf8_or_lossy, timeout_error_with_kill_failure,
+    timeout_message_with_buffered_output, validate_workdir, BashExecutionMode, BashOutput,
+    PIPE_BUFFER_CAPACITY,
 };
 use crate::error::{ToolError, ToolResult};
 #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
@@ -55,7 +56,7 @@ where
 fn take_pipe_buffer(buffer: SharedPipeBuffer) -> Vec<u8> {
     match Arc::try_unwrap(buffer) {
         Ok(mutex) => mutex.into_inner(),
-        Err(shared) => shared.lock().clone(),
+        Err(shared) => std::mem::take(&mut *shared.lock()),
     }
 }
 
@@ -165,8 +166,8 @@ pub(in crate::tools::bash) async fn run_wrapped_command(
 
             Ok(BashOutput {
                 exit_code: status.code(),
-                stdout: String::from_utf8_lossy(&stdout_data).into_owned(),
-                stderr: String::from_utf8_lossy(&stderr_data).into_owned(),
+                stdout: string_from_utf8_or_lossy(stdout_data),
+                stderr: string_from_utf8_or_lossy(stderr_data),
             })
         }
         None => {

--- a/src/llm-coding-tools-serdesai/src/absolute/edit.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/edit.rs
@@ -28,46 +28,31 @@ struct EditArgs {
 }
 
 /// Tool for making exact string replacements in files.
-#[derive(Debug, Clone, Default)]
-pub struct EditTool;
+#[derive(Debug, Clone)]
+pub struct EditTool {
+    definition: ToolDefinition,
+}
+
+impl Default for EditTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl EditTool {
     /// Creates a new edit tool instance.
     #[inline]
     pub fn new() -> Self {
-        Self
+        Self {
+            definition: build_definition(),
+        }
     }
 }
 
 #[async_trait]
 impl<Deps: Send + Sync> Tool<Deps> for EditTool {
     fn definition(&self) -> ToolDefinition {
-        let schema = SchemaBuilder::new()
-            .string(
-                edit_meta::param::FILE_PATH_ABSOLUTE.name,
-                edit_meta::param::FILE_PATH_ABSOLUTE.description,
-                edit_meta::param::FILE_PATH_ABSOLUTE.required,
-            )
-            .string(
-                edit_meta::param::OLD_STRING.name,
-                edit_meta::param::OLD_STRING.description,
-                edit_meta::param::OLD_STRING.required,
-            )
-            .string(
-                edit_meta::param::NEW_STRING.name,
-                edit_meta::param::NEW_STRING.description,
-                edit_meta::param::NEW_STRING.required,
-            )
-            .boolean(
-                edit_meta::param::REPLACE_ALL.name,
-                edit_meta::param::REPLACE_ALL.description,
-                edit_meta::param::REPLACE_ALL.required,
-            )
-            .build()
-            .expect("schema build should not fail");
-
-        ToolDefinition::new(edit_meta::NAME, edit_meta::description::ABSOLUTE)
-            .with_parameters(schema)
+        self.definition.clone()
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
@@ -95,6 +80,40 @@ impl ToolContext for EditTool {
         ToolPrompt::Edit {
             path_mode: PathMode::Absolute,
         }
+    }
+}
+
+fn build_definition() -> ToolDefinition {
+    let schema = SchemaBuilder::new()
+        .string(
+            edit_meta::param::FILE_PATH_ABSOLUTE.name,
+            edit_meta::param::FILE_PATH_ABSOLUTE.description,
+            edit_meta::param::FILE_PATH_ABSOLUTE.required,
+        )
+        .string(
+            edit_meta::param::OLD_STRING.name,
+            edit_meta::param::OLD_STRING.description,
+            edit_meta::param::OLD_STRING.required,
+        )
+        .string(
+            edit_meta::param::NEW_STRING.name,
+            edit_meta::param::NEW_STRING.description,
+            edit_meta::param::NEW_STRING.required,
+        )
+        .boolean(
+            edit_meta::param::REPLACE_ALL.name,
+            edit_meta::param::REPLACE_ALL.description,
+            edit_meta::param::REPLACE_ALL.required,
+        )
+        .build()
+        .expect("schema build should not fail");
+
+    ToolDefinition {
+        name: edit_meta::NAME.to_owned(),
+        description: edit_meta::description::ABSOLUTE.to_owned(),
+        parameters_json_schema: schema,
+        strict: None,
+        outer_typed_dict_key: None,
     }
 }
 

--- a/src/llm-coding-tools-serdesai/src/absolute/glob.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/glob.rs
@@ -24,36 +24,31 @@ struct GlobArgs {
 /// Tool for finding files matching glob patterns.
 ///
 /// Respects `.gitignore` and returns paths sorted by modification time (newest first).
-#[derive(Debug, Clone, Default)]
-pub struct GlobTool;
+#[derive(Debug, Clone)]
+pub struct GlobTool {
+    definition: ToolDefinition,
+}
+
+impl Default for GlobTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl GlobTool {
     /// Creates a new glob tool instance.
     #[inline]
     pub fn new() -> Self {
-        Self
+        Self {
+            definition: build_definition(),
+        }
     }
 }
 
 #[async_trait]
 impl<Deps: Send + Sync> Tool<Deps> for GlobTool {
     fn definition(&self) -> ToolDefinition {
-        let schema = SchemaBuilder::new()
-            .string(
-                glob_meta::param::PATTERN.name,
-                glob_meta::param::PATTERN.description,
-                glob_meta::param::PATTERN.required,
-            )
-            .string(
-                glob_meta::param::PATH_ABSOLUTE.name,
-                glob_meta::param::PATH_ABSOLUTE.description,
-                glob_meta::param::PATH_ABSOLUTE.required,
-            )
-            .build()
-            .expect("schema build should not fail");
-
-        ToolDefinition::new(glob_meta::NAME, glob_meta::description::ABSOLUTE)
-            .with_parameters(schema)
+        self.definition.clone()
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
@@ -77,6 +72,30 @@ impl ToolContext for GlobTool {
         ToolPrompt::Glob {
             path_mode: PathMode::Absolute,
         }
+    }
+}
+
+fn build_definition() -> ToolDefinition {
+    let schema = SchemaBuilder::new()
+        .string(
+            glob_meta::param::PATTERN.name,
+            glob_meta::param::PATTERN.description,
+            glob_meta::param::PATTERN.required,
+        )
+        .string(
+            glob_meta::param::PATH_ABSOLUTE.name,
+            glob_meta::param::PATH_ABSOLUTE.description,
+            glob_meta::param::PATH_ABSOLUTE.required,
+        )
+        .build()
+        .expect("schema build should not fail");
+
+    ToolDefinition {
+        name: glob_meta::NAME.to_owned(),
+        description: glob_meta::description::ABSOLUTE.to_owned(),
+        parameters_json_schema: schema,
+        strict: None,
+        outer_typed_dict_key: None,
     }
 }
 

--- a/src/llm-coding-tools-serdesai/src/absolute/grep.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/grep.rs
@@ -32,51 +32,31 @@ struct GrepArgs {
 /// The `LINE_NUMBERS` const generic controls output format:
 /// - `true` (default): Lines prefixed with `L{number}: `
 /// - `false`: Raw matching lines
-#[derive(Debug, Clone, Default)]
-pub struct GrepTool<const LINE_NUMBERS: bool = true>;
+#[derive(Debug, Clone)]
+pub struct GrepTool<const LINE_NUMBERS: bool = true> {
+    definition: ToolDefinition,
+}
+
+impl<const LINE_NUMBERS: bool> Default for GrepTool<LINE_NUMBERS> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl<const LINE_NUMBERS: bool> GrepTool<LINE_NUMBERS> {
     /// Creates a new grep tool instance.
     #[inline]
     pub fn new() -> Self {
-        Self
+        Self {
+            definition: build_definition::<LINE_NUMBERS>(),
+        }
     }
 }
 
 #[async_trait]
 impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_NUMBERS> {
     fn definition(&self) -> ToolDefinition {
-        let schema = SchemaBuilder::new()
-            .string(
-                grep_meta::param::PATTERN.name,
-                grep_meta::param::PATTERN.description,
-                grep_meta::param::PATTERN.required,
-            )
-            .string(
-                grep_meta::param::PATH_ABSOLUTE.name,
-                grep_meta::param::PATH_ABSOLUTE.description,
-                grep_meta::param::PATH_ABSOLUTE.required,
-            )
-            .string(
-                grep_meta::param::INCLUDE.name,
-                grep_meta::param::INCLUDE.description,
-                grep_meta::param::INCLUDE.required,
-            )
-            .integer_constrained(
-                grep_meta::param::LIMIT.name,
-                grep_meta::param::LIMIT.description,
-                grep_meta::param::LIMIT.required,
-                Some(1),
-                Some(grep_meta::MAX_LIMIT as i64),
-            )
-            .build()
-            .expect("schema build should not fail");
-
-        ToolDefinition::new(
-            grep_meta::NAME,
-            grep_meta::description::absolute(LINE_NUMBERS),
-        )
-        .with_parameters(schema)
+        self.definition.clone()
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
@@ -135,6 +115,42 @@ impl<const LINE_NUMBERS: bool> ToolContext for GrepTool<LINE_NUMBERS> {
             path_mode: PathMode::Absolute,
             line_numbers: LINE_NUMBERS,
         }
+    }
+}
+
+fn build_definition<const LINE_NUMBERS: bool>() -> ToolDefinition {
+    let schema = SchemaBuilder::new()
+        .string(
+            grep_meta::param::PATTERN.name,
+            grep_meta::param::PATTERN.description,
+            grep_meta::param::PATTERN.required,
+        )
+        .string(
+            grep_meta::param::PATH_ABSOLUTE.name,
+            grep_meta::param::PATH_ABSOLUTE.description,
+            grep_meta::param::PATH_ABSOLUTE.required,
+        )
+        .string(
+            grep_meta::param::INCLUDE.name,
+            grep_meta::param::INCLUDE.description,
+            grep_meta::param::INCLUDE.required,
+        )
+        .integer_constrained(
+            grep_meta::param::LIMIT.name,
+            grep_meta::param::LIMIT.description,
+            grep_meta::param::LIMIT.required,
+            Some(1),
+            Some(grep_meta::MAX_LIMIT as i64),
+        )
+        .build()
+        .expect("schema build should not fail");
+
+    ToolDefinition {
+        name: grep_meta::NAME.to_owned(),
+        description: grep_meta::description::absolute(LINE_NUMBERS).to_owned(),
+        parameters_json_schema: schema,
+        strict: None,
+        outer_typed_dict_key: None,
     }
 }
 

--- a/src/llm-coding-tools-serdesai/src/absolute/read.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/read.rs
@@ -29,48 +29,31 @@ struct ReadArgs {
 /// The `LINE_NUMBERS` const generic controls output format:
 /// - `true` (default): Lines prefixed with `L{number}: `
 /// - `false`: Raw file content
-#[derive(Debug, Clone, Default)]
-pub struct ReadTool<const LINE_NUMBERS: bool = true>;
+#[derive(Debug, Clone)]
+pub struct ReadTool<const LINE_NUMBERS: bool = true> {
+    definition: ToolDefinition,
+}
+
+impl<const LINE_NUMBERS: bool> Default for ReadTool<LINE_NUMBERS> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl<const LINE_NUMBERS: bool> ReadTool<LINE_NUMBERS> {
     /// Creates a new read tool instance.
     #[inline]
     pub fn new() -> Self {
-        Self
+        Self {
+            definition: build_definition::<LINE_NUMBERS>(),
+        }
     }
 }
 
 #[async_trait]
 impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for ReadTool<LINE_NUMBERS> {
     fn definition(&self) -> ToolDefinition {
-        let schema = SchemaBuilder::new()
-            .string(
-                read_meta::param::FILE_PATH_ABSOLUTE.name,
-                read_meta::param::FILE_PATH_ABSOLUTE.description,
-                read_meta::param::FILE_PATH_ABSOLUTE.required,
-            )
-            .integer_constrained(
-                read_meta::param::OFFSET.name,
-                read_meta::param::OFFSET.description,
-                read_meta::param::OFFSET.required,
-                Some(1),
-                None,
-            )
-            .integer_constrained(
-                read_meta::param::LIMIT.name,
-                read_meta::param::LIMIT.description,
-                read_meta::param::LIMIT.required,
-                Some(1),
-                None,
-            )
-            .build()
-            .expect("schema build should not fail");
-
-        ToolDefinition::new(
-            read_meta::NAME,
-            read_meta::description::absolute(LINE_NUMBERS),
-        )
-        .with_parameters(schema)
+        self.definition.clone()
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
@@ -93,6 +76,39 @@ impl<const LINE_NUMBERS: bool> ToolContext for ReadTool<LINE_NUMBERS> {
             path_mode: PathMode::Absolute,
             line_numbers: LINE_NUMBERS,
         }
+    }
+}
+
+fn build_definition<const LINE_NUMBERS: bool>() -> ToolDefinition {
+    let schema = SchemaBuilder::new()
+        .string(
+            read_meta::param::FILE_PATH_ABSOLUTE.name,
+            read_meta::param::FILE_PATH_ABSOLUTE.description,
+            read_meta::param::FILE_PATH_ABSOLUTE.required,
+        )
+        .integer_constrained(
+            read_meta::param::OFFSET.name,
+            read_meta::param::OFFSET.description,
+            read_meta::param::OFFSET.required,
+            Some(1),
+            None,
+        )
+        .integer_constrained(
+            read_meta::param::LIMIT.name,
+            read_meta::param::LIMIT.description,
+            read_meta::param::LIMIT.required,
+            Some(1),
+            None,
+        )
+        .build()
+        .expect("schema build should not fail");
+
+    ToolDefinition {
+        name: read_meta::NAME.to_owned(),
+        description: read_meta::description::absolute(LINE_NUMBERS).to_owned(),
+        parameters_json_schema: schema,
+        strict: None,
+        outer_typed_dict_key: None,
     }
 }
 

--- a/src/llm-coding-tools-serdesai/src/absolute/write.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/write.rs
@@ -23,36 +23,31 @@ struct WriteArgs {
 /// Tool for writing content to files.
 ///
 /// Creates parent directories if needed and overwrites existing files.
-#[derive(Debug, Clone, Default)]
-pub struct WriteTool;
+#[derive(Debug, Clone)]
+pub struct WriteTool {
+    definition: ToolDefinition,
+}
+
+impl Default for WriteTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl WriteTool {
     /// Creates a new write tool instance.
     #[inline]
     pub fn new() -> Self {
-        Self
+        Self {
+            definition: build_definition(),
+        }
     }
 }
 
 #[async_trait]
 impl<Deps: Send + Sync> Tool<Deps> for WriteTool {
     fn definition(&self) -> ToolDefinition {
-        let schema = SchemaBuilder::new()
-            .string(
-                write_meta::param::FILE_PATH_ABSOLUTE.name,
-                write_meta::param::FILE_PATH_ABSOLUTE.description,
-                write_meta::param::FILE_PATH_ABSOLUTE.required,
-            )
-            .string(
-                write_meta::param::CONTENT.name,
-                write_meta::param::CONTENT.description,
-                write_meta::param::CONTENT.required,
-            )
-            .build()
-            .expect("schema build should not fail");
-
-        ToolDefinition::new(write_meta::NAME, write_meta::description::ABSOLUTE)
-            .with_parameters(schema)
+        self.definition.clone()
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
@@ -74,6 +69,30 @@ impl ToolContext for WriteTool {
         ToolPrompt::Write {
             path_mode: PathMode::Absolute,
         }
+    }
+}
+
+fn build_definition() -> ToolDefinition {
+    let schema = SchemaBuilder::new()
+        .string(
+            write_meta::param::FILE_PATH_ABSOLUTE.name,
+            write_meta::param::FILE_PATH_ABSOLUTE.description,
+            write_meta::param::FILE_PATH_ABSOLUTE.required,
+        )
+        .string(
+            write_meta::param::CONTENT.name,
+            write_meta::param::CONTENT.description,
+            write_meta::param::CONTENT.required,
+        )
+        .build()
+        .expect("schema build should not fail");
+
+    ToolDefinition {
+        name: write_meta::NAME.to_owned(),
+        description: write_meta::description::ABSOLUTE.to_owned(),
+        parameters_json_schema: schema,
+        strict: None,
+        outer_typed_dict_key: None,
     }
 }
 

--- a/src/llm-coding-tools-serdesai/src/allowed/edit.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/edit.rs
@@ -30,6 +30,7 @@ struct EditArgs {
 /// Tool for making exact string replacements in files within allowed directories.
 #[derive(Debug, Clone)]
 pub struct EditTool {
+    definition: ToolDefinition,
     resolver: AllowedPathResolver,
 }
 
@@ -40,39 +41,17 @@ impl EditTool {
     ///
     /// [`ReadTool::new`]: super::ReadTool::new
     pub fn new(resolver: AllowedPathResolver) -> Self {
-        Self { resolver }
+        Self {
+            definition: build_definition(),
+            resolver,
+        }
     }
 }
 
 #[async_trait]
 impl<Deps: Send + Sync> Tool<Deps> for EditTool {
     fn definition(&self) -> ToolDefinition {
-        let schema = SchemaBuilder::new()
-            .string(
-                edit_meta::param::FILE_PATH_ALLOWED.name,
-                edit_meta::param::FILE_PATH_ALLOWED.description,
-                edit_meta::param::FILE_PATH_ALLOWED.required,
-            )
-            .string(
-                edit_meta::param::OLD_STRING.name,
-                edit_meta::param::OLD_STRING.description,
-                edit_meta::param::OLD_STRING.required,
-            )
-            .string(
-                edit_meta::param::NEW_STRING.name,
-                edit_meta::param::NEW_STRING.description,
-                edit_meta::param::NEW_STRING.required,
-            )
-            .boolean(
-                edit_meta::param::REPLACE_ALL.name,
-                edit_meta::param::REPLACE_ALL.description,
-                edit_meta::param::REPLACE_ALL.required,
-            )
-            .build()
-            .expect("schema build should not fail");
-
-        ToolDefinition::new(edit_meta::NAME, edit_meta::description::ALLOWED)
-            .with_parameters(schema)
+        self.definition.clone()
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
@@ -99,6 +78,40 @@ impl ToolContext for EditTool {
         ToolPrompt::Edit {
             path_mode: PathMode::Allowed,
         }
+    }
+}
+
+fn build_definition() -> ToolDefinition {
+    let schema = SchemaBuilder::new()
+        .string(
+            edit_meta::param::FILE_PATH_ALLOWED.name,
+            edit_meta::param::FILE_PATH_ALLOWED.description,
+            edit_meta::param::FILE_PATH_ALLOWED.required,
+        )
+        .string(
+            edit_meta::param::OLD_STRING.name,
+            edit_meta::param::OLD_STRING.description,
+            edit_meta::param::OLD_STRING.required,
+        )
+        .string(
+            edit_meta::param::NEW_STRING.name,
+            edit_meta::param::NEW_STRING.description,
+            edit_meta::param::NEW_STRING.required,
+        )
+        .boolean(
+            edit_meta::param::REPLACE_ALL.name,
+            edit_meta::param::REPLACE_ALL.description,
+            edit_meta::param::REPLACE_ALL.required,
+        )
+        .build()
+        .expect("schema build should not fail");
+
+    ToolDefinition {
+        name: edit_meta::NAME.to_owned(),
+        description: edit_meta::description::ALLOWED.to_owned(),
+        parameters_json_schema: schema,
+        strict: None,
+        outer_typed_dict_key: None,
     }
 }
 

--- a/src/llm-coding-tools-serdesai/src/allowed/glob.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/glob.rs
@@ -24,6 +24,7 @@ struct GlobArgs {
 /// Tool for finding files matching glob patterns within allowed directories.
 #[derive(Debug, Clone)]
 pub struct GlobTool {
+    definition: ToolDefinition,
     resolver: AllowedPathResolver,
 }
 
@@ -34,29 +35,17 @@ impl GlobTool {
     ///
     /// [`ReadTool::new`]: super::ReadTool::new
     pub fn new(resolver: AllowedPathResolver) -> Self {
-        Self { resolver }
+        Self {
+            definition: build_definition(),
+            resolver,
+        }
     }
 }
 
 #[async_trait]
 impl<Deps: Send + Sync> Tool<Deps> for GlobTool {
     fn definition(&self) -> ToolDefinition {
-        let schema = SchemaBuilder::new()
-            .string(
-                glob_meta::param::PATTERN.name,
-                glob_meta::param::PATTERN.description,
-                glob_meta::param::PATTERN.required,
-            )
-            .string(
-                glob_meta::param::PATH_ALLOWED.name,
-                glob_meta::param::PATH_ALLOWED.description,
-                glob_meta::param::PATH_ALLOWED.required,
-            )
-            .build()
-            .expect("schema build should not fail");
-
-        ToolDefinition::new(glob_meta::NAME, glob_meta::description::ALLOWED)
-            .with_parameters(schema)
+        self.definition.clone()
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
@@ -78,6 +67,30 @@ impl ToolContext for GlobTool {
         ToolPrompt::Glob {
             path_mode: PathMode::Allowed,
         }
+    }
+}
+
+fn build_definition() -> ToolDefinition {
+    let schema = SchemaBuilder::new()
+        .string(
+            glob_meta::param::PATTERN.name,
+            glob_meta::param::PATTERN.description,
+            glob_meta::param::PATTERN.required,
+        )
+        .string(
+            glob_meta::param::PATH_ALLOWED.name,
+            glob_meta::param::PATH_ALLOWED.description,
+            glob_meta::param::PATH_ALLOWED.required,
+        )
+        .build()
+        .expect("schema build should not fail");
+
+    ToolDefinition {
+        name: glob_meta::NAME.to_owned(),
+        description: glob_meta::description::ALLOWED.to_owned(),
+        parameters_json_schema: schema,
+        strict: None,
+        outer_typed_dict_key: None,
     }
 }
 

--- a/src/llm-coding-tools-serdesai/src/allowed/grep.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/grep.rs
@@ -30,6 +30,7 @@ struct GrepArgs {
 /// Tool for searching file contents within allowed directories.
 #[derive(Debug, Clone)]
 pub struct GrepTool<const LINE_NUMBERS: bool = true> {
+    definition: ToolDefinition,
     resolver: AllowedPathResolver,
 }
 
@@ -40,44 +41,17 @@ impl<const LINE_NUMBERS: bool> GrepTool<LINE_NUMBERS> {
     ///
     /// [`ReadTool::new`]: super::ReadTool::new
     pub fn new(resolver: AllowedPathResolver) -> Self {
-        Self { resolver }
+        Self {
+            definition: build_definition::<LINE_NUMBERS>(),
+            resolver,
+        }
     }
 }
 
 #[async_trait]
 impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_NUMBERS> {
     fn definition(&self) -> ToolDefinition {
-        let schema = SchemaBuilder::new()
-            .string(
-                grep_meta::param::PATTERN.name,
-                grep_meta::param::PATTERN.description,
-                grep_meta::param::PATTERN.required,
-            )
-            .string(
-                grep_meta::param::PATH_ALLOWED.name,
-                grep_meta::param::PATH_ALLOWED.description,
-                grep_meta::param::PATH_ALLOWED.required,
-            )
-            .string(
-                grep_meta::param::INCLUDE.name,
-                grep_meta::param::INCLUDE.description,
-                grep_meta::param::INCLUDE.required,
-            )
-            .integer_constrained(
-                grep_meta::param::LIMIT.name,
-                grep_meta::param::LIMIT.description,
-                grep_meta::param::LIMIT.required,
-                Some(1),
-                Some(grep_meta::MAX_LIMIT as i64),
-            )
-            .build()
-            .expect("schema build should not fail");
-
-        ToolDefinition::new(
-            grep_meta::NAME,
-            grep_meta::description::allowed(LINE_NUMBERS),
-        )
-        .with_parameters(schema)
+        self.definition.clone()
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
@@ -135,6 +109,42 @@ impl<const LINE_NUMBERS: bool> ToolContext for GrepTool<LINE_NUMBERS> {
             path_mode: PathMode::Allowed,
             line_numbers: LINE_NUMBERS,
         }
+    }
+}
+
+fn build_definition<const LINE_NUMBERS: bool>() -> ToolDefinition {
+    let schema = SchemaBuilder::new()
+        .string(
+            grep_meta::param::PATTERN.name,
+            grep_meta::param::PATTERN.description,
+            grep_meta::param::PATTERN.required,
+        )
+        .string(
+            grep_meta::param::PATH_ALLOWED.name,
+            grep_meta::param::PATH_ALLOWED.description,
+            grep_meta::param::PATH_ALLOWED.required,
+        )
+        .string(
+            grep_meta::param::INCLUDE.name,
+            grep_meta::param::INCLUDE.description,
+            grep_meta::param::INCLUDE.required,
+        )
+        .integer_constrained(
+            grep_meta::param::LIMIT.name,
+            grep_meta::param::LIMIT.description,
+            grep_meta::param::LIMIT.required,
+            Some(1),
+            Some(grep_meta::MAX_LIMIT as i64),
+        )
+        .build()
+        .expect("schema build should not fail");
+
+    ToolDefinition {
+        name: grep_meta::NAME.to_owned(),
+        description: grep_meta::description::allowed(LINE_NUMBERS).to_owned(),
+        parameters_json_schema: schema,
+        strict: None,
+        outer_typed_dict_key: None,
     }
 }
 

--- a/src/llm-coding-tools-serdesai/src/allowed/read.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/read.rs
@@ -29,6 +29,7 @@ struct ReadArgs {
 /// Restricts access to configured allowed directories.
 #[derive(Debug, Clone)]
 pub struct ReadTool<const LINE_NUMBERS: bool = true> {
+    definition: ToolDefinition,
     resolver: AllowedPathResolver,
 }
 
@@ -53,41 +54,17 @@ impl<const LINE_NUMBERS: bool> ReadTool<LINE_NUMBERS> {
     /// let edit = EditTool::new(resolver);
     /// ```
     pub fn new(resolver: AllowedPathResolver) -> Self {
-        Self { resolver }
+        Self {
+            definition: build_definition::<LINE_NUMBERS>(),
+            resolver,
+        }
     }
 }
 
 #[async_trait]
 impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for ReadTool<LINE_NUMBERS> {
     fn definition(&self) -> ToolDefinition {
-        let schema = SchemaBuilder::new()
-            .string(
-                read_meta::param::FILE_PATH_ALLOWED.name,
-                read_meta::param::FILE_PATH_ALLOWED.description,
-                read_meta::param::FILE_PATH_ALLOWED.required,
-            )
-            .integer_constrained(
-                read_meta::param::OFFSET.name,
-                read_meta::param::OFFSET.description,
-                read_meta::param::OFFSET.required,
-                Some(1),
-                None,
-            )
-            .integer_constrained(
-                read_meta::param::LIMIT.name,
-                read_meta::param::LIMIT.description,
-                read_meta::param::LIMIT.required,
-                Some(1),
-                None,
-            )
-            .build()
-            .expect("schema build should not fail");
-
-        ToolDefinition::new(
-            read_meta::NAME,
-            read_meta::description::allowed(LINE_NUMBERS),
-        )
-        .with_parameters(schema)
+        self.definition.clone()
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
@@ -109,6 +86,39 @@ impl<const LINE_NUMBERS: bool> ToolContext for ReadTool<LINE_NUMBERS> {
             path_mode: PathMode::Allowed,
             line_numbers: LINE_NUMBERS,
         }
+    }
+}
+
+fn build_definition<const LINE_NUMBERS: bool>() -> ToolDefinition {
+    let schema = SchemaBuilder::new()
+        .string(
+            read_meta::param::FILE_PATH_ALLOWED.name,
+            read_meta::param::FILE_PATH_ALLOWED.description,
+            read_meta::param::FILE_PATH_ALLOWED.required,
+        )
+        .integer_constrained(
+            read_meta::param::OFFSET.name,
+            read_meta::param::OFFSET.description,
+            read_meta::param::OFFSET.required,
+            Some(1),
+            None,
+        )
+        .integer_constrained(
+            read_meta::param::LIMIT.name,
+            read_meta::param::LIMIT.description,
+            read_meta::param::LIMIT.required,
+            Some(1),
+            None,
+        )
+        .build()
+        .expect("schema build should not fail");
+
+    ToolDefinition {
+        name: read_meta::NAME.to_owned(),
+        description: read_meta::description::allowed(LINE_NUMBERS).to_owned(),
+        parameters_json_schema: schema,
+        strict: None,
+        outer_typed_dict_key: None,
     }
 }
 

--- a/src/llm-coding-tools-serdesai/src/allowed/write.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/write.rs
@@ -22,6 +22,7 @@ struct WriteArgs {
 /// Tool for writing content to files within allowed directories.
 #[derive(Debug, Clone)]
 pub struct WriteTool {
+    definition: ToolDefinition,
     resolver: AllowedPathResolver,
 }
 
@@ -32,29 +33,17 @@ impl WriteTool {
     ///
     /// [`ReadTool::new`]: super::ReadTool::new
     pub fn new(resolver: AllowedPathResolver) -> Self {
-        Self { resolver }
+        Self {
+            definition: build_definition(),
+            resolver,
+        }
     }
 }
 
 #[async_trait]
 impl<Deps: Send + Sync> Tool<Deps> for WriteTool {
     fn definition(&self) -> ToolDefinition {
-        let schema = SchemaBuilder::new()
-            .string(
-                write_meta::param::FILE_PATH_ALLOWED.name,
-                write_meta::param::FILE_PATH_ALLOWED.description,
-                write_meta::param::FILE_PATH_ALLOWED.required,
-            )
-            .string(
-                write_meta::param::CONTENT.name,
-                write_meta::param::CONTENT.description,
-                write_meta::param::CONTENT.required,
-            )
-            .build()
-            .expect("schema build should not fail");
-
-        ToolDefinition::new(write_meta::NAME, write_meta::description::ALLOWED)
-            .with_parameters(schema)
+        self.definition.clone()
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
@@ -73,6 +62,30 @@ impl ToolContext for WriteTool {
         ToolPrompt::Write {
             path_mode: PathMode::Allowed,
         }
+    }
+}
+
+fn build_definition() -> ToolDefinition {
+    let schema = SchemaBuilder::new()
+        .string(
+            write_meta::param::FILE_PATH_ALLOWED.name,
+            write_meta::param::FILE_PATH_ALLOWED.description,
+            write_meta::param::FILE_PATH_ALLOWED.required,
+        )
+        .string(
+            write_meta::param::CONTENT.name,
+            write_meta::param::CONTENT.description,
+            write_meta::param::CONTENT.required,
+        )
+        .build()
+        .expect("schema build should not fail");
+
+    ToolDefinition {
+        name: write_meta::NAME.to_owned(),
+        description: write_meta::description::ALLOWED.to_owned(),
+        parameters_json_schema: schema,
+        strict: None,
+        outer_typed_dict_key: None,
     }
 }
 

--- a/src/llm-coding-tools-serdesai/src/bash.rs
+++ b/src/llm-coding-tools-serdesai/src/bash.rs
@@ -53,6 +53,7 @@ struct BashArgs {
 /// Uses bash on Unix, cmd on Windows.
 #[derive(Debug, Clone)]
 pub struct BashTool {
+    definition: ToolDefinition,
     /// Explicit execution mode for this tool instance.
     mode: BashExecutionMode, // ZST. 0 bytes when all optionals disabled.
     /// Default timeout for commands when not specified in args.
@@ -82,6 +83,7 @@ impl BashTool {
     /// to sandbox commands.
     pub fn host() -> Self {
         Self {
+            definition: build_definition(),
             mode: BashExecutionMode::Host,
             default_timeout: None,
             default_workdir: None,
@@ -140,31 +142,7 @@ impl BashTool {
 #[async_trait]
 impl<Deps: Send + Sync> Tool<Deps> for BashTool {
     fn definition(&self) -> ToolDefinition {
-        ToolDefinition::new(bash_meta::NAME, bash_meta::DESCRIPTION).with_parameters(
-            SchemaBuilder::new()
-                .string_constrained(
-                    bash_meta::param::COMMAND.name,
-                    bash_meta::param::COMMAND.description,
-                    bash_meta::param::COMMAND.required,
-                    Some(1),
-                    None,
-                    None,
-                )
-                .string(
-                    bash_meta::param::WORKDIR.name,
-                    bash_meta::param::WORKDIR.description,
-                    bash_meta::param::WORKDIR.required,
-                )
-                .integer_constrained(
-                    bash_meta::param::TIMEOUT_MS.name,
-                    bash_meta::param::TIMEOUT_MS.description,
-                    bash_meta::param::TIMEOUT_MS.required,
-                    Some(1),
-                    Some(bash_meta::MAX_TIMEOUT_MS as i64),
-                )
-                .build()
-                .expect("schema serialization should never fail"),
-        )
+        self.definition.clone()
     }
 
     /// Executes a shell command through the configured [`BashExecutionMode`].
@@ -240,6 +218,38 @@ impl ToolContext for BashTool {
             network_disabled: bash_prompt_network_disabled(&self.mode),
             sandboxed: bash_prompt_sandboxed(&self.mode),
         }
+    }
+}
+
+fn build_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: bash_meta::NAME.to_owned(),
+        description: bash_meta::DESCRIPTION.to_owned(),
+        parameters_json_schema: SchemaBuilder::new()
+            .string_constrained(
+                bash_meta::param::COMMAND.name,
+                bash_meta::param::COMMAND.description,
+                bash_meta::param::COMMAND.required,
+                Some(1),
+                None,
+                None,
+            )
+            .string(
+                bash_meta::param::WORKDIR.name,
+                bash_meta::param::WORKDIR.description,
+                bash_meta::param::WORKDIR.required,
+            )
+            .integer_constrained(
+                bash_meta::param::TIMEOUT_MS.name,
+                bash_meta::param::TIMEOUT_MS.description,
+                bash_meta::param::TIMEOUT_MS.required,
+                Some(1),
+                Some(bash_meta::MAX_TIMEOUT_MS as i64),
+            )
+            .build()
+            .expect("schema serialization should never fail"),
+        strict: None,
+        outer_typed_dict_key: None,
     }
 }
 

--- a/src/llm-coding-tools-serdesai/src/task/definition.rs
+++ b/src/llm-coding-tools-serdesai/src/task/definition.rs
@@ -31,11 +31,12 @@ pub fn render_task_targets(targets: &[TaskTargetSummary]) -> String {
 
 /// Builds a SerdesAI Task definition using the shared target summaries.
 pub fn task_tool_definition(targets: &[TaskTargetSummary]) -> ToolDefinition {
-    let description = format!(
-        "{}\n\n{}",
-        task_meta::DESCRIPTION_PREFIX,
-        render_task_targets(targets)
-    );
+    let rendered_targets = render_task_targets(targets);
+    let mut description =
+        String::with_capacity(task_meta::DESCRIPTION_PREFIX.len() + rendered_targets.len() + 2);
+    description.push_str(task_meta::DESCRIPTION_PREFIX);
+    description.push_str("\n\n");
+    description.push_str(&rendered_targets);
     let schema = SchemaBuilder::new()
         .string(
             task_meta::param::DESCRIPTION.name,
@@ -65,7 +66,13 @@ pub fn task_tool_definition(targets: &[TaskTargetSummary]) -> ToolDefinition {
         .build()
         .expect("task schema should be valid");
 
-    ToolDefinition::new(task_meta::NAME, description).with_parameters(schema)
+    ToolDefinition {
+        name: task_meta::NAME.to_owned(),
+        description,
+        parameters_json_schema: schema,
+        strict: None,
+        outer_typed_dict_key: None,
+    }
 }
 
 #[cfg(test)]

--- a/src/llm-coding-tools-serdesai/src/task/tool.rs
+++ b/src/llm-coding-tools-serdesai/src/task/tool.rs
@@ -22,7 +22,7 @@ use serdes_ai::tools::{RunContext, Tool, ToolDefinition, ToolError, ToolResult, 
 #[derive(Clone)]
 pub(crate) struct TaskTool<C: CredentialLookup + Send + Sync + 'static = CredentialResolver> {
     caller_name: Box<str>,
-    targets: Vec<TaskTargetSummary>,
+    definition: ToolDefinition,
     handle: TaskHandle<C>,
 }
 
@@ -38,7 +38,7 @@ where
     ) -> Self {
         Self {
             caller_name: caller_name.into(),
-            targets,
+            definition: task_tool_definition(&targets),
             handle,
         }
     }
@@ -50,7 +50,7 @@ where
     C: CredentialLookup + Send + Sync + 'static,
 {
     fn definition(&self) -> ToolDefinition {
-        task_tool_definition(&self.targets)
+        self.definition.clone()
     }
 
     /// Deserialises `args` as [`TaskInput`], delegates to [`TaskHandle::execute`],

--- a/src/llm-coding-tools-serdesai/src/todo.rs
+++ b/src/llm-coding-tools-serdesai/src/todo.rs
@@ -33,59 +33,24 @@ struct TodoReadArgs {}
 /// Tool for writing/replacing the todo list.
 #[derive(Debug, Clone)]
 pub struct TodoWriteTool {
+    definition: ToolDefinition,
     state: TodoState,
 }
 
 impl TodoWriteTool {
     /// Creates a new todo write tool with the given state.
     pub fn new(state: TodoState) -> Self {
-        Self { state }
+        Self {
+            definition: build_todo_write_definition(),
+            state,
+        }
     }
 }
 
 #[async_trait]
 impl<Deps: Send + Sync> Tool<Deps> for TodoWriteTool {
     fn definition(&self) -> ToolDefinition {
-        ToolDefinition::new(
-            todo_write_meta::NAME,
-            todo_write_meta::DESCRIPTION,
-        )
-        .with_parameters(
-            SchemaBuilder::new()
-                .raw(
-                    todo_write_meta::param::TODOS.name,
-                    serde_json::json!({
-                        "type": "array",
-                        "description": todo_write_meta::param::TODOS.description,
-                        "items": {
-                            "type": "object",
-                            "required": [
-                                todo_write_meta::param::ID.name,
-                                todo_write_meta::param::CONTENT.name,
-                                todo_write_meta::param::STATUS.name,
-                                todo_write_meta::param::PRIORITY.name
-                            ],
-                            "properties": {
-                                "id": { "type": "string", "description": todo_write_meta::param::ID.description },
-                                "content": { "type": "string", "description": todo_write_meta::param::CONTENT.description },
-                                "status": {
-                                    "type": "string",
-                                    "enum": ["pending", "in_progress", "completed", "cancelled"],
-                                    "description": todo_write_meta::param::STATUS.description
-                                },
-                                "priority": {
-                                    "type": "string",
-                                    "enum": ["high", "medium", "low"],
-                                    "description": todo_write_meta::param::PRIORITY.description
-                                }
-                            }
-                        }
-                    }),
-                    todo_write_meta::param::TODOS.required,
-                )
-                .build()
-                .expect("schema serialization should never fail"),
-        )
+        self.definition.clone()
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
@@ -107,24 +72,24 @@ impl ToolContext for TodoWriteTool {
 /// Tool for reading the current todo list.
 #[derive(Debug, Clone)]
 pub struct TodoReadTool {
+    definition: ToolDefinition,
     state: TodoState,
 }
 
 impl TodoReadTool {
     /// Creates a new todo read tool with the given state.
     pub fn new(state: TodoState) -> Self {
-        Self { state }
+        Self {
+            definition: build_todo_read_definition(),
+            state,
+        }
     }
 }
 
 #[async_trait]
 impl<Deps: Send + Sync> Tool<Deps> for TodoReadTool {
     fn definition(&self) -> ToolDefinition {
-        ToolDefinition::new(todo_read_meta::NAME, todo_read_meta::DESCRIPTION).with_parameters(
-            SchemaBuilder::new()
-                .build()
-                .expect("schema serialization should never fail"),
-        )
+        self.definition.clone()
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
@@ -155,6 +120,61 @@ pub fn create_todo_tools() -> (TodoReadTool, TodoWriteTool, TodoState) {
         TodoWriteTool::new(state.clone()),
         state,
     )
+}
+
+fn build_todo_write_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: todo_write_meta::NAME.to_owned(),
+        description: todo_write_meta::DESCRIPTION.to_owned(),
+        parameters_json_schema: SchemaBuilder::new()
+            .raw(
+                todo_write_meta::param::TODOS.name,
+                serde_json::json!({
+                    "type": "array",
+                    "description": todo_write_meta::param::TODOS.description,
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            todo_write_meta::param::ID.name,
+                            todo_write_meta::param::CONTENT.name,
+                            todo_write_meta::param::STATUS.name,
+                            todo_write_meta::param::PRIORITY.name
+                        ],
+                        "properties": {
+                            "id": { "type": "string", "description": todo_write_meta::param::ID.description },
+                            "content": { "type": "string", "description": todo_write_meta::param::CONTENT.description },
+                            "status": {
+                                "type": "string",
+                                "enum": ["pending", "in_progress", "completed", "cancelled"],
+                                "description": todo_write_meta::param::STATUS.description
+                            },
+                            "priority": {
+                                "type": "string",
+                                "enum": ["high", "medium", "low"],
+                                "description": todo_write_meta::param::PRIORITY.description
+                            }
+                        }
+                    }
+                }),
+                todo_write_meta::param::TODOS.required,
+            )
+            .build()
+            .expect("schema serialization should never fail"),
+        strict: None,
+        outer_typed_dict_key: None,
+    }
+}
+
+fn build_todo_read_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: todo_read_meta::NAME.to_owned(),
+        description: todo_read_meta::DESCRIPTION.to_owned(),
+        parameters_json_schema: SchemaBuilder::new()
+            .build()
+            .expect("schema serialization should never fail"),
+        strict: None,
+        outer_typed_dict_key: None,
+    }
 }
 
 #[cfg(test)]

--- a/src/llm-coding-tools-serdesai/src/webfetch.rs
+++ b/src/llm-coding-tools-serdesai/src/webfetch.rs
@@ -33,6 +33,7 @@ struct WebFetchArgs {
 #[derive(Debug, Clone)]
 pub struct WebFetchTool {
     client: reqwest::Client,
+    definition: ToolDefinition,
 }
 
 impl Default for WebFetchTool {
@@ -46,35 +47,23 @@ impl WebFetchTool {
     pub fn new() -> Self {
         Self {
             client: reqwest::Client::new(),
+            definition: build_definition(),
         }
     }
 
     /// Creates a webfetch tool with a custom client.
     pub fn with_client(client: reqwest::Client) -> Self {
-        Self { client }
+        Self {
+            client,
+            definition: build_definition(),
+        }
     }
 }
 
 #[async_trait]
 impl<Deps: Send + Sync> Tool<Deps> for WebFetchTool {
     fn definition(&self) -> ToolDefinition {
-        ToolDefinition::new(webfetch_meta::NAME, webfetch_meta::DESCRIPTION).with_parameters(
-            SchemaBuilder::new()
-                .string(
-                    webfetch_meta::param::URL.name,
-                    webfetch_meta::param::URL.description,
-                    webfetch_meta::param::URL.required,
-                )
-                .integer_constrained(
-                    webfetch_meta::param::TIMEOUT_MS.name,
-                    webfetch_meta::param::TIMEOUT_MS.description,
-                    webfetch_meta::param::TIMEOUT_MS.required,
-                    Some(1),
-                    Some(webfetch_meta::MAX_TIMEOUT_MS as i64),
-                )
-                .build()
-                .expect("schema serialization should never fail"),
-        )
+        self.definition.clone()
     }
 
     async fn call(&self, _ctx: &RunContext<Deps>, args: serde_json::Value) -> ToolResult {
@@ -92,6 +81,30 @@ impl ToolContext for WebFetchTool {
 
     fn context(&self) -> ToolPrompt {
         ToolPrompt::WebFetch
+    }
+}
+
+fn build_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: webfetch_meta::NAME.to_owned(),
+        description: webfetch_meta::DESCRIPTION.to_owned(),
+        parameters_json_schema: SchemaBuilder::new()
+            .string(
+                webfetch_meta::param::URL.name,
+                webfetch_meta::param::URL.description,
+                webfetch_meta::param::URL.required,
+            )
+            .integer_constrained(
+                webfetch_meta::param::TIMEOUT_MS.name,
+                webfetch_meta::param::TIMEOUT_MS.description,
+                webfetch_meta::param::TIMEOUT_MS.required,
+                Some(1),
+                Some(webfetch_meta::MAX_TIMEOUT_MS as i64),
+            )
+            .build()
+            .expect("schema serialization should never fail"),
+        strict: None,
+        outer_typed_dict_key: None,
     }
 }
 


### PR DESCRIPTION
## Summary

This PR optimizes three distinct hot paths where repeated per-call overhead was measurable:

### 1. Core Bash Output Handling (per-command execution hot path)

**Context:** Every bash command execution converts stdout/stderr bytes to UTF-8 strings for the LLM response. Previously this unconditionally used `String::from_utf8_lossy(...).into_owned()`, which always allocates a new String even when the input is already valid UTF-8.

**Change:** Added a fast path using `String::from_utf8` that takes ownership of the original buffer when valid UTF-8, avoiding a copy. Only falls back to lossy conversion when needed.

**Also:** Replaced `Arc<Mutex<Vec<u8>>>` clone fallback with `std::mem::take`, avoiding the final buffer clone when multiple readers race.

### 2. Bubblewrap Sandbox Wrapping (per-command setup hot path)

**Context:** Every sandboxed bash command calls `wrap_command()` to build the bubblewrap invocation. This was validating the working directory existence on every call via filesystem syscalls, even for directories that were already validated when the sandbox profile was constructed at startup.

**Change:** Added `Profile::is_prevalidated_workdir()` to recognize exact profile-owned roots (workspace, synthetic home, cache root, tmp mounts, explicit mount points). These are trusted without re-validation. Nested paths and external directories still go through full validation.

**Also:** Streamlined backend probing by reusing a single `PATH` snapshot across binary lookup, shell lookup, and availability checking. Removed the separate `bwrap --version` subprocess that was being spawned before the actual capability probe.

### 3. SerdesAI Tool Definitions (per-tool-metadata-request hot path)

**Context:** Every time an agent framework requests tool metadata (which can happen frequently during a session), `Tool::definition()` was rebuilding the complete `ToolDefinition` including JSON schema construction from scratch.

**Change:** Moved all tool definitions to eager one-time construction at `Tool` initialization. Each tool now stores its `ToolDefinition` as a field and `definition()` simply returns `self.definition.clone()`. Also replaced `ToolDefinition::new(...).with_parameters(...)` with direct struct construction to avoid the hidden empty-schema initialization.

---

## Benchmark Evidence

### Core Bash Hot Paths

**Setup:** Benchmarking the UTF-8 conversion and buffer handling that happens on every command completion.

| Benchmark | Time | Description |
|-----------|------|-------------|
| `valid_utf8_lossy_old` | 6.47-6.54 µs | Always copies via `String::from_utf8_lossy().into_owned()` |
| `valid_utf8_lossy_new` | 648-665 ns | Fast path: `String::from_utf8` when valid UTF-8 → **~10x faster** |
| `invalid_utf8_lossy_old` | 6.43-6.47 µs | Fallback path (unchanged performance) |
| `invalid_utf8_lossy_new` | 6.42-6.52 µs | Same as old (correct fallback behavior) |
| `shared_pipe_clone_old` | 539-543 ns | Cloning contended `Arc<Mutex<Vec<u8>>>` |
| `shared_pipe_take_new` | 313-315 ns | `std::mem::take` instead → **~1.7x faster** |

### Bubblewrap Per-Command Wrap Path

**Setup:** Benchmarking `wrap_command()` and `build_command_wrap()` which run on every sandboxed command. Comparing validation-skipping optimization vs always-validating baseline.

| Benchmark | Time | Description |
|-----------|------|-------------|
| `wrap_command/current_exact_workspace` | 106 ns | Exact prevalidated root (skips redundant validation) |
| `wrap_command/baseline_exact_workspace` | 362 ns | Always validates via filesystem → **baseline is ~3.4x slower** |
| `wrap_command/current_nested_workspace` | 526-528 ns | Nested path still validates + maps correctly |
| `build_command_wrap_tokio/exact_workspace` | 1.02 µs | Full wrap + tokio `CommandWrap` setup for exact root |
| `build_command_wrap_tokio/nested_workspace` | 1.48 µs | Same for nested path (includes mapping overhead) |

### Bubblewrap Backend Probing

**Setup:** Benchmarking `probe_backend_uncached()` which runs at most once per unique `PATH` value (cached afterwards, but we measure the uncached case).

| Benchmark | Time | Description |
|-----------|------|-------------|
| `probe_backend_uncached/old` | 2.37-2.39 ms | Spawns `bwrap --version` then real probe, multiple PATH lookups |
| `probe_backend_uncached/new` | 1.18-1.19 ms | Single PATH snapshot, no version subprocess → **~50% faster** |

### SerdesAI Tool Definitions

**Setup:** Benchmarking `Tool::definition()` calls which happen whenever the agent framework requests tool metadata. Comparing eager construction + clone vs building fresh every time.

**Bash tool (most complex schema):**
| Benchmark | Time | Description |
|-----------|------|-------------|
| `bash_clone_prebuilt` | 248-251 ns | Return prebuilt definition (what we do now) |
| `bash_build_direct` | 913-918 ns | Build via direct `ToolDefinition { ... }` → **~3.7x slower** |
| `bash_build_via_new` | 1.00 µs | Build via `ToolDefinition::new().with_parameters()` → **~10% worse than direct** |

**Read tool (simpler schema):**
| Benchmark | Time | Description |
|-----------|------|-------------|
| `read_clone_prebuilt` | 340-342 ns | Return prebuilt definition |
| `read_build_direct` | 845-852 ns | Build fresh → **~2.5x slower** |

**Task tool definition (string building optimization):**
| Benchmark | Time | Description |
|-----------|------|-------------|
| `task_build_old` | 1.45-1.47 µs | `format!()` based description building |
| `task_build_new` | 1.26-1.27 µs | `with_capacity` + `push_str` → **~13% faster even before caching** |