### PR TITLE
Simplify agent build flow, task schema, and runtime docs

### DIFF
--- a/src/.cargo/verify.ps1
+++ b/src/.cargo/verify.ps1
@@ -76,7 +76,7 @@ try {
     }
 
     Write-Host "Formatting..."
-    Invoke-LoggedCommand "cargo" @("fmt", "--all", "--check", "--quiet")
+    Invoke-LoggedCommand "cargo" @("fmt", "--all", "--quiet")
 
     Write-Host "Linux-only feature coverage..."
     if ($onLinux) {

--- a/src/.cargo/verify.sh
+++ b/src/.cargo/verify.sh
@@ -62,7 +62,7 @@ DOC_ARGS=(--workspace --document-private-items --no-deps --quiet --exclude llm-c
 run_cmd env RUSTDOCFLAGS="-D warnings" cargo doc "${DOC_ARGS[@]}"
 
 echo "Formatting..."
-run_cmd cargo fmt --all --check --quiet
+run_cmd cargo fmt --all --quiet
 
 echo "Linux-only feature coverage..."
 if [ "$IS_LINUX" = true ]; then

--- a/src/llm-coding-tools-agents/ARCHITECTURE.md
+++ b/src/llm-coding-tools-agents/ARCHITECTURE.md
@@ -73,7 +73,7 @@ You are a careful code reviewer.
 
 ### Loading Pipeline
 
-```
+```text
     .md file / string / bytes
              │
              │  AgentLoader::add_directory / add_file / add_from_str
@@ -105,7 +105,7 @@ You are a careful code reviewer.
 `AgentLoader::add_directory` walks the given root with `.gitignore` support
 (`ignore` crate), keeping only files matching:
 
-```
+```text
 agent/**/*.md
 agents/**/*.md
 ```
@@ -113,7 +113,7 @@ agents/**/*.md
 Agent name is derived from the relative path by stripping the `agent/` or
 `agents/` prefix and `.md` suffix:
 
-```
+```text
 agent/code-reviewer.md      -> "code-reviewer"
 agents/nested/deep.md        -> "nested/deep"
 ```
@@ -147,7 +147,7 @@ settings, and the available tools.
 
 ### Building the Runtime
 
-```
+```text
    AgentRuntimeBuilder::new()
        .catalog(catalog)
        .defaults(AgentDefaults { model, temperature, top_p })
@@ -194,7 +194,7 @@ Fallback settings used when an individual agent doesn't specify them:
 
 When an agent needs to run, you resolve which model it should use:
 
-```
+```text
    resolve_model_with_catalog(model_catalog, defaults, agent)
                 │
                 │  1. agent.model set?  -> parse "provider/model-id"
@@ -238,7 +238,7 @@ permission:
 `RulesetExt::from_permission_config` converts this into a `Ruleset` (from
 `llm-coding-tools-core::permissions`):
 
-```
+```text
 PermissionRule::Action(Allow)    -> Rule { key: "read",   pattern: "*", action: Allow }
 PermissionRule::Action(Deny)     -> Rule { key: "bash",   pattern: "*", action: Deny  }
 PermissionRule::Pattern({ .. })  -> Rule { key: "task",   pattern: "*",        action: Deny  }
@@ -251,7 +251,7 @@ Evaluation uses **last-match-wins** semantics.
 
 `AgentRuntime::allowed_tools(caller_name)` filters the tool catalog:
 
-```
+```text
    runtime.tools()
         │
         │  for each entry:
@@ -266,7 +266,7 @@ Evaluation uses **last-match-wins** semantics.
 `callable_targets(catalog, caller_name)` returns agents the caller may delegate
 to via the Task tool:
 
-```
+```text
    all agents (sorted by name)
         │
         │  filter:
@@ -287,7 +287,7 @@ delegation to all non-Primary agents.
 
 ### Error Model
 
-```
+```text
 AgentLoadError
 ├── Io { path, source }              file read / directory scan failure
 ├── Parse { path, source }           frontmatter YAML parse failure
@@ -315,7 +315,7 @@ in-memory sources, displayed as `<memory>`).
 
 ### File Map
 
-```
+```text
 llm-coding-tools-agents
 ├── lib.rs                  crate root, re-exports
 ├── catalog.rs              AgentCatalog - in-memory name -> AgentConfig store

--- a/src/llm-coding-tools-agents/ARCHITECTURE.md
+++ b/src/llm-coding-tools-agents/ARCHITECTURE.md
@@ -1,0 +1,339 @@
+# Architecture: llm-coding-tools-agents
+
+Framework-agnostic agent configuration loading, catalog management, model
+resolution, permission filtering, and runtime assembly.
+
+Upstream integrations (e.g. `llm-coding-tools-serdesai`) consume the
+[`AgentRuntime`] produced here and adapt it to their framework's agent builder.
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Phase 1: Loading](#phase-1-loading)
+  - [Loading Pipeline](#loading-pipeline)
+  - [File Discovery](#file-discovery)
+  - [YAML Preprocessor](#yaml-preprocessor)
+- [Phase 2: Building](#phase-2-building)
+  - [Building the Runtime](#building-the-runtime)
+  - [AgentDefaults](#agentdefaults)
+  - [Tool Catalog](#tool-catalog)
+  - [Model Resolution](#model-resolution)
+- [Phase 3: Runtime Usage](#phase-3-runtime-usage)
+  - [Permission Filtering](#permission-filtering)
+  - [Allowed Tools](#allowed-tools)
+  - [Callable Targets](#callable-targets)
+- [Reference](#reference)
+  - [Error Model](#error-model)
+  - [Testing](#testing)
+  - [File Map](#file-map)
+
+## Quick Start
+
+Three steps from markdown files to a working runtime:
+
+```rust
+use llm_coding_tools_agents::{AgentLoader, AgentCatalog, AgentRuntimeBuilder, AgentDefaults};
+use std::path::Path;
+
+// 1. Load agents from directory
+let loader = AgentLoader::new();
+let mut catalog = AgentCatalog::new();
+loader.add_directory(&mut catalog, Path::new("~/.opencode"))?;
+
+// 2. Build the runtime
+let runtime = AgentRuntimeBuilder::new()
+    .catalog(catalog)
+    .defaults(AgentDefaults::with_model("openai/gpt-4o"))
+    .build();
+
+// 3. Use the runtime (e.g., resolve which model an agent should use)
+let agent = runtime.catalog().by_name("code-reviewer").unwrap();
+// ... pass to your framework's agent builder
+```
+
+## Phase 1: Loading
+
+Agent definitions live in markdown files with YAML frontmatter:
+
+```markdown
+---
+name: code-reviewer
+mode: subagent
+description: Reviews code and flags high-risk issues
+model: openrouter/openai/gpt-4o
+permission:
+  read: allow
+  bash: deny
+  task:
+    "*": deny
+    review-*: allow
+---
+You are a careful code reviewer.
+```
+
+### Loading Pipeline
+
+```
+    .md file / string / bytes
+             │
+             │  AgentLoader::add_directory / add_file / add_from_str
+             ▼
+    ┌────────────────────────────────────────────────────────────┐
+    │ 1. CRLF -> LF normalization             crlf-to-lf-inplace │
+    │ 2. Find frontmatter delimiters          parser/mod.rs      │
+    │ 3. Preprocess YAML                      preprocessor       │
+    │    Rewrites colon-containing values to block scalars       │
+    │ 4. Parse YAML -> RawFrontmatter         serde_yaml         │
+    │ 5. Validate headless compatibility      no "ask" perms     │
+    │ 6. Build AgentConfig                    from_raw           │
+    └──────────────────────────────┬─────────────────────────────┘
+                                   │
+                                   ▼
+                            ┌─────────────┐
+                            │ AgentConfig │  name, mode, model, permissions, prompt
+                            └──────┬──────┘
+                                   │
+                                   ▼
+                            ┌──────────────┐
+                            │ AgentCatalog │  AHashMap<String, AgentConfig>
+                            └──────────────┘  last-insert-wins on duplicate names
+```
+
+### File Discovery
+
+`AgentLoader::add_directory` walks the given root with `.gitignore` support
+(`ignore` crate), keeping only files matching:
+
+```
+agent/**/*.md
+agents/**/*.md
+```
+
+Agent name is derived from the relative path by stripping the `agent/` or
+`agents/` prefix and `.md` suffix:
+
+```
+agent/code-reviewer.md      -> "code-reviewer"
+agents/nested/deep.md        -> "nested/deep"
+```
+
+Frontmatter `name:` overrides the derived name when present.
+
+### YAML Preprocessor
+
+The preprocessor (`parser/preprocessor.rs`) rewrites lines where an unquoted
+value contains a bare `:` - a YAML ambiguity. For example:
+
+```yaml
+model: provider/model:tag
+```
+
+becomes:
+
+```yaml
+model: |-
+  provider/model:tag
+```
+
+Already-safe forms (quoted, block scalars, flow syntax, comments, indented
+continuation lines) are left untouched.
+
+## Phase 2: Building
+
+Once you have an [`AgentCatalog`], you assemble an [`AgentRuntime`] that holds
+everything needed to run agents: the catalog, default settings, Task delegation
+settings, and the available tools.
+
+### Building the Runtime
+
+```
+   AgentRuntimeBuilder::new()
+       .catalog(catalog)
+       .defaults(AgentDefaults { model, temperature, top_p })
+       .max_task_depth(n)        // or .task_settings(TaskSettings::with_max_depth(n))
+       .tools(vec![...])         // or default_tools() if omitted
+       .build()
+                │
+                ▼
+          ┌──────────────┐
+          │ AgentRuntime │  catalog + defaults + task_settings + tools
+          └──────────────┘
+```
+
+`AgentRuntime` is `Clone`, `Send`, `Sync`, and stores no async state.
+
+### AgentDefaults
+
+Fallback settings used when an individual agent doesn't specify them:
+
+| Field         | Meaning                            |
+| ------------- | ---------------------------------- |
+| `model`       | Default `provider/model-id`        |
+| `temperature` | Default sampling temperature       |
+| `top_p`       | Default nucleus sampling parameter |
+
+### Tool Catalog
+
+`default_tools()` returns 10 entries:
+
+| Kind      | Tool name   |
+| --------- | ----------- |
+| Read      | `read`      |
+| Write     | `write`     |
+| Edit      | `edit`      |
+| Glob      | `glob`      |
+| Grep      | `grep`      |
+| Bash      | `bash`      |
+| WebFetch  | `webfetch`  |
+| TodoRead  | `todoread`  |
+| TodoWrite | `todowrite` |
+| Task      | `task`      |
+
+### Model Resolution
+
+When an agent needs to run, you resolve which model it should use:
+
+```
+   resolve_model_with_catalog(model_catalog, defaults, agent)
+                │
+                │  1. agent.model set?  -> parse "provider/model-id"
+                │     └─ malformed?     -> MalformedModelIdentifier ("agent override")
+                │
+                │  2. defaults.model?   -> parse "provider/model-id"
+                │     └─ malformed?     -> MalformedModelIdentifier ("runtime default")
+                │
+                │  3. neither set?       -> MissingEffectiveModel
+                │
+                │  4. provider in catalog?  -> no -> UnknownProvider
+                │  5. model in catalog?     -> no -> UnknownModel
+                ▼
+          ┌────────────────┐
+          │ ResolvedModel  │  provider: Box<str>, model: Box<str>
+          └────────────────┘
+```
+
+Precedence: **agent override** wins over **runtime default**.
+
+A malformed agent override does **not** fall back to the default - it errors.
+
+## Phase 3: Runtime Usage
+
+With a built [`AgentRuntime`], you can query what an agent is allowed to do
+and which other agents it can delegate to.
+
+### Permission Filtering
+
+Agent frontmatter may include a `permission` map:
+
+```yaml
+permission:
+  read: allow
+  bash: deny
+  task:
+    "*": deny
+    "review-*": allow
+```
+
+`RulesetExt::from_permission_config` converts this into a `Ruleset` (from
+`llm-coding-tools-core::permissions`):
+
+```
+PermissionRule::Action(Allow)    -> Rule { key: "read",   pattern: "*", action: Allow }
+PermissionRule::Action(Deny)     -> Rule { key: "bash",   pattern: "*", action: Deny  }
+PermissionRule::Pattern({ .. })  -> Rule { key: "task",   pattern: "*",        action: Deny  }
+                                    Rule { key: "task",   pattern: "review-*", action: Allow }
+```
+
+Evaluation uses **last-match-wins** semantics.
+
+### Allowed Tools
+
+`AgentRuntime::allowed_tools(caller_name)` filters the tool catalog:
+
+```
+   runtime.tools()
+        │
+        │  for each entry:
+        │    Task  -> only if >= 1 callable subagent target exists
+        │    other -> is_allowed(entry.name, "*") per Ruleset
+        ▼
+   Vec<ToolCatalogEntry>
+```
+
+### Callable Targets
+
+`callable_targets(catalog, caller_name)` returns agents the caller may delegate
+to via the Task tool:
+
+```
+   all agents (sorted by name)
+        │
+        │  filter:
+        │    mode != Primary  (only All + Subagent are callable)
+        │    AND
+        │    if caller defines permission.task:
+        │      ruleset.is_allowed("task", target.name)
+        │    else (no explicit permission.task):
+        │      default-allow all non-Primary targets
+        ▼
+   Vec<&AgentConfig>
+```
+
+OpenCode compatibility: omitting `permission.task` defaults to allowing
+delegation to all non-Primary agents.
+
+## Reference
+
+### Error Model
+
+```
+AgentLoadError
+├── Io { path, source }              file read / directory scan failure
+├── Parse { path, source }           frontmatter YAML parse failure
+│                                     source: AgentParseError
+│                                       ├── MissingFrontmatter
+│                                       ├── InvalidYaml { message }
+│                                       └── SchemaValidation { message }
+└── SchemaValidation { path, msg }   invalid mode, empty name, "ask" permission
+
+ModelResolutionError
+├── MalformedModelIdentifier          missing "/" or empty segments
+├── MissingEffectiveModel             neither agent nor default specifies a model
+├── UnknownProvider                   provider not in ModelCatalog
+└── UnknownModel                      provider found but model not listed
+```
+
+All loader errors carry an optional `path: Option<PathBuf>` (`None` for
+in-memory sources, displayed as `<memory>`).
+
+### Testing
+
+- `tempfile` + `indoc` fixtures for file/directory loading tests.
+- No external services required.
+- Parser benchmarks in `benches/parser.rs` (Criterion).
+
+### File Map
+
+```
+llm-coding-tools-agents
+├── lib.rs                  crate root, re-exports
+├── catalog.rs              AgentCatalog - in-memory name -> AgentConfig store
+├── extensions.rs           RulesetExt - builds Ruleset from frontmatter permissions
+├── loader.rs               AgentLoader - scans dirs/files/strings -> AgentCatalog
+├── parser/
+│   ├── mod.rs              parse_agent() - YAML frontmatter + body extractor
+│   └── preprocessor.rs     YAML preprocessor - rewrites colon-containing values
+├── types/
+│   ├── mod.rs              re-exports
+│   ├── config.rs           AgentConfig, AgentMode, PermissionRule, parse_model_parts
+│   └── error.rs            AgentLoadError, AgentLoadResult
+├── runtime/
+│   ├── mod.rs              module root, re-exports
+│   ├── state.rs            AgentRuntime, AgentDefaults
+│   ├── builder.rs          AgentRuntimeBuilder
+│   ├── model.rs            resolve_model_with_catalog(), ResolvedModel, ModelResolutionError
+│   ├── task.rs             callable_targets(), summarize_callable_targets(), allowed_tools()
+│   └── tool_catalog.rs     ToolCatalogEntry, ToolCatalogKind, default_tools()
+└── benches/
+    └── parser.rs           Criterion benchmarks for frontmatter parsing
+```

--- a/src/llm-coding-tools-agents/ARCHITECTURE.md
+++ b/src/llm-coding-tools-agents/ARCHITECTURE.md
@@ -38,7 +38,7 @@ use std::path::Path;
 // 1. Load agents from directory
 let loader = AgentLoader::new();
 let mut catalog = AgentCatalog::new();
-loader.add_directory(&mut catalog, Path::new("~/.opencode"))?;
+loader.add_directory(&mut catalog, Path::new("agents"))?;
 
 // 2. Build the runtime
 let runtime = AgentRuntimeBuilder::new()
@@ -46,7 +46,7 @@ let runtime = AgentRuntimeBuilder::new()
     .defaults(AgentDefaults::with_model("openai/gpt-4o"))
     .build();
 
-// 3. Use the runtime (e.g., resolve which model an agent should use)
+// 3. Use the runtime (e.g., look up agents by name)
 let agent = runtime.catalog().by_name("code-reviewer").unwrap();
 // ... pass to your framework's agent builder
 ```
@@ -78,15 +78,16 @@ You are a careful code reviewer.
              │
              │  AgentLoader::add_directory / add_file / add_from_str
              ▼
-    ┌────────────────────────────────────────────────────────────┐
-    │ 1. CRLF -> LF normalization             crlf-to-lf-inplace │
-    │ 2. Find frontmatter delimiters          parser/mod.rs      │
-    │ 3. Preprocess YAML                      preprocessor       │
-    │    Rewrites colon-containing values to block scalars       │
-    │ 4. Parse YAML -> RawFrontmatter         serde_yaml         │
-    │ 5. Validate headless compatibility      no "ask" perms     │
-    │ 6. Build AgentConfig                    from_raw           │
-    └──────────────────────────────┬─────────────────────────────┘
+    ┌─────────────────────────────────────────────────────────────────────┐
+    │ 1. CRLF -> LF normalization             crlf-to-lf-inplace          │
+    │ 2. Find frontmatter delimiters          parser/mod.rs               │
+    │ 3. Preprocess YAML                      preprocessor                │
+    │    Rewrites colon-containing values to block scalars                │
+    │ 4. Parse YAML -> serde_yaml::Value      serde_yaml                  │
+    │ 5. Validate headless compatibility      no "ask" in permission.task │
+    │ 6. Deserialize Value -> RawFrontmatter  serde_yaml                  │
+    │ 7. Build AgentConfig                    from_raw                    │
+    └──────────────────────────────┬──────────────────────────────────────┘
                                    │
                                    ▼
                             ┌─────────────┐
@@ -294,7 +295,7 @@ AgentLoadError
 │                                       ├── MissingFrontmatter
 │                                       ├── InvalidYaml { message }
 │                                       └── SchemaValidation { message }
-└── SchemaValidation { path, msg }   invalid mode, empty name, "ask" permission
+└── SchemaValidation { path, message } invalid mode, empty name, "ask" permission
 
 ModelResolutionError
 ├── MalformedModelIdentifier          missing "/" or empty segments

--- a/src/llm-coding-tools-agents/README.md
+++ b/src/llm-coding-tools-agents/README.md
@@ -91,3 +91,5 @@ while settings with no runtime effect are accepted and ignored:
   ([docs](https://opencode.ai/docs/permissions#what-ask-does)).
 - [`hidden`](https://opencode.ai/docs/agents#hidden) is accepted for
   compatibility, but ignored at runtime.
+
+For the internal architecture, see [ARCHITECTURE.md](https://github.com/Sewer56/llm-coding-tools/blob/main/src/llm-coding-tools-agents/ARCHITECTURE.md).

--- a/src/llm-coding-tools-bubblewrap/ARCHITECTURE.md
+++ b/src/llm-coding-tools-bubblewrap/ARCHITECTURE.md
@@ -7,7 +7,7 @@ For the security model, see [SANDBOX-PROFILES.md](../../SANDBOX-PROFILES.md).
 
 ## File Map
 
-```
+```text
 llm-coding-tools-bubblewrap
 ├── lib.rs                  crate root, re-exports, Linux-only gate
 ├── error.rs                LinuxBwrapError
@@ -30,7 +30,7 @@ llm-coding-tools-bubblewrap
 
 ## Building a Profile
 
-```
+```text
    Builder::public_bot()          Builder::trusted_maintenance()         Builder::new()
    or any with_*() chain
            │
@@ -55,7 +55,7 @@ llm-coding-tools-bubblewrap
 
 Pass the `Profile` to `wrap_command` directly, or use an adapter:
 
-```
+```text
                 ┌──────────┐
                 │ Profile  │
                 └────┬─────┘
@@ -73,7 +73,7 @@ Pass the `Profile` to `wrap_command` directly, or use an adapter:
 
 ## What build() Does
 
-```
+```text
    ensure cache dirs ──► validate ──► find bwrap ──► find shell ──► build static args
           │                │              │               │                │
     validation.rs    validation.rs    probe.rs    builder.rs +      builder.rs
@@ -102,7 +102,7 @@ bwrap prefix (flags, mounts, env). `wrap_command` only appends `--chdir
 When `wrap_command` needs to translate a host working directory to a sandbox
 path, `SandboxLayout::classify` walks the mount tree:
 
-```
+```text
 host_path
  ├── under workspace?       → remap workspace → workspace_dest
  ├── under synthetic_home?  → remap home → home_dest
@@ -127,7 +127,7 @@ Shell search order: `bash` on PATH → `sh` on PATH → hardcoded candidates
 
 ## Error Model
 
-```
+```text
 LinuxBwrapError
 ├── InvalidPath(String)    bad path, bad env name/value, bad symlink,
 │                          bad credential mount, bad tmp backing,
@@ -140,7 +140,7 @@ per-call working directory.
 
 ## Feature Flags
 
-```
+```text
 (default)   → wrap_command only (no process-wrap dependency)
 tokio       → wrap::tokio::build_command_wrap   (process-wrap tokio1, process-group)
 blocking    → wrap::blocking::build_command_wrap (process-wrap std, process-group)

--- a/src/llm-coding-tools-core/examples/system_prompt/definitions.rs
+++ b/src/llm-coding-tools-core/examples/system_prompt/definitions.rs
@@ -339,10 +339,6 @@ fn push_task_definition(definitions: &mut Vec<Value>, case: PromptCase) {
                     string_schema(tool_metadata::task::param::SUBAGENT_TYPE.description),
                 ),
                 (
-                    tool_metadata::task::param::SESSION_ID.name,
-                    string_schema(tool_metadata::task::param::SESSION_ID.description),
-                ),
-                (
                     tool_metadata::task::param::COMMAND.name,
                     string_schema(tool_metadata::task::param::COMMAND.description),
                 ),

--- a/src/llm-coding-tools-core/src/context/tool_prompt/tool_sections.rs
+++ b/src/llm-coding-tools-core/src/context/tool_prompt/tool_sections.rs
@@ -217,7 +217,7 @@ fn write_todo_write_section(output: &mut String) {
 fn write_task_section(output: &mut String, facts: ToolPromptFacts) {
     push_block(
         output,
-        "- Use task for real delegation, custom slash commands, or independent sub-work you can run in parallel.\n",
+        "- Use task for real delegation or parallel sub-work. Tasks are stateless - include full context; do not rely on prior state.\n",
     );
 
     let mut tools = [""; 3];

--- a/src/llm-coding-tools-core/src/context/tool_prompt/tool_sections.rs
+++ b/src/llm-coding-tools-core/src/context/tool_prompt/tool_sections.rs
@@ -217,11 +217,7 @@ fn write_todo_write_section(output: &mut String) {
 fn write_task_section(output: &mut String, facts: ToolPromptFacts) {
     push_block(
         output,
-        formatcp!(
-            "- This runtime is stateless. Do not pass `{}`.\n\
-            - Use it for real delegation, custom slash commands, or independent sub-work you can run in parallel.\n",
-            crate::tool_metadata::task::param::SESSION_ID.name,
-        ),
+        "- Use task for real delegation, custom slash commands, or independent sub-work you can run in parallel.\n",
     );
 
     let mut tools = [""; 3];

--- a/src/llm-coding-tools-core/src/tool_metadata/task.rs
+++ b/src/llm-coding-tools-core/src/tool_metadata/task.rs
@@ -24,10 +24,6 @@ pub mod param {
     pub const SUBAGENT_TYPE: ParamMetadata =
         ParamMetadata::new("subagent_type", "Exact name of the target subagent.", true);
 
-    /// `session_id` parameter metadata.
-    pub const SESSION_ID: ParamMetadata =
-        ParamMetadata::new("session_id", "Unsupported in this runtime; omit.", false);
-
     /// `command` parameter metadata.
     pub const COMMAND: ParamMetadata =
         ParamMetadata::new("command", "Source command or slash-command context.", false);

--- a/src/llm-coding-tools-core/src/tools/task.rs
+++ b/src/llm-coding-tools-core/src/tools/task.rs
@@ -75,8 +75,6 @@ pub struct TaskInput {
     pub prompt: String,
     /// The subagent type/name to invoke.
     pub subagent_type: String,
-    /// Optional session ID to continue an existing task session.
-    pub session_id: Option<String>,
     /// Optional command that triggered this task (for context).
     pub command: Option<String>,
 }
@@ -86,8 +84,6 @@ pub struct TaskInput {
 pub struct TaskOutput {
     /// The text summary/response from the agent.
     pub summary: String,
-    /// Session ID for continuation (if supported by implementation).
-    pub session_id: Option<String>,
     /// Optional metadata from the execution.
     pub metadata: Option<Value>,
 }
@@ -98,16 +94,8 @@ impl TaskOutput {
     pub fn new(summary: impl Into<String>) -> Self {
         Self {
             summary: summary.into(),
-            session_id: None,
             metadata: None,
         }
-    }
-
-    /// Sets the session ID.
-    #[inline]
-    pub fn with_session_id(mut self, session_id: impl Into<String>) -> Self {
-        self.session_id = Some(session_id.into());
-        self
     }
 
     /// Sets metadata.

--- a/src/llm-coding-tools-serdesai/AGENTS-ARCHITECTURE.md
+++ b/src/llm-coding-tools-serdesai/AGENTS-ARCHITECTURE.md
@@ -1,0 +1,305 @@
+# Architecture: llm-coding-tools-serdesai (Agent Runtime)
+
+SerdesAI adapter that builds runnable [`serdes_ai::Agent`] instances from the
+framework-agnostic [`AgentRuntime`] provided by `llm-coding-tools-agents`.
+
+The crate also contains standalone file tools (read, write, edit, glob, grep,
+bash, webfetch, todo) and Linux bubblewrap sandboxing. This document focuses
+on the **agent runtime** subsystem.
+
+For the foundation crate, see
+[llm-coding-tools-agents/ARCHITECTURE.md](https://github.com/Sewer56/llm-coding-tools/blob/main/src/llm-coding-tools-agents/ARCHITECTURE.md).
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Phase 1: Building Agents](#phase-1-building-agents)
+  - [Building the Context (Setup)](#building-the-context-setup)
+  - [Building a SerdesAI Agent (Runtime)](#building-a-serdesai-agent-runtime)
+  - [Shared: prepare_build()](#shared-prepare_build)
+    - [Model Resolution: `resolve_model_with_catalog`](#model-resolution-resolve_model_with_catalog)
+    - [Provider Bridge: `build_serdes_model`](#provider-bridge-build_serdes_model)
+- [Task Delegation](#task-delegation)
+  - [Depth Guard](#depth-guard)
+- [Reference](#reference)
+  - [Error Model](#error-model)
+  - [Feature Flags](#feature-flags)
+  - [Testing](#testing)
+  - [File Map](#file-map)
+
+## Quick Start
+
+Build and run an agent from markdown definitions:
+
+```rust
+use llm_coding_tools_agents::{AgentCatalog, AgentLoader, AgentRuntimeBuilder};
+use llm_coding_tools_core::CredentialResolver;
+use llm_coding_tools_models_dev::ModelsDevCatalog;
+use llm_coding_tools_serdesai::{AgentBuildContext, AgentDefaults};
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Load model catalog (models.dev crate)
+    let load_result = ModelsDevCatalog::load().await?;
+    
+    // 2. Load agent definitions (agents crate)
+    let mut catalog = AgentCatalog::new();
+    AgentLoader::new().add_directory(&mut catalog, "~/.opencode")?;
+    
+    // 3. Build runtime with defaults (agents crate + serdesai defaults)
+    let runtime = AgentRuntimeBuilder::new()
+        .catalog(catalog)
+        .defaults(AgentDefaults::with_model("synthetic/hf:zai-org/GLM-4.7-Flash"))
+        .build();
+    let build_context = AgentBuildContext::new(
+        Arc::new(runtime),
+        Arc::new(load_result.catalog),
+        Arc::new(CredentialResolver::without_env()),
+    );
+    
+    // 4. Build and run the agent (serdesai crate - converts runtime -> runnable agent)
+    let agent = build_context.build("code-reviewer")?;
+    let response = agent.run("Review this code", ()).await?; // run via serdes
+    println!("{}", response.output());
+    
+    Ok(())
+}
+```
+
+## Phase 1: Building Agents
+
+Transform framework-agnostic agent configurations into runnable SerdesAI
+agents with tools.
+
+`AgentBuildContext::build()` is the single public build entrypoint.
+The process splits into two phases:
+
+### Building the Context (Setup)
+
+Create a reusable build context once with shared resources:
+
+```
+   Arc<AgentRuntime> + Arc<ModelCatalog> + Arc<Credentials>
+                         │
+                         ▼
+                AgentBuildContext::new(...)
+                         │
+                         ▼
+            AgentBuildContext
+            ├─ Arc<AgentRuntime>      (agent catalog + config)
+            ├─ Arc<ModelCatalog>      (model definitions)
+            └─ Arc<CredentialResolver> (API credentials)
+```
+
+This context holds references to shared resources and can build multiple agents.
+
+### Building a SerdesAI Agent (Runtime)
+
+Build individual SerdesAI agents from the context (can be called multiple times).
+Transforms the framework-agnostic [`AgentConfig`] into a runnable SerdesAI
+[`Agent`]:
+
+```
+   AgentBuildContext::build("agent-name")
+                         │
+                         ▼
+                    build_agent()
+                         │
+                         ▼
+                    prepare_build()
+            ┌─────────────────────────┐
+            │ 1. Load AgentConfig     │
+            │ 2. resolve_model()      │
+            │ 3. build_serdes_model() │
+            │ 4. allowed_tools()      │
+            │ 5. Summarize targets    │
+            └─────────────────────────┘
+                         │
+                         ▼
+              Depth guard check
+            (clears targets if at limit)
+                         │
+                         ▼
+           attach_standard_tools()
+            (TaskTool only if targets exist)
+                         │
+                         ▼
+               SerdesAI Agent<(), String>
+```
+
+Results in a runnable SerdesAI `Agent<(), String>` ready to call `.run()`.
+
+Internally shares the build context (via Arc) so delegated sub-agents can
+recursively build each other at runtime.
+
+### Shared: prepare_build()
+
+Central helper that gathers all configuration from the runtime catalog
+([`AgentConfig`]) to construct a runnable SerdesAI [`Agent`].
+
+```
+prepare_build(runtime, name, model_catalog, credentials)
+    │
+    ▼
+1. Load config    -> AgentConfig (by name)
+2. Resolve model  -> ResolvedModel
+3. Build model    -> BoxedModel
+4. Get tools      -> Vec<ToolCatalogEntry>
+5. Summarize      -> Vec<TaskTargetSummary>
+    │
+    ▼
+PreparedBuild {
+    agent_name, model, prompt,
+    temperature, top_p,
+    tools,
+    callable_target_summaries,
+}
+```
+
+#### Model Resolution: `resolve_model_with_catalog`
+
+Resolves which model an agent should use by checking agent override, then
+runtime defaults, validating against the model catalog:
+
+```
+   resolve_model_with_catalog(model_catalog, defaults, agent)
+                │
+                │  1. Check agent.model override
+                │     └─ not set? check defaults.model
+                │  2. Parse "provider/model-id"
+                │  3. Validate provider exists in catalog
+                │  4. Validate model exists in catalog
+                ▼
+           ┌────────────────┐
+           │ ResolvedModel  │  provider + model
+           └────────────────┘
+```
+
+Precedence: **agent override** wins over **runtime default**.
+
+#### Provider Bridge: `build_serdes_model`
+
+Connects framework-agnostic [`ResolvedModel`] to concrete SerdesAI
+[`BoxedModel`] implementations:
+
+```
+   ResolvedModel { provider, model }
+        │
+        │  catalog.lookup_provider(provider)
+        ▼
+   ProviderInfo { api_url, env_vars, api_type }
+        │
+        │  match api_type
+        ▼
+   build_serdes_model()
+        │
+        │  credential resolution:
+        │    require_env_value()    finds first _API_KEY / _TOKEN
+        │    first_matching_env()   optional values (region, project_id)
+        ▼
+   ResolvedSerdesModel { model: BoxedModel, spec: "provider:model" }
+```
+
+Each provider function is gated behind a feature flag. When the feature is
+disabled, `feature_disabled_error()` returns a clear message telling the user
+which flag to enable.
+
+| ProviderType      | SerdesAI Model       | Notes               |
+| ----------------- | -------------------- | ------------------- |
+| OpenAiCompletions | OpenAIChatModel      |                     |
+| OpenAiResponses   | OpenAIResponsesModel |                     |
+| Anthropic         | AnthropicModel       |                     |
+| Google            | GoogleModel          |                     |
+| Groq              | GroqModel            | fixed endpoint      |
+| Mistral           | MistralModel         |                     |
+| Ollama            | OllamaModel          | no credential       |
+| Bedrock           | BedrockModel         | AWS credentials     |
+| Azure             | AzureOpenAIModel     | endpoint + key      |
+| OpenRouter        | OpenRouterModel      | fixed endpoint      |
+| HuggingFace       | HuggingFaceModel     |                     |
+| Cohere            | CohereModel          | fixed endpoint      |
+| ChatGptOAuth      | ChatGptOAuthModel    | access token        |
+| ClaudeCodeOAuth   | ClaudeCodeOAuthModel | access token        |
+| Antigravity       | AntigravityModel     | token + project_id  |
+| Unknown           | ModelError           | configuration error |
+
+## Task Delegation
+
+How agents delegate work to sub-agents at runtime via the `task` tool.
+With depth limits and validation.
+
+```
+   LLM emits tool_call("task", { subagent_type, prompt, description })
+        │
+        ▼
+   TaskTool::call()
+        │
+        ▼
+    TaskHandle::execute(caller_name, input)
+        │
+        ├─ check task_settings.allows_delegation(current_depth)
+        │    └─ exceeded? -> ValidationFailed("max_task_depth reached")
+        ├─ validate_target(caller_name, target_name)
+        │    ├─ caller in catalog?       -> no  -> ExecutionFailed
+        │    ├─ target in catalog?       -> no  -> ValidationFailed("unknown")
+        │    ├─ target.mode == Primary?  -> yes -> ValidationFailed("primary")
+        │    └─ permission.task allows?  -> no  -> ValidationFailed("not allowed")
+        │
+        ├─ build_agent(context, target_name, depth+1)
+        │    └─ recursive: builds sub-agent with its own tools
+        │       (TaskTool included only if sub-agent has callable targets
+        │        and depth < max_task_depth)
+        │
+        └─ agent.run(prompt, ())
+             └─ response text -> TaskOutput
+```
+
+### Depth Guard
+
+`TaskSettings::max_depth` (default: 3) limits delegation hops:
+
+```
+   depth 0  ->  orchestrator (has TaskTool)
+   depth 1  ->  sub-agent-a  (has TaskTool if max_depth > 1)
+   depth 2  ->  sub-agent-b  (has TaskTool if max_depth > 2)
+   depth 3  ->  leaf-agent   (no TaskTool at default max_depth=3)
+```
+
+Two defenses:
+
+1. **Build time**: `build_agent()` clears `callable_target_summaries` when disabled,
+   so `attach_standard_tools()` skips TaskTool.
+2. **Runtime**: `TaskHandle::execute()` re-checks depth (defense-in-depth).
+
+## Reference
+
+### Error Model
+
+Build-time: `AgentBuildError` - catalog issues (UnknownAgent), model resolution
+failures (ModelResolutionError), or model init errors (ModelInit).
+Runtime: `ToolError::ValidationFailed` (unknown/primary target, permission denied,
+max depth) or `ToolError::ExecutionFailed` (sub-agent build/run failure).
+
+### File Map
+
+```
+llm-coding-tools-serdesai/src/
+├── agent_runtime/
+│   ├── mod.rs              module root, re-exports from llm-coding-tools-agents
+│   ├── build.rs            prepare_build(), attach_standard_tools()
+│   │                         AgentBuildError
+│   ├── model.rs            resolve_model() - thin wrapper delegating to agents crate
+│   ├── task.rs             AgentBuildContext (public)
+│   │                         build_agent() internals (private)
+│   └── provider_bridge/
+│       ├── mod.rs          build_serdes_model() - ProviderType -> concrete SerdesAI model
+│       └── tests.rs        provider bridge integration tests
+├── task/
+│   ├── mod.rs              module root, re-exports
+│   ├── definition.rs       task_tool_definition(), render_task_targets()
+│   ├── handle.rs           TaskHandle - validates + executes delegated Task calls
+│   └── tool.rs             TaskTool - SerdesAI Tool impl backed by TaskHandle
+├── agent_ext.rs            AgentBuilderExt - bridges serdes_ai::tools::Tool -> ToolExecutor
+└── lib.rs                  crate root, re-exports
+```

--- a/src/llm-coding-tools-serdesai/AGENTS-ARCHITECTURE.md
+++ b/src/llm-coding-tools-serdesai/AGENTS-ARCHITECTURE.md
@@ -3,7 +3,7 @@
 SerdesAI adapter that builds runnable [`serdes_ai::Agent`] instances from the
 framework-agnostic [`AgentRuntime`] provided by `llm-coding-tools-agents`.
 
-The crate also contains standalone file tools (read, write, edit, glob, grep,
+The crate also contains standalone tools (read, write, edit, glob, grep,
 bash, webfetch, todo) and Linux bubblewrap sandboxing. This document focuses
 on the **agent runtime** subsystem.
 
@@ -23,8 +23,6 @@ For the foundation crate, see
   - [Depth Guard](#depth-guard)
 - [Reference](#reference)
   - [Error Model](#error-model)
-  - [Feature Flags](#feature-flags)
-  - [Testing](#testing)
   - [File Map](#file-map)
 
 ## Quick Start
@@ -195,15 +193,15 @@ Connects framework-agnostic [`ResolvedModel`] to concrete SerdesAI
    build_serdes_model()
         │
         │  credential resolution:
-        │    require_env_value()    finds first _API_KEY / _TOKEN
-        │    first_matching_env()   optional values (region, project_id)
+        │    require_env_value()          finds first _API_KEY / _TOKEN
+        │    first_matching_env_value()   optional values (region, project_id)
         ▼
    ResolvedSerdesModel { model: BoxedModel, spec: "provider:model" }
 ```
 
-Each provider function is gated behind a feature flag. When the feature is
-disabled, `feature_disabled_error()` returns a clear message telling the user
-which flag to enable.
+Each provider function is gated behind a feature flag. When a feature is
+disabled, model construction returns a clear configuration error telling the
+user which flag to enable.
 
 | ProviderType      | SerdesAI Model       | Notes               |
 | ----------------- | -------------------- | ------------------- |
@@ -244,7 +242,8 @@ With depth limits and validation.
         │    ├─ caller in catalog?       -> no  -> ExecutionFailed
         │    ├─ target in catalog?       -> no  -> ValidationFailed("unknown")
         │    ├─ target.mode == Primary?  -> yes -> ValidationFailed("primary")
-        │    └─ permission.task allows?  -> no  -> ValidationFailed("not allowed")
+        │    └─ permission.task configured + disallows?
+        │         └─ yes -> ValidationFailed("not allowed")
         │
         ├─ build_agent(context, target_name, depth+1)
         │    └─ recursive: builds sub-agent with its own tools

--- a/src/llm-coding-tools-serdesai/AGENTS-ARCHITECTURE.md
+++ b/src/llm-coding-tools-serdesai/AGENTS-ARCHITECTURE.md
@@ -77,7 +77,7 @@ The process splits into two phases:
 
 Create a reusable build context once with shared resources:
 
-```
+```text
    Arc<AgentRuntime> + Arc<ModelCatalog> + Arc<Credentials>
                          │
                          ▼
@@ -98,7 +98,7 @@ Build individual SerdesAI agents from the context (can be called multiple times)
 Transforms the framework-agnostic [`AgentConfig`] into a runnable SerdesAI
 [`Agent`]:
 
-```
+```text
    AgentBuildContext::build("agent-name")
                          │
                          ▼
@@ -115,8 +115,8 @@ Transforms the framework-agnostic [`AgentConfig`] into a runnable SerdesAI
             └─────────────────────────┘
                          │
                          ▼
-              Depth guard check
-            (clears targets if at limit)
+               Depth guard check
+             (clears targets if at limit)
                          │
                          ▼
            attach_standard_tools()
@@ -136,7 +136,7 @@ recursively build each other at runtime.
 Central helper that gathers all configuration from the runtime catalog
 ([`AgentConfig`]) to construct a runnable SerdesAI [`Agent`].
 
-```
+```text
 prepare_build(runtime, name, model_catalog, credentials)
     │
     ▼
@@ -160,7 +160,7 @@ PreparedBuild {
 Resolves which model an agent should use by checking agent override, then
 runtime defaults, validating against the model catalog:
 
-```
+```text
    resolve_model_with_catalog(model_catalog, defaults, agent)
                 │
                 │  1. Check agent.model override
@@ -181,7 +181,7 @@ Precedence: **agent override** wins over **runtime default**.
 Connects framework-agnostic [`ResolvedModel`] to concrete SerdesAI
 [`BoxedModel`] implementations:
 
-```
+```text
    ResolvedModel { provider, model }
         │
         │  catalog.lookup_provider(provider)
@@ -227,7 +227,7 @@ user which flag to enable.
 How agents delegate work to sub-agents at runtime via the `task` tool.
 With depth limits and validation.
 
-```
+```text
    LLM emits tool_call("task", { subagent_type, prompt, description })
         │
         ▼
@@ -258,7 +258,7 @@ With depth limits and validation.
 
 `TaskSettings::max_depth` (default: 3) limits delegation hops:
 
-```
+```text
    depth 0  ->  orchestrator (has TaskTool)
    depth 1  ->  sub-agent-a  (has TaskTool if max_depth > 1)
    depth 2  ->  sub-agent-b  (has TaskTool if max_depth > 2)
@@ -282,7 +282,7 @@ max depth) or `ToolError::ExecutionFailed` (sub-agent build/run failure).
 
 ### File Map
 
-```
+```text
 llm-coding-tools-serdesai/src/
 ├── agent_runtime/
 │   ├── mod.rs              module root, re-exports from llm-coding-tools-agents

--- a/src/llm-coding-tools-serdesai/README.md
+++ b/src/llm-coding-tools-serdesai/README.md
@@ -103,19 +103,23 @@ More info in [SANDBOX-PROFILES.md](https://github.com/Sewer56/llm-coding-tools/b
 
 ## Agent Runtime
 
-For OpenCode-style agent support, use `AgentRuntimeExt` to build agents from an [`AgentRuntime`](https://docs.rs/llm-coding-tools-agents/latest/llm_coding_tools_agents/struct.AgentRuntime.html):
+For OpenCode-style agent support, create an [`AgentBuildContext`] from shared runtime inputs and build agents by name:
 
 ```rust,no_run
-use llm_coding_tools_serdesai::AgentRuntimeExt;
+use llm_coding_tools_serdesai::AgentBuildContext;
 use llm_coding_tools_agents::AgentRuntimeBuilder;
 use llm_coding_tools_core::{CredentialResolver, models::ModelCatalog};
+use std::sync::Arc;
 
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 # fn get_catalog() -> ModelCatalog { unimplemented!() }
 let runtime = AgentRuntimeBuilder::new().build();
-let catalog = get_catalog(); // Load from models-dev, config file, etc.
-let credentials = CredentialResolver::new();
-let _agent = runtime.build("planner", &catalog, &credentials)?;
+let build_context = AgentBuildContext::new(
+    Arc::new(runtime),
+    Arc::new(get_catalog()), // Load from models-dev, config file, etc.
+    Arc::new(CredentialResolver::new()),
+);
+let _agent = build_context.build("planner")?;
 # Ok(())
 # }
 ```
@@ -124,13 +128,13 @@ This requires the `llm-coding-tools-agents` crate, a `ModelCatalog` for model re
 
 ### Task Tool
 
-Use [`AgentRuntimeTaskExt::build_with_task`] to build an agent that can delegate one-shot work to subagents via the Task tool.
+The same `build()` call enables Task delegation when callable targets exist and `max_task_depth` permits delegation.
 
 ```rust,no_run
 use llm_coding_tools_agents::{AgentCatalog, AgentLoader, AgentRuntimeBuilder};
 use llm_coding_tools_core::CredentialResolver;
 use llm_coding_tools_models_dev::ModelsDevCatalog;
-use llm_coding_tools_serdesai::{AgentDefaults, AgentRuntimeTaskExt};
+use llm_coding_tools_serdesai::{AgentBuildContext, AgentDefaults};
 use std::{path::PathBuf, sync::Arc};
 
 # #[tokio::main]
@@ -147,24 +151,23 @@ let runtime = AgentRuntimeBuilder::new()
     // .max_task_depth(5) // Optional: defaults to 3 Task hops
     .build();
 
-let credentials = Arc::new(CredentialResolver::new());
-let agent = runtime.build_with_task(
-    "orchestrator",
+let build_context = AgentBuildContext::new(
+    Arc::new(runtime),
     Arc::new(load_result.catalog),
-    credentials,
-)?;
+    Arc::new(CredentialResolver::new()),
+);
+let agent = build_context.build("orchestrator")?;
 # Ok(())
 # }
 ```
 
 This requires the `llm-coding-tools-models-dev` crate; the example uses `ModelsDevCatalog::load()` to obtain a `ModelCatalog` for model resolution.
 
-Each Task call builds and runs the subagent once, and rejects `session_id`.
+Each Task call builds and runs the subagent once.
 
 Normal tools default to `deny` when omitted, but omitted `permission.task`
 is auto-enabled if any task is callable for OpenCode compatibility.
 
-Use [`build_agent_with_credentials_and_task`] for the lower-level helper.
 See [examples/serdesai-task.rs](examples/serdesai-task.rs).
 
 ## Examples
@@ -179,12 +182,14 @@ cargo run --example serdesai-sandboxed -p llm-coding-tools-serdesai
 # Execution with Sandboxed `bash`
 cargo run --example serdesai-sandboxed-bash --features linux-bubblewrap -p llm-coding-tools-serdesai
 
-# Markdown agent runtime (no delegation)
+# Markdown agent runtime (shared build context)
 cargo run --example serdesai-agents -p llm-coding-tools-serdesai
 
 # Stateless single-hop Task delegation
 cargo run --example serdesai-task -p llm-coding-tools-serdesai
 ```
+
+For agent runtime architecture, see [AGENTS-ARCHITECTURE.md](AGENTS-ARCHITECTURE.md).
 
 ## License
 

--- a/src/llm-coding-tools-serdesai/README.md
+++ b/src/llm-coding-tools-serdesai/README.md
@@ -15,7 +15,7 @@ llm-coding-tools-serdesai = "0.2"
 
 ## Quick Start
 
-Minimal runnable agent (requires `OPENAI_API_KEY`):
+Minimal runnable agent (requires `OPENAI_API_KEY`).
 
 ```rust,no_run
 use llm_coding_tools_serdesai::absolute::{EditTool, GlobTool, GrepTool, ReadTool};
@@ -23,35 +23,37 @@ use llm_coding_tools_serdesai::agent_ext::AgentBuilderExt;
 use llm_coding_tools_serdesai::{BashTool, SystemPromptBuilder, WebFetchTool, create_todo_tools};
 use serdes_ai::prelude::*;
 
-#[tokio::main]
-async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
-    let (todo_read, todo_write, _state) = create_todo_tools();
-    let mut pb = SystemPromptBuilder::new();
+# #[tokio::main]
+# async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+let (todo_read, todo_write, _state) = create_todo_tools();
+let mut pb = SystemPromptBuilder::new();
 
-    // Build agent with tools - call .system_prompt() last
-    let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
-        .tool(pb.track(ReadTool::<true>::new()))
-        .tool(pb.track(GlobTool::new()))
-        .tool(pb.track(GrepTool::<true>::new()))
-        .tool(pb.track(EditTool::new()))
-        .tool(pb.track(BashTool::host()))
-        .tool(pb.track(WebFetchTool::new()))
-        .tool(pb.track(todo_read))
-        .tool(pb.track(todo_write))
-        .system_prompt(pb.build())  // Last, after tracking all tools
-        .build();
+// Build agent with tools - call .system_prompt() last
+let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
+    .tool(pb.track(ReadTool::<true>::new()))
+    .tool(pb.track(GlobTool::new()))
+    .tool(pb.track(GrepTool::<true>::new()))
+    .tool(pb.track(EditTool::new()))
+    .tool(pb.track(BashTool::host()))
+    .tool(pb.track(WebFetchTool::new()))
+    .tool(pb.track(todo_read))
+    .tool(pb.track(todo_write))
+    .system_prompt(pb.build())  // Last, after tracking all tools
+    .build();
 
-    // Run agent with tools
-    let response = agent
-        .run("Search for TODO comments in src/", ())
-        .await?;
-    println!("{}", response.output());
+// Run agent with tools
+let response = agent
+    .run("Search for TODO comments in src/", ())
+    .await?;
+println!("{}", response.output());
 
-    Ok(())
-}
+# Ok(())
+# }
 ```
 
 See the [serdesai-basic example](examples/serdesai-basic.rs) for a complete working setup.
+
+For named agents and subagent Task delegation, see [Build and Run Agents](#build-and-run-agents).
 
 ## Tool Variants
 
@@ -77,58 +79,14 @@ let sandboxed_edit = AllowedEditTool::new(resolver.clone());
 let sandboxed_write = AllowedWriteTool::new(resolver);
 ```
 
-Use `SystemPromptBuilder` to track tools and generate context-aware prompts. Context strings are re-exported in `llm_coding_tools_serdesai::context` (e.g., `BASH`, `READ_ABSOLUTE`).
+Use `SystemPromptBuilder` to track tools and generate context-aware prompts.
+Context strings are re-exported in `llm_coding_tools_serdesai::context`
+(e.g., `BASH`, `READ_ABSOLUTE`).
 
-## Linux shell sandboxing
+## Build and Run Agents
 
-Enable the `linux-bubblewrap` feature flag to use Linux `bwrap` sandbox profiles:
-
-```toml
-[dependencies]
-llm-coding-tools-serdesai = { version = "0.2", features = ["linux-bubblewrap"] }
-```
-
-Out of the box, 2 profiles are available:
-
-- **Public Bot**: Assumes anyone can call; and thus defaults to the strictest containment. 
-    - No full host filesystem access, synthetic home, memory-backed `/tmp`, network disabled, sanitized system `PATH`.
-- **Trusted Maintenance**: Assumes work in a more trusted environment, e.g. maintaining codebases. 
-    - Read-only host `/` with writable overlays, disk-backed `/tmp`, sanitized host `PATH`, network enabled.
-
-We default to **Public Bot** profile when sandboxing is used.
-In either case, trusted or not, please evaluate whether the solution fits your
-security needs. I can make no guarantees.
-
-More info in [SANDBOX-PROFILES.md](https://github.com/Sewer56/llm-coding-tools/blob/main/SANDBOX-PROFILES.md).
-
-## Agent Runtime
-
-For OpenCode-style agent support, create an [`AgentBuildContext`] from shared runtime inputs and build agents by name:
-
-```rust,no_run
-use llm_coding_tools_serdesai::AgentBuildContext;
-use llm_coding_tools_agents::AgentRuntimeBuilder;
-use llm_coding_tools_core::{CredentialResolver, models::ModelCatalog};
-use std::sync::Arc;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-# fn get_catalog() -> ModelCatalog { unimplemented!() }
-let runtime = AgentRuntimeBuilder::new().build();
-let build_context = AgentBuildContext::new(
-    Arc::new(runtime),
-    Arc::new(get_catalog()), // Load from models-dev, config file, etc.
-    Arc::new(CredentialResolver::new()),
-);
-let _agent = build_context.build("planner")?;
-# Ok(())
-# }
-```
-
-This requires the `llm-coding-tools-agents` crate, a `ModelCatalog` for model resolution, and an application-owned credential resolver.
-
-### Task Tool
-
-The same `build()` call enables Task delegation when callable targets exist and `max_task_depth` permits delegation.
+Load agents, load the models.dev catalog, then build by name from a shared
+[`AgentBuildContext`]:
 
 ```rust,no_run
 use llm_coding_tools_agents::{AgentCatalog, AgentLoader, AgentRuntimeBuilder};
@@ -139,15 +97,15 @@ use std::{path::PathBuf, sync::Arc};
 
 # #[tokio::main]
 # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-let examples_root = PathBuf::from("/path/to/your/project/examples");
-let load_result = ModelsDevCatalog::load().await?;
-
+let agents_dir = PathBuf::from("path/to/your/agents");
 let mut catalog = AgentCatalog::new();
-AgentLoader::new().add_directory(&mut catalog, &examples_root)?;
+AgentLoader::new().add_directory(&mut catalog, &agents_dir)?;
+
+let load_result = ModelsDevCatalog::load().await?;
 
 let runtime = AgentRuntimeBuilder::new()
     .catalog(catalog)
-    .defaults(AgentDefaults::with_model("synthetic/hf:zai-org/GLM-4.7"))
+    .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4o-mini"))
     // .max_task_depth(5) // Optional: defaults to 3 Task hops
     .build();
 
@@ -156,19 +114,46 @@ let build_context = AgentBuildContext::new(
     Arc::new(load_result.catalog),
     Arc::new(CredentialResolver::new()),
 );
-let agent = build_context.build("orchestrator")?;
+let agent = build_context.build("planner")?;
+let response = agent.run("Say hello in one sentence.", ()).await?;
+println!("{}", response.output());
 # Ok(())
 # }
 ```
 
-This requires the `llm-coding-tools-models-dev` crate; the example uses `ModelsDevCatalog::load()` to obtain a `ModelCatalog` for model resolution.
+`AgentRuntimeBuilder::new().build()` is empty by default, so load agents into
+`.catalog(...)` before `build_context.build("planner")?`.
 
-Each Task call builds and runs the subagent once.
+Task uses the same setup and `build()` call; the `task` tool is attached
+automatically when callable targets exist and `max_task_depth` allows delegation.
 
-Normal tools default to `deny` when omitted, but omitted `permission.task`
-is auto-enabled if any task is callable for OpenCode compatibility.
+If you already have your own `ModelCatalog`, you can use that instead of
+`ModelsDevCatalog::load()` (for example via a `get_catalog()` helper).
 
-See [examples/serdesai-task.rs](examples/serdesai-task.rs).
+See [examples/serdesai-agents.rs](examples/serdesai-agents.rs) and
+[examples/serdesai-task.rs](examples/serdesai-task.rs).
+
+## Linux Shell Sandboxing
+
+Enable the `linux-bubblewrap` feature flag to use Linux `bwrap` sandbox profiles:
+
+```toml
+[dependencies]
+llm-coding-tools-serdesai = { version = "0.2", features = ["linux-bubblewrap"] }
+```
+
+Out of the box, 2 profiles are available:
+
+- **Public Bot**: Assumes anyone can call; and thus defaults to the strictest containment.
+    - No full host filesystem access, synthetic home, memory-backed `/tmp`, network disabled, sanitized system `PATH`.
+- **Trusted Maintenance**: Assumes work in a more trusted environment, e.g. maintaining codebases.
+    - Read-only host `/` with writable overlays, disk-backed `/tmp`, sanitized host `PATH`, network enabled.
+
+We default to **Public Bot** profile when sandboxing is used.
+In either case, trusted or not, please evaluate whether the solution fits your
+security needs. I can make no guarantees.
+
+More info in [SANDBOX-PROFILES.md](https://github.com/Sewer56/llm-coding-tools/blob/main/SANDBOX-PROFILES.md).
 
 ## Examples
 

--- a/src/llm-coding-tools-serdesai/examples/serdesai-agents.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-agents.rs
@@ -1,7 +1,7 @@
 //! Markdown-agent runtime example using models.dev catalog.
 //!
 //! Loads markdown agents through [`AgentLoader`], builds one named agent through
-//! [`AgentRuntimeBuilder`], and runs it without Task/delegation.
+//! [`AgentBuildContext`], and runs it.
 //!
 //! The model catalog is loaded from models.dev, which provides up-to-date
 //! provider and model information from <https://models.dev/api.json>.
@@ -12,8 +12,8 @@
 use llm_coding_tools_agents::{AgentCatalog, AgentLoader, AgentRuntimeBuilder};
 use llm_coding_tools_core::CredentialResolver;
 use llm_coding_tools_models_dev::ModelsDevCatalog;
-use llm_coding_tools_serdesai::{AgentDefaults, AgentRuntimeExt};
-use std::path::PathBuf;
+use llm_coding_tools_serdesai::{AgentBuildContext, AgentDefaults};
+use std::{path::PathBuf, sync::Arc};
 
 const AGENT_NAME: &str = "basic/file-reader";
 const MODEL_ID: &str = "synthetic/hf:zai-org/GLM-4.7-Flash";
@@ -43,12 +43,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .catalog(catalog)
         .defaults(AgentDefaults::with_model(MODEL_ID))
         .build();
+    let build_context = AgentBuildContext::new(
+        Arc::new(runtime),
+        Arc::new(load_result.catalog),
+        Arc::new(credentials),
+    );
 
     println!(
         "Loading named agent `{AGENT_NAME}` from {}",
         examples_root.display()
     );
-    let agent = runtime.build(AGENT_NAME, &load_result.catalog, &credentials)?;
+    let agent = build_context.build(AGENT_NAME)?;
     println!(
         "Built `{AGENT_NAME}` on demand with {} tools.",
         agent.tools().len()

--- a/src/llm-coding-tools-serdesai/examples/serdesai-task.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-task.rs
@@ -1,7 +1,7 @@
 //! Stateless Task delegation example using the models.dev catalog.
 //!
 //! Loads markdown agents from `examples/agents/task-demo/`, builds the primary
-//! orchestrator through [`AgentRuntimeTaskExt::build_with_task`], and runs one
+//! orchestrator through [`AgentBuildContext::build`], and runs one
 //! prompt that should delegate exactly once to `reader`.
 //!
 //! Run: Edit the API_KEY_NAME and API_KEY_VALUE constants below, then:
@@ -11,7 +11,7 @@ use futures::StreamExt;
 use llm_coding_tools_agents::{AgentCatalog, AgentLoader, AgentRuntimeBuilder};
 use llm_coding_tools_core::{CredentialResolver, TaskInput};
 use llm_coding_tools_models_dev::ModelsDevCatalog;
-use llm_coding_tools_serdesai::{AgentDefaults, AgentRuntimeTaskExt};
+use llm_coding_tools_serdesai::{AgentBuildContext, AgentDefaults};
 use serdes_ai::{AgentStreamEvent, UserContent};
 use std::{
     fmt::Write,
@@ -52,16 +52,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .catalog(catalog)
         .defaults(AgentDefaults::with_model(MODEL_ID))
         .build();
+    let build_context = AgentBuildContext::new(
+        Arc::new(runtime),
+        Arc::new(load_result.catalog),
+        Arc::new(credentials),
+    );
 
     println!(
         "Loading named agent `{AGENT_NAME}` from {}",
         agents_dir.display()
     );
-    let agent = runtime.build_with_task(
-        AGENT_NAME,
-        Arc::new(load_result.catalog),
-        Arc::new(credentials),
-    )?;
+    let agent = build_context.build(AGENT_NAME)?;
     println!(
         "Built `{AGENT_NAME}` on demand with {} tools.",
         agent.tools().len()

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
@@ -54,12 +54,6 @@ impl PreparedBuild {
     pub(super) fn callable_target_summaries(&self) -> &[TaskTargetSummary] {
         &self.callable_target_summaries
     }
-
-    /// Clears callable Task target summaries for depth-limited builds.
-    #[inline]
-    pub(super) fn clear_callable_target_summaries(&mut self) {
-        self.callable_target_summaries.clear();
-    }
 }
 
 /// Resolves model configuration and collects build parameters for an agent.
@@ -68,6 +62,7 @@ pub(super) fn prepare_build<C>(
     name: &str,
     model_catalog: &ModelCatalog,
     credentials: &C,
+    with_summaries: bool,
 ) -> Result<PreparedBuild, AgentBuildError>
 where
     C: CredentialLookup,
@@ -79,7 +74,11 @@ where
     let resolved = resolve_model(model_catalog, runtime.defaults(), agent)?;
     let serdes_model = build_serdes_model(model_catalog, &resolved, credentials)?;
     let tools = runtime.allowed_tools(name);
-    let callable_target_summaries = summarize_callable_targets(runtime.catalog(), name);
+    let callable_target_summaries = if with_summaries {
+        summarize_callable_targets(runtime.catalog(), name)
+    } else {
+        Vec::new()
+    };
 
     Ok(PreparedBuild {
         agent_name: agent.name.clone(),
@@ -320,8 +319,8 @@ mod tests {
             .build();
 
         // Agent with permissions gets only the allowed tools
-        let prepared =
-            prepare_build(&runtime, "with-tools", &catalog, &credentials).expect("should succeed");
+        let prepared = prepare_build(&runtime, "with-tools", &catalog, &credentials, true)
+            .expect("should succeed");
         let agent = build_with_mock(&prepared, "with-tools");
         let names: HashSet<&str> = agent.tools().iter().map(|t| t.name()).collect();
         assert!(names.contains(read_meta::NAME));
@@ -329,8 +328,8 @@ mod tests {
         assert_eq!(names.len(), 2);
 
         // Agent with empty permissions gets no tools
-        let prepared =
-            prepare_build(&runtime, "no-tools", &catalog, &credentials).expect("should succeed");
+        let prepared = prepare_build(&runtime, "no-tools", &catalog, &credentials, true)
+            .expect("should succeed");
         let agent = build_with_mock(&prepared, "no-tools");
         assert!(agent.tools().is_empty());
     }
@@ -358,8 +357,8 @@ mod tests {
             .build();
 
         // Agent-level settings win over defaults
-        let prepared =
-            prepare_build(&runtime, "planner", &catalog, &credentials).expect("should succeed");
+        let prepared = prepare_build(&runtime, "planner", &catalog, &credentials, true)
+            .expect("should succeed");
         assert_eq!(prepared.model_spec.as_ref(), "openrouter:openai/gpt-4o");
         assert!((prepared.temperature.unwrap() - 0.4).abs() < 1e-6);
         assert!((prepared.top_p.unwrap() - 0.8).abs() < 1e-6);
@@ -374,7 +373,7 @@ mod tests {
         let runtime = AgentRuntimeBuilder::new()
             .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
             .build();
-        let err = prepare_build(&runtime, "missing", &catalog, &credentials)
+        let err = prepare_build(&runtime, "missing", &catalog, &credentials, true)
             .err()
             .expect("should fail");
         assert!(matches!(err, AgentBuildError::UnknownAgent { name } if &*name == "missing"));
@@ -402,7 +401,7 @@ mod tests {
             .defaults(AgentDefaults::default())
             .build();
         let prepared =
-            prepare_build(&runtime, "dupe", &catalog, &credentials).expect("should succeed");
+            prepare_build(&runtime, "dupe", &catalog, &credentials, true).expect("should succeed");
         assert_eq!(prepared.model_spec.as_ref(), "openrouter:openai/gpt-4o");
         let agent = build_with_mock(&prepared, "dupe");
         assert_eq!(agent.tools().len(), 1);

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
@@ -1,8 +1,8 @@
-//! Build SerdesAI agents from an [`AgentRuntime`] catalog.
+//! Shared SerdesAI agent build helpers.
 //!
-//! Use [`AgentRuntimeExt::build`] or [`build_agent_with_credentials`] with an
-//! application-provided credential resolver. The builder resolves the model,
-//! filters tools by permissions, and sets up the system prompt.
+//! [`AgentBuildContext`](crate::agent_runtime::AgentBuildContext) and Task delegation
+//! internals reuse these helpers to resolve models, permissions, and tool
+//! attachments.
 
 use super::model::resolve_model;
 use super::provider_bridge::build_serdes_model;
@@ -16,62 +16,9 @@ use llm_coding_tools_agents::{
     AgentRuntime, ModelResolutionError, TaskTargetSummary, ToolCatalogEntry, ToolCatalogKind,
     summarize_callable_targets,
 };
-use llm_coding_tools_core::{CredentialLookup, CredentialResolver, models::ModelCatalog};
-use serdes_ai::{Agent, AgentBuilder};
+use llm_coding_tools_core::{CredentialLookup, models::ModelCatalog};
+use serdes_ai::AgentBuilder;
 use serdes_ai_models::BoxedModel;
-
-/// SerdesAI-specific runtime extension methods.
-pub trait AgentRuntimeExt {
-    /// Builds a runnable SerdesAI agent for the named catalog entry.
-    fn build<C>(
-        &self,
-        name: &str,
-        model_catalog: &ModelCatalog,
-        credentials: &C,
-    ) -> Result<Agent<(), String>, AgentBuildError>
-    where
-        C: CredentialLookup;
-}
-
-impl AgentRuntimeExt for AgentRuntime {
-    fn build<C>(
-        &self,
-        name: &str,
-        model_catalog: &ModelCatalog,
-        credentials: &C,
-    ) -> Result<Agent<(), String>, AgentBuildError>
-    where
-        C: CredentialLookup,
-    {
-        let prepared = prepare_build(self, name, model_catalog, credentials)?;
-        let builder = AgentBuilder::<(), String>::from_arc(prepared.model.clone());
-        Ok(finish_builder(builder, &prepared)?.build())
-    }
-}
-
-/// Builds a runnable SerdesAI agent using the provided credential resolver.
-///
-/// This is useful when your application wants to provide config-file or test
-/// overrides while keeping the catalog-driven provider lookup flow.
-///
-/// # Errors
-///
-/// Returns [`AgentBuildError`] when the named agent is missing, model selection
-/// fails, the adapter cannot create one of the requested tools, or the model
-/// backend rejects the resolved credentials or provider settings.
-pub fn build_agent_with_credentials<C>(
-    runtime: &AgentRuntime,
-    name: &str,
-    model_catalog: &ModelCatalog,
-    credentials: &C,
-) -> Result<Agent<(), String>, AgentBuildError>
-where
-    C: CredentialLookup,
-{
-    let prepared = prepare_build(runtime, name, model_catalog, credentials)?;
-    let builder = AgentBuilder::<(), String>::from_arc(prepared.model.clone());
-    Ok(finish_builder(builder, &prepared)?.build())
-}
 
 /// Resolved build parameters ready for agent construction.
 #[derive(Clone)]
@@ -107,6 +54,12 @@ impl PreparedBuild {
     pub(super) fn callable_target_summaries(&self) -> &[TaskTargetSummary] {
         &self.callable_target_summaries
     }
+
+    /// Clears callable Task target summaries for depth-limited builds.
+    #[inline]
+    pub(super) fn clear_callable_target_summaries(&mut self) {
+        self.callable_target_summaries.clear();
+    }
 }
 
 /// Resolves model configuration and collects build parameters for an agent.
@@ -141,24 +94,6 @@ where
         tools,
         callable_target_summaries,
     })
-}
-
-/// Resolves build parameters for a Task-enabled build at `current_depth`.
-pub(super) fn prepare_task_build<C>(
-    runtime: &AgentRuntime,
-    name: &str,
-    model_catalog: &ModelCatalog,
-    credentials: &C,
-    current_depth: u8,
-) -> Result<PreparedBuild, AgentBuildError>
-where
-    C: CredentialLookup,
-{
-    let mut prepared = prepare_build(runtime, name, model_catalog, credentials)?;
-    if !runtime.task_settings().allows_delegation(current_depth) {
-        prepared.callable_target_summaries.clear();
-    }
-    Ok(prepared)
 }
 
 /// Attaches the standard runtime tools and prompt contexts without finalizing the builder.
@@ -226,18 +161,6 @@ where
     Ok((builder, prompt_builder))
 }
 
-/// Configures an [`AgentBuilder`] with name, prompt, tools, and sampling parameters.
-///
-/// Returns [`AgentBuildError::UnsupportedToolKind`] if a tool kind cannot be materialized.
-fn finish_builder(
-    builder: AgentBuilder<(), String>,
-    prepared: &PreparedBuild,
-) -> Result<AgentBuilder<(), String>, AgentBuildError> {
-    let (builder, prompt_builder) =
-        attach_standard_tools::<CredentialResolver>(builder, prepared, None)?;
-    Ok(builder.system_prompt(prompt_builder.build()))
-}
-
 /// Error returned when a build cannot produce a SerdesAI agent.
 #[derive(Debug, thiserror::Error)]
 pub enum AgentBuildError {
@@ -263,7 +186,7 @@ pub enum AgentBuildError {
 
 #[cfg(test)]
 mod tests {
-    use super::{AgentBuildError, prepare_build};
+    use super::{AgentBuildError, attach_standard_tools, prepare_build};
     use ahash::AHashMap;
     use indexmap::IndexMap;
     use llm_coding_tools_agents::{
@@ -276,7 +199,7 @@ mod tests {
     };
     use llm_coding_tools_core::permissions::PermissionAction;
     use llm_coding_tools_core::tool_metadata::{
-        bash as bash_meta, glob as glob_meta, read as read_meta, task as task_meta,
+        bash as bash_meta, glob as glob_meta, read as read_meta,
     };
     use serdes_ai::AgentBuilder;
     use serdes_ai_models::MockModel;
@@ -287,12 +210,13 @@ mod tests {
         prepared: &super::PreparedBuild,
         name: &str,
     ) -> serdes_ai::Agent<(), String> {
-        super::finish_builder(
+        let (builder, prompt_builder) = attach_standard_tools::<CredentialResolver>(
             AgentBuilder::<(), String>::new(MockModel::new(name)),
             prepared,
+            None,
         )
-        .expect("build should succeed")
-        .build()
+        .expect("build should succeed");
+        builder.system_prompt(prompt_builder.build()).build()
     }
 
     /// Creates a minimal agent config with no model or sampling overrides.
@@ -483,66 +407,5 @@ mod tests {
         let agent = build_with_mock(&prepared, "dupe");
         assert_eq!(agent.tools().len(), 1);
         assert_eq!(agent.tools()[0].name(), glob_meta::NAME);
-    }
-
-    /// Creates a subagent config with no model or sampling overrides.
-    fn subagent(
-        name: &str,
-        permission: IndexMap<String, PermissionRule>,
-        prompt: &str,
-    ) -> AgentConfig {
-        let mut config = agent(name, permission, prompt);
-        config.mode = AgentMode::Subagent;
-        config
-    }
-
-    #[test]
-    fn plain_build_omits_task_tool_without_task_handle() {
-        let credentials = credentials();
-        let catalog = catalog();
-
-        let runtime = AgentRuntimeBuilder::new()
-            .catalog(AgentCatalog::from_entries([
-                agent(
-                    "caller",
-                    allow_tools(&[task_meta::NAME, read_meta::NAME]),
-                    "prompt",
-                ),
-                subagent("sub-target", IndexMap::new(), "subagent prompt"),
-            ]))
-            .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
-            .build();
-
-        let prepared =
-            prepare_build(&runtime, "caller", &catalog, &credentials).expect("should succeed");
-        assert!(!prepared.callable_target_summaries.is_empty());
-
-        let agent = build_with_mock(&prepared, "caller");
-        let names: Vec<&str> = agent.tools().iter().map(|t| t.name()).collect();
-        assert!(names.contains(&read_meta::NAME));
-        assert!(!names.contains(&task_meta::NAME));
-    }
-
-    #[test]
-    fn build_skips_task_tool_when_no_callable_targets() {
-        let credentials = credentials();
-        let catalog = catalog();
-
-        let runtime = AgentRuntimeBuilder::new()
-            .catalog(AgentCatalog::from_entries([agent(
-                "solo",
-                allow_tools(&[task_meta::NAME]),
-                "prompt",
-            )]))
-            .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
-            .build();
-
-        let prepared =
-            prepare_build(&runtime, "solo", &catalog, &credentials).expect("should succeed");
-        assert!(prepared.callable_target_summaries.is_empty());
-
-        let agent = build_with_mock(&prepared, "solo");
-        let names: Vec<&str> = agent.tools().iter().map(|t| t.name()).collect();
-        assert!(!names.contains(&task_meta::NAME));
     }
 }

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/mod.rs
@@ -1,25 +1,22 @@
 //! SerdesAI adapter for the generic agent runtime.
 //!
 //! The data-only runtime foundation lives in [`llm_coding_tools_agents`]. This
-//! module re-exports those generic types and adds SerdesAI-specific agent
-//! building through [`AgentRuntimeExt`] and [`build_agent_with_credentials`],
-//! both of which accept caller-provided model catalogs and credential lookups.
+//! module re-exports those generic types and adds SerdesAI-specific build
+//! orchestration through [`AgentBuildContext`].
 //!
 //! # Public API
-//! - [`AgentRuntimeExt`] - Builds a runnable SerdesAI agent for the named catalog entry.
-//! - [`build_agent_with_credentials`] - Builds with explicit caller-provided credentials.
-//! - [`AgentRuntimeTaskExt`] - Builds with conditional Task support.
-//! - [`build_agent_with_credentials_and_task`] - Task-enabled build with explicit credentials.
+//! - [`AgentBuildContext`] - Shared context that builds runnable agents by name.
+//! - [`AgentBuildError`] - Build-time failures.
 
 mod build;
 mod model;
 mod provider_bridge;
 mod task;
 
-pub use build::{AgentBuildError, AgentRuntimeExt, build_agent_with_credentials};
+pub use build::AgentBuildError;
 pub use llm_coding_tools_agents::{
     AgentDefaults, AgentRuntime, AgentRuntimeBuilder, ModelResolutionError, ResolvedModel,
     ToolCatalogEntry, ToolCatalogKind, default_tools, resolve_model_with_catalog,
 };
-pub use task::{AgentRuntimeTaskExt, build_agent_with_credentials_and_task};
-pub(crate) use task::{TaskBuildContext, build_task_enabled_agent};
+pub use task::AgentBuildContext;
+pub(crate) use task::{TaskBuildContext, build_agent};

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/task.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/task.rs
@@ -114,19 +114,17 @@ pub(crate) fn build_agent<C>(
 where
     C: CredentialLookup + Send + Sync + 'static,
 {
-    let mut prepared = prepare_build(
+    let with_summaries = context
+        .runtime()
+        .task_settings()
+        .allows_delegation(current_depth);
+    let prepared = prepare_build(
         context.runtime.as_ref(),
         name,
         context.model_catalog.as_ref(),
         context.credentials.as_ref(),
+        with_summaries,
     )?;
-    if !context
-        .runtime()
-        .task_settings()
-        .allows_delegation(current_depth)
-    {
-        prepared.clear_callable_target_summaries();
-    }
     let builder = AgentBuilder::<(), String>::from_arc(prepared.model().clone());
     let task_handle = TaskHandle::new(context, current_depth);
     let (builder, prompt_builder) = attach_standard_tools(builder, &prepared, Some(&task_handle))?;

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/task.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/task.rs
@@ -1,41 +1,68 @@
-//! Task-enabled SerdesAI runtime builders.
+//! Shared-context SerdesAI runtime builder.
 //!
 //! # Public API
-//! - [`AgentRuntimeTaskExt`] - Builds a runnable agent with conditional Task support.
-//! - [`build_agent_with_credentials_and_task`] - Same build path with explicit shared credentials.
+//! - [`AgentBuildContext`] - Reusable shared inputs for building runnable agents.
 
-use super::build::{AgentBuildError, attach_standard_tools, prepare_task_build};
+use super::build::{AgentBuildError, attach_standard_tools, prepare_build};
+use crate::task::TaskHandle;
 use llm_coding_tools_agents::AgentRuntime;
 use llm_coding_tools_core::{CredentialLookup, CredentialResolver, models::ModelCatalog};
 use serdes_ai::{Agent, AgentBuilder};
 use std::sync::Arc;
 
-use crate::task::TaskHandle;
-
-/// SerdesAI-specific task-enabled runtime extension methods.
-pub trait AgentRuntimeTaskExt {
-    /// Builds a runnable SerdesAI agent that conditionally includes Task delegation.
-    fn build_with_task<C>(
-        &self,
-        name: &str,
-        model_catalog: Arc<ModelCatalog>,
-        credentials: Arc<C>,
-    ) -> Result<Agent<(), String>, AgentBuildError>
-    where
-        C: CredentialLookup + Send + Sync + 'static;
+/// Reusable shared inputs for building runnable SerdesAI agents.
+///
+/// Create once and call [`AgentBuildContext::build`] for each catalog agent
+/// name you want to run. This build path always applies Task delegation
+/// semantics; the Task tool is still attached conditionally based on
+/// callable targets and `max_task_depth`.
+#[derive(Clone)]
+pub struct AgentBuildContext<C: CredentialLookup + Send + Sync + 'static = CredentialResolver> {
+    context: Arc<TaskBuildContext<C>>,
 }
 
-impl AgentRuntimeTaskExt for AgentRuntime {
-    fn build_with_task<C>(
-        &self,
-        name: &str,
+impl<C> AgentBuildContext<C>
+where
+    C: CredentialLookup + Send + Sync + 'static,
+{
+    /// Creates a shared build context from runtime state, model catalog, and credentials.
+    #[inline]
+    pub fn new(
+        runtime: Arc<AgentRuntime>,
         model_catalog: Arc<ModelCatalog>,
         credentials: Arc<C>,
-    ) -> Result<Agent<(), String>, AgentBuildError>
-    where
-        C: CredentialLookup + Send + Sync + 'static,
-    {
-        build_agent_with_credentials_and_task(self, name, model_catalog, credentials)
+    ) -> Self {
+        Self {
+            context: Arc::new(TaskBuildContext {
+                runtime,
+                model_catalog,
+                credentials,
+            }),
+        }
+    }
+
+    /// Builds a runnable SerdesAI agent for the named catalog entry.
+    #[inline]
+    pub fn build(&self, name: &str) -> Result<Agent<(), String>, AgentBuildError> {
+        build_agent(Arc::clone(&self.context), name, 0)
+    }
+
+    /// Returns the shared runtime.
+    #[inline]
+    pub fn runtime(&self) -> &AgentRuntime {
+        self.context.runtime()
+    }
+
+    /// Returns the shared model catalog.
+    #[inline]
+    pub fn model_catalog(&self) -> &ModelCatalog {
+        self.context.model_catalog.as_ref()
+    }
+
+    /// Returns the shared credential lookup.
+    #[inline]
+    pub fn credentials(&self) -> &C {
+        self.context.credentials.as_ref()
     }
 }
 
@@ -43,7 +70,7 @@ impl AgentRuntimeTaskExt for AgentRuntime {
 #[derive(Clone)]
 pub(crate) struct TaskBuildContext<C: CredentialLookup + Send + Sync + ?Sized = CredentialResolver>
 {
-    runtime: AgentRuntime,
+    runtime: Arc<AgentRuntime>,
     model_catalog: Arc<ModelCatalog>,
     credentials: Arc<C>,
 }
@@ -55,7 +82,7 @@ where
     /// Returns a reference to the runtime.
     #[inline]
     pub(crate) fn runtime(&self) -> &AgentRuntime {
-        &self.runtime
+        self.runtime.as_ref()
     }
 }
 
@@ -66,7 +93,7 @@ where
 {
     /// Creates a new task build context for testing.
     pub fn new_for_test(
-        runtime: AgentRuntime,
+        runtime: Arc<AgentRuntime>,
         model_catalog: Arc<ModelCatalog>,
         credentials: Arc<C>,
     ) -> Self {
@@ -78,26 +105,8 @@ where
     }
 }
 
-/// Builds a runnable SerdesAI agent with conditional Task support using shared credentials.
-pub fn build_agent_with_credentials_and_task<C>(
-    runtime: &AgentRuntime,
-    name: &str,
-    model_catalog: Arc<ModelCatalog>,
-    credentials: Arc<C>,
-) -> Result<Agent<(), String>, AgentBuildError>
-where
-    C: CredentialLookup + Send + Sync + 'static,
-{
-    let context = Arc::new(TaskBuildContext {
-        runtime: runtime.clone(),
-        model_catalog,
-        credentials,
-    });
-    build_task_enabled_agent(context, name, 0)
-}
-
-/// Builds one runnable agent using the shared task-enabled build context.
-pub(crate) fn build_task_enabled_agent<C>(
+/// Builds one runnable agent using the shared build context.
+pub(crate) fn build_agent<C>(
     context: Arc<TaskBuildContext<C>>,
     name: &str,
     current_depth: u8,
@@ -105,13 +114,19 @@ pub(crate) fn build_task_enabled_agent<C>(
 where
     C: CredentialLookup + Send + Sync + 'static,
 {
-    let prepared = prepare_task_build(
-        &context.runtime,
+    let mut prepared = prepare_build(
+        context.runtime.as_ref(),
         name,
         context.model_catalog.as_ref(),
         context.credentials.as_ref(),
-        current_depth,
     )?;
+    if !context
+        .runtime()
+        .task_settings()
+        .allows_delegation(current_depth)
+    {
+        prepared.clear_callable_target_summaries();
+    }
     let builder = AgentBuilder::<(), String>::from_arc(prepared.model().clone());
     let task_handle = TaskHandle::new(context, current_depth);
     let (builder, prompt_builder) = attach_standard_tools(builder, &prepared, Some(&task_handle))?;
@@ -202,7 +217,7 @@ mod tests {
     }
 
     #[test]
-    fn build_task_enabled_agent_skips_task_tool_when_no_targets_are_callable() {
+    fn build_agent_skips_task_tool_when_no_targets_are_callable() {
         let credentials = credentials();
         let model_catalog = Arc::new(catalog());
 
@@ -220,18 +235,18 @@ mod tests {
             .build();
 
         let context = Arc::new(TaskBuildContext {
-            runtime,
+            runtime: Arc::new(runtime),
             model_catalog,
             credentials,
         });
 
-        let agent = build_task_enabled_agent(context, "caller", 0).expect("build should succeed");
+        let agent = build_agent(context, "caller", 0).expect("build should succeed");
         let names: Vec<_> = agent.tools().iter().map(|t| t.name()).collect();
         assert!(!names.contains(&task_meta::NAME));
     }
 
     #[test]
-    fn build_task_enabled_agent_attaches_task_when_callable_targets_exist() {
+    fn build_agent_attaches_task_when_callable_targets_exist() {
         let credentials = credentials();
         let model_catalog = Arc::new(catalog());
 
@@ -254,19 +269,19 @@ mod tests {
             .build();
 
         let context = Arc::new(TaskBuildContext {
-            runtime,
+            runtime: Arc::new(runtime),
             model_catalog,
             credentials,
         });
 
-        let agent = build_task_enabled_agent(context, "caller", 0).expect("build should succeed");
+        let agent = build_agent(context, "caller", 0).expect("build should succeed");
         let names: Vec<_> = agent.tools().iter().map(|t| t.name()).collect();
         assert!(names.contains(&task_meta::NAME));
         assert!(names.contains(&read_meta::NAME));
     }
 
     #[test]
-    fn build_task_enabled_agent_attaches_task_when_task_permission_is_target_scoped() {
+    fn build_agent_attaches_task_when_task_permission_is_target_scoped() {
         let credentials = credentials();
         let model_catalog = Arc::new(catalog());
 
@@ -287,18 +302,18 @@ mod tests {
             .build();
 
         let context = Arc::new(TaskBuildContext {
-            runtime,
+            runtime: Arc::new(runtime),
             model_catalog,
             credentials,
         });
 
-        let agent = build_task_enabled_agent(context, "caller", 0).expect("build should succeed");
+        let agent = build_agent(context, "caller", 0).expect("build should succeed");
         let names: Vec<_> = agent.tools().iter().map(|t| t.name()).collect();
         assert_eq!(names, vec![task_meta::NAME]);
     }
 
     #[test]
-    fn build_task_enabled_agent_attaches_task_when_permission_task_is_absent() {
+    fn build_agent_attaches_task_when_permission_task_is_absent() {
         let credentials = credentials();
         let model_catalog = Arc::new(catalog());
 
@@ -316,21 +331,21 @@ mod tests {
             .build();
 
         let context = Arc::new(TaskBuildContext {
-            runtime,
+            runtime: Arc::new(runtime),
             model_catalog,
             credentials,
         });
 
         // OpenCode-compatible default: omitting `permission.task` still exposes Task.
         // Any non-primary callable target keeps delegation available to the caller.
-        let agent = build_task_enabled_agent(context, "caller", 0).expect("build should succeed");
+        let agent = build_agent(context, "caller", 0).expect("build should succeed");
         let names: Vec<_> = agent.tools().iter().map(|t| t.name()).collect();
         assert!(names.contains(&read_meta::NAME));
         assert!(names.contains(&task_meta::NAME));
     }
 
     #[test]
-    fn build_with_task_omits_task_tool_when_no_targets_are_callable() {
+    fn agent_build_context_omits_task_tool_when_no_targets_are_callable() {
         let model_catalog = Arc::new(catalog());
         let credentials = credentials();
 
@@ -347,15 +362,14 @@ mod tests {
             .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
             .build();
 
-        let agent = runtime
-            .build_with_task("caller", model_catalog, credentials)
-            .expect("build should succeed");
+        let context = AgentBuildContext::new(Arc::new(runtime), model_catalog, credentials);
+        let agent = context.build("caller").expect("build should succeed");
         let names: Vec<_> = agent.tools().iter().map(|t| t.name()).collect();
         assert!(!names.contains(&task_meta::NAME));
     }
 
     #[test]
-    fn build_task_enabled_agent_omits_task_tool_at_max_depth() {
+    fn build_agent_omits_task_tool_at_max_depth() {
         // Mid-chain: an already-delegated agent (depth=1) at max_task_depth=1
         // must not receive the Task tool.
         let credentials = credentials();
@@ -381,19 +395,19 @@ mod tests {
             .build();
 
         let context = Arc::new(TaskBuildContext {
-            runtime,
+            runtime: Arc::new(runtime),
             model_catalog,
             credentials,
         });
 
-        let agent = build_task_enabled_agent(context, "caller", 1).expect("build should succeed");
+        let agent = build_agent(context, "caller", 1).expect("build should succeed");
         let names: Vec<_> = agent.tools().iter().map(|t| t.name()).collect();
         assert!(!names.contains(&task_meta::NAME));
         assert!(names.contains(&read_meta::NAME));
     }
 
     #[test]
-    fn build_with_task_omits_task_tool_when_max_depth_is_zero() {
+    fn agent_build_context_omits_task_tool_when_max_depth_is_zero() {
         // Root agent: max_task_depth=0 disables delegation entirely from the start.
         let model_catalog = Arc::new(catalog());
         let credentials = credentials();
@@ -417,9 +431,8 @@ mod tests {
             .max_task_depth(0)
             .build();
 
-        let agent = runtime
-            .build_with_task("caller", model_catalog, credentials)
-            .expect("build should succeed");
+        let context = AgentBuildContext::new(Arc::new(runtime), model_catalog, credentials);
+        let agent = context.build("caller").expect("build should succeed");
         let names: Vec<_> = agent.tools().iter().map(|t| t.name()).collect();
         assert!(!names.contains(&task_meta::NAME));
         assert!(names.contains(&read_meta::NAME));

--- a/src/llm-coding-tools-serdesai/src/lib.rs
+++ b/src/llm-coding-tools-serdesai/src/lib.rs
@@ -54,10 +54,7 @@ pub use llm_coding_tools_core::{
 };
 
 // Re-export standalone tools and runtime helpers
-pub use agent_runtime::{
-    AgentBuildError, AgentRuntimeExt, AgentRuntimeTaskExt, build_agent_with_credentials,
-    build_agent_with_credentials_and_task,
-};
+pub use agent_runtime::{AgentBuildContext, AgentBuildError};
 pub use bash::BashTool;
 pub use llm_coding_tools_agents::{
     AgentDefaults, AgentRuntime, AgentRuntimeBuilder, ModelResolutionError, ResolvedModel,

--- a/src/llm-coding-tools-serdesai/src/task/definition.rs
+++ b/src/llm-coding-tools-serdesai/src/task/definition.rs
@@ -54,11 +54,6 @@ pub fn task_tool_definition(targets: &[TaskTargetSummary]) -> ToolDefinition {
             task_meta::param::SUBAGENT_TYPE.required,
         )
         .string(
-            task_meta::param::SESSION_ID.name,
-            task_meta::param::SESSION_ID.description,
-            task_meta::param::SESSION_ID.required,
-        )
-        .string(
             task_meta::param::COMMAND.name,
             task_meta::param::COMMAND.description,
             task_meta::param::COMMAND.required,
@@ -133,14 +128,5 @@ mod tests {
         // Verify description includes all expected parameters
         let desc = definition.description();
         assert!(!desc.is_empty());
-    }
-
-    #[test]
-    fn task_tool_definition_keeps_session_id_description_compatibility_only() {
-        let targets = vec![];
-        let definition = task_tool_definition(&targets);
-
-        // The definition should be valid and include task
-        assert_eq!(definition.name(), task_meta::NAME);
     }
 }

--- a/src/llm-coding-tools-serdesai/src/task/handle.rs
+++ b/src/llm-coding-tools-serdesai/src/task/handle.rs
@@ -4,7 +4,7 @@
 //! then builds and runs that agent with the caller's prompt.
 //! Each call is independent — no session state is kept between runs.
 
-use crate::agent_runtime::{TaskBuildContext, build_task_enabled_agent};
+use crate::agent_runtime::{TaskBuildContext, build_agent};
 use llm_coding_tools_agents::{AgentMode, RulesetExt};
 use llm_coding_tools_core::permissions::Ruleset;
 use llm_coding_tools_core::tool_metadata::task as task_meta;
@@ -34,7 +34,7 @@ impl<C> TaskHandle<C>
 where
     C: CredentialLookup + Send + Sync + 'static,
 {
-    /// Creates a new handle over the shared task-enabled build context.
+    /// Creates a new handle over the shared build context.
     #[inline]
     pub(crate) fn new(context: Arc<TaskBuildContext<C>>, current_depth: u8) -> Self {
         Self {
@@ -58,7 +58,6 @@ where
     /// # Errors
     ///
     /// Returns [`ToolError::ValidationFailed`] when:
-    /// - `session_id` is present (task sessions are unsupported).
     /// - The caller is already at the configured maximum Task delegation depth.
     /// - The caller or target agent is missing from the catalog.
     /// - The target uses [`AgentMode::Primary`].
@@ -71,14 +70,6 @@ where
         caller_name: &str,
         input: TaskInput,
     ) -> Result<TaskOutput, ToolError> {
-        if input.session_id.is_some() {
-            return Err(ToolError::validation_error(
-                task_meta::NAME,
-                Some("session_id".to_string()),
-                "task sessions are not supported by this runtime; omit `session_id`",
-            ));
-        }
-
         let target_name = input.subagent_type.clone();
         let task_settings = self.context.runtime().task_settings();
         if !task_settings.allows_delegation(self.current_depth) {
@@ -95,7 +86,7 @@ where
         }
 
         self.validate_target(caller_name, &target_name)?;
-        let agent = build_task_enabled_agent::<C>(
+        let agent = build_agent::<C>(
             self.context.clone(),
             target_name.as_str(),
             self.current_depth.saturating_add(1),
@@ -247,7 +238,7 @@ mod tests {
         runtime: llm_coding_tools_agents::AgentRuntime,
     ) -> Arc<TaskBuildContext<CredentialResolver<false>>> {
         Arc::new(TaskBuildContext::new_for_test(
-            runtime,
+            Arc::new(runtime),
             Arc::new(catalog()),
             credentials(),
         ))
@@ -268,7 +259,6 @@ mod tests {
             description: "test".into(),
             prompt: "test prompt".into(),
             subagent_type: "nonexistent".into(),
-            session_id: None,
             command: None,
         };
 
@@ -301,7 +291,6 @@ mod tests {
             description: "test".into(),
             prompt: "test prompt".into(),
             subagent_type: "primary-agent".into(),
-            session_id: None,
             command: None,
         };
 
@@ -338,7 +327,6 @@ mod tests {
             description: "test".into(),
             prompt: "test prompt".into(),
             subagent_type: "target".into(),
-            session_id: None,
             command: None,
         };
 
@@ -352,41 +340,6 @@ mod tests {
                 let error_message = &errors[0].message;
                 assert!(error_message.contains("not allowed"));
                 assert!(error_message.contains("caller"));
-            }
-            _ => panic!("Expected ValidationFailed error, got: {:?}", err),
-        }
-    }
-
-    #[tokio::test]
-    async fn execute_rejects_session_id() {
-        let runtime = runtime_with_agents(vec![
-            agent("caller", AgentMode::All, allow_tools(&[task_meta::NAME])),
-            agent("target", AgentMode::All, allow_tools(&[])),
-        ])
-        .build();
-        let context = build_test_context(runtime);
-        let handle = TaskHandle::new(context, 0);
-
-        let input = TaskInput {
-            description: "test".into(),
-            prompt: "test prompt".into(),
-            subagent_type: "target".into(),
-            session_id: Some("session-123".into()),
-            command: None,
-        };
-
-        let result = handle.execute("caller", input).await;
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        match &err {
-            ToolError::ValidationFailed { tool_name, errors } => {
-                assert_eq!(tool_name, task_meta::NAME);
-                assert!(!errors.is_empty());
-                let error_field = errors[0].field.as_ref().expect("Expected field");
-                assert_eq!(error_field, "session_id");
-                let error_message = &errors[0].message;
-                assert!(error_message.contains("not supported"));
-                assert!(error_message.contains("omit"));
             }
             _ => panic!("Expected ValidationFailed error, got: {:?}", err),
         }
@@ -410,7 +363,6 @@ mod tests {
             description: "test".into(),
             prompt: "test prompt".into(),
             subagent_type: "target".into(),
-            session_id: None,
             command: None,
         };
 

--- a/src/llm-coding-tools-serdesai/src/task/mod.rs
+++ b/src/llm-coding-tools-serdesai/src/task/mod.rs
@@ -5,7 +5,7 @@
 //! - [`render_task_targets`] - Renders callable targets for Task descriptions.
 //!
 //! The concrete runtime pieces that execute delegated work stay crate-private so
-//! callers use the public task-enabled build APIs instead of constructing Task
+//! callers use the public build API instead of constructing Task
 //! tools by hand.
 
 mod definition;


### PR DESCRIPTION
## Summary
- Consolidate SerdesAI agent creation into one API path: `AgentBuildContext::build()`.
- Drop `session_id` from the Task contract to align with stateless delegation.
- Add architecture docs for both runtime crates and link them from README docs.

## Details
- **Unified build path**
  - Removed old split APIs (`AgentRuntimeExt`, `AgentRuntimeTaskExt`, and related helper functions).
  - Introduced/standardized `AgentBuildContext::new(...).build(name)`.
  - Renamed internal builder helper to `build_agent` and inlined depth-gating prep logic into that path.
- **Task API cleanup**
  - Removed `session_id` from:
    - `TaskInput`
    - `TaskOutput`
    - task tool metadata/definition
    - task prompt definition/example schema
  - Removed runtime validation branch that rejected `session_id` (field no longer exists).
- **Docs/examples**
  - Updated SerdesAI examples and README usage to the new `AgentBuildContext` API.
  - Added architecture docs and README references for discoverability:
    - `src/llm-coding-tools-agents/ARCHITECTURE.md`
    - `src/llm-coding-tools-serdesai/AGENTS-ARCHITECTURE.md`