### PR TITLE
Added: Per-agent tool settings for configurable tool behaviour limits

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2042,6 +2042,7 @@ dependencies = [
  "parking_lot",
  "process-wrap",
  "reqwest 0.13.1",
+ "rstest",
  "schemars",
  "serde",
  "serde_json",

--- a/src/llm-coding-tools-agents/README.md
+++ b/src/llm-coding-tools-agents/README.md
@@ -143,10 +143,10 @@ tool_settings:
 | -------- | ----------------------- | ----- | -------- | ---- | ------------------------------------------------ |
 | read     | `line_numbers`          | bool  | `true`   | —    | Show line numbers in output                      |
 | read     | `limit`                 | usize | `2000`   | 1    | Max lines per file read                          |
-| read     | `max_line_length`       | usize | `2000`   | 100  | Max characters per line (truncates longer lines) |
+| read     | `max_line_length`       | usize | `2000`   | 4    | Max characters per line (truncates longer lines) |
 | grep     | `line_numbers`          | bool  | `true`   | —    | Show line numbers in output                      |
 | grep     | `limit`                 | usize | `100`    | 1    | Max matches returned                             |
-| grep     | `max_line_length`       | usize | `2000`   | 100  | Max characters per match line                    |
+| grep     | `max_line_length`       | usize | `2000`   | 4    | Max characters per match line                    |
 | glob     | `limit`                 | usize | `1000`   | 1    | Max files returned                               |
 | bash     | `timeout_ms`            | usize | `120000` | 1000 | Default command timeout in milliseconds          |
 | webfetch | `timeout_ms`            | usize | `30000`  | 1000 | Fetch timeout in milliseconds                    |

--- a/src/llm-coding-tools-agents/README.md
+++ b/src/llm-coding-tools-agents/README.md
@@ -132,25 +132,29 @@ tool_settings:
     limit: 1000                 # default: 1000
   bash:
     timeout_ms: 120000          # default: 120000 (2 minutes)
+    max_timeout_ms: 600000      # default: 600000 (10 minutes)
   webfetch:
     timeout_ms: 30000           # default: 30000 (30 seconds)
+    max_timeout_ms: 600000      # default: 600000 (10 minutes)
     max_response_size_mib: 5    # default: 5
 ```
 
 **Setting reference:**
 
-| Tool     | Setting                 | Type  | Default  | Min  | Description                                      |
-| -------- | ----------------------- | ----- | -------- | ---- | ------------------------------------------------ |
-| read     | `line_numbers`          | bool  | `true`   | —    | Show line numbers in output                      |
-| read     | `limit`                 | usize | `2000`   | 1    | Max lines per file read                          |
-| read     | `max_line_length`       | usize | `2000`   | 4    | Max characters per line (truncates longer lines) |
-| grep     | `line_numbers`          | bool  | `true`   | —    | Show line numbers in output                      |
-| grep     | `limit`                 | usize | `100`    | 1    | Max matches returned                             |
-| grep     | `max_line_length`       | usize | `2000`   | 4    | Max characters per match line                    |
-| glob     | `limit`                 | usize | `1000`   | 1    | Max files returned                               |
-| bash     | `timeout_ms`            | usize | `120000` | 1000 | Default command timeout in milliseconds          |
-| webfetch | `timeout_ms`            | usize | `30000`  | 1000 | Fetch timeout in milliseconds                    |
-| webfetch | `max_response_size_mib` | usize | `5`      | 1    | Max response body size in MiB                    |
+| Tool     | Setting                 | Type  | Default  | Min  | Description                                             |
+| -------- | ----------------------- | ----- | -------- | ---- | ------------------------------------------------------- |
+| read     | `line_numbers`          | bool  | `true`   | —    | Show line numbers in output                             |
+| read     | `limit`                 | usize | `2000`   | 1    | Max lines per file read                                 |
+| read     | `max_line_length`       | usize | `2000`   | 4    | Max characters per line (truncates longer lines)        |
+| grep     | `line_numbers`          | bool  | `true`   | —    | Show line numbers in output                             |
+| grep     | `limit`                 | usize | `100`    | 1    | Max matches returned                                    |
+| grep     | `max_line_length`       | usize | `2000`   | 4    | Max characters per match line                           |
+| glob     | `limit`                 | usize | `1000`   | 1    | Max files returned                                      |
+| bash     | `timeout_ms`            | usize | `120000` | 1000 | Default command timeout in milliseconds                 |
+| bash     | `max_timeout_ms`        | usize | `600000` | *    | Maximum timeout LLM can request (must be >= timeout_ms) |
+| webfetch | `timeout_ms`            | usize | `30000`  | 1000 | Fetch timeout in milliseconds                           |
+| webfetch | `max_timeout_ms`        | usize | `600000` | *    | Maximum timeout LLM can request (must be >= timeout_ms) |
+| webfetch | `max_response_size_mib` | usize | `5`      | 1    | Max response body size in MiB                           |
 
 **Output format:**
 
@@ -194,8 +198,14 @@ fn main() {
 - **`bash.timeout_ms`** - Maximum time a shell command may run before being killed, in
   milliseconds. Used when the LLM doesn't specify `timeout_ms`.
 
+- **`bash.max_timeout_ms`** - Maximum timeout the LLM is allowed to request via the 
+  `timeout_ms` parameter. Must be greater than or equal to `timeout_ms`.
+
 - **`webfetch.timeout_ms`** - Maximum time to wait for a response from a URL, in
   milliseconds. Used when the LLM doesn't specify `timeout_ms`.
+
+- **`webfetch.max_timeout_ms`** - Maximum timeout the LLM is allowed to request via the
+  `timeout_ms` parameter. Must be greater than or equal to `timeout_ms`.
 
 - **`webfetch.max_response_size_mib`** - Maximum response body size in mebibytes.
   Responses larger than this are rejected.

--- a/src/llm-coding-tools-agents/README.md
+++ b/src/llm-coding-tools-agents/README.md
@@ -116,15 +116,41 @@ subagents for OpenCode compatibility. To disable delegation, explicitly set
 
 #### Tool settings
 
-Configure per-tool behaviour:
+Configure per-tool behaviour via `tool_settings`:
 
 ```yaml
 tool_settings:
   read:
-    line_numbers: false  # Default: true
+    line_numbers: true          # default: true
+    limit: 2000                 # default: 2000
+    max_line_length: 2000       # default: 2000
   grep:
-    line_numbers: false  # Default: true
+    line_numbers: true          # default: true
+    limit: 100                  # default: 100
+    max_line_length: 2000       # default: 2000
+  glob:
+    limit: 1000                 # default: 1000
+  bash:
+    timeout_ms: 120000          # default: 120000 (2 minutes)
+  webfetch:
+    timeout_ms: 30000           # default: 30000 (30 seconds)
+    max_response_size_mib: 5    # default: 5
 ```
+
+**Setting reference:**
+
+| Tool     | Setting                 | Type  | Default  | Min  | Description                                      |
+| -------- | ----------------------- | ----- | -------- | ---- | ------------------------------------------------ |
+| read     | `line_numbers`          | bool  | `true`   | —    | Show line numbers in output                      |
+| read     | `limit`                 | usize | `2000`   | 1    | Max lines per file read                          |
+| read     | `max_line_length`       | usize | `2000`   | 100  | Max characters per line (truncates longer lines) |
+| grep     | `line_numbers`          | bool  | `true`   | —    | Show line numbers in output                      |
+| grep     | `limit`                 | usize | `100`    | 1    | Max matches returned                             |
+| grep     | `max_line_length`       | usize | `2000`   | 100  | Max characters per match line                    |
+| glob     | `limit`                 | usize | `1000`   | 1    | Max files returned                               |
+| bash     | `timeout_ms`            | usize | `120000` | 1000 | Default command timeout in milliseconds          |
+| webfetch | `timeout_ms`            | usize | `30000`  | 1000 | Fetch timeout in milliseconds                    |
+| webfetch | `max_response_size_mib` | usize | `5`      | 1    | Max response body size in MiB                    |
 
 **Output format:**
 
@@ -149,6 +175,30 @@ fn main() {
   
 - **`line_numbers: false`** - For read-only agents that summarize, analyse, or answer
   questions without citing line numbers. Saves tokens and produces cleaner output.
+
+- **`read.limit`** - Maximum number of lines returned when the LLM doesn't specify a
+  `limit` in its tool call. Lines beyond this are not read.
+
+- **`read.max_line_length`** - Maximum characters per line in read output. Longer lines
+  are truncated with `...` appended.
+
+- **`grep.limit`** - Maximum number of matches returned when the LLM doesn't specify a
+  `limit`. Extra matches are dropped.
+
+- **`grep.max_line_length`** - Maximum characters per line in grep output. Longer lines
+  are truncated with `...` appended.
+
+- **`glob.limit`** - Maximum number of file paths returned. Results beyond this are
+  dropped and `truncated: true` is set.
+
+- **`bash.timeout_ms`** - Maximum time a shell command may run before being killed, in
+  milliseconds. Used when the LLM doesn't specify `timeout_ms`.
+
+- **`webfetch.timeout_ms`** - Maximum time to wait for a response from a URL, in
+  milliseconds. Used when the LLM doesn't specify `timeout_ms`.
+
+- **`webfetch.max_response_size_mib`** - Maximum response body size in mebibytes.
+  Responses larger than this are rejected.
 
 ## Building agents
 

--- a/src/llm-coding-tools-agents/src/loader.rs
+++ b/src/llm-coding-tools-agents/src/loader.rs
@@ -400,7 +400,7 @@ mod tests {
     use crate::AgentToolSettings;
     use ahash::AHashMap;
     use indexmap::IndexMap;
-    use indoc::indoc;
+    use indoc::{formatdoc, indoc};
     use rstest::rstest;
     use std::fs::{self, File};
     use std::io::Write;
@@ -1301,6 +1301,33 @@ mod tests {
             result,
             Err(AgentLoadError::SchemaValidation { message, .. })
                 if message.contains("invalid_field_name_xyz")
+        ));
+    }
+
+    #[rstest]
+    #[case("read")]
+    #[case("grep")]
+    fn parse_tool_settings_rejects_max_line_length_below_minimum(#[case] tool: &str) {
+        let loader = AgentLoader::new();
+        let mut catalog = AgentCatalog::new();
+
+        let markdown = formatdoc! {
+            r#"
+            ---
+            description: Test agent
+            tool_settings:
+              {tool}:
+                max_line_length: 3
+            ---
+            Prompt"#
+        };
+
+        let result = loader.add_from_str(&mut catalog, &markdown, "test");
+        assert!(matches!(
+            result,
+            Err(AgentLoadError::SchemaValidation { message, .. })
+                if message.contains(&format!("{tool}.max_line_length"))
+                    && message.contains(">= 4")
         ));
     }
 }

--- a/src/llm-coding-tools-agents/src/types/tool_settings.rs
+++ b/src/llm-coding-tools-agents/src/types/tool_settings.rs
@@ -28,6 +28,7 @@
 //! ```
 
 use llm_coding_tools_core::tool_metadata::{bash, glob, grep, read, webfetch};
+use llm_coding_tools_core::util::MIN_LINE_LENGTH;
 use serde::{Deserialize, Serialize};
 
 /// Per-agent tool settings controlling tool behaviour.
@@ -61,8 +62,11 @@ pub struct ReadToolSettings {
     /// Maximum lines to return per read (default: 2000, min: 1).
     #[serde(default = "read_default_limit")]
     pub limit: usize,
-    /// Maximum characters per line before truncation (default: 2000, min: 100).
-    #[serde(default = "read_default_max_line_length")]
+    /// Maximum characters per line before truncation (default: 2000, min: 4).
+    #[serde(
+        default = "read_default_max_line_length",
+        deserialize_with = "deserialize_read_max_line_length"
+    )]
     pub max_line_length: usize,
 }
 
@@ -86,8 +90,11 @@ pub struct GrepToolSettings {
     /// Maximum matches to return (default: 100, min: 1).
     #[serde(default = "grep_default_limit")]
     pub limit: usize,
-    /// Maximum characters per line before truncation (default: 2000, min: 100).
-    #[serde(default = "grep_default_max_line_length")]
+    /// Maximum characters per line before truncation (default: 2000, min: 4).
+    #[serde(
+        default = "grep_default_max_line_length",
+        deserialize_with = "deserialize_grep_max_line_length"
+    )]
     pub max_line_length: usize,
 }
 
@@ -200,6 +207,37 @@ const fn webfetch_default_timeout_ms() -> u64 {
 #[inline]
 const fn webfetch_default_max_response_size_mib() -> usize {
     webfetch::MAX_RESPONSE_SIZE_MIB
+}
+
+fn deserialize_read_max_line_length<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_min_max_line_length(deserializer, "read.max_line_length")
+}
+
+fn deserialize_grep_max_line_length<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_min_max_line_length(deserializer, "grep.max_line_length")
+}
+
+fn deserialize_min_max_line_length<'de, D>(
+    deserializer: D,
+    field_name: &str,
+) -> Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = usize::deserialize(deserializer)?;
+    if value < MIN_LINE_LENGTH {
+        return Err(serde::de::Error::custom(format!(
+            "{field_name} must be >= {}",
+            MIN_LINE_LENGTH
+        )));
+    }
+    Ok(value)
 }
 
 /// Deserializes `tool_settings`, rejecting explicit `null` while allowing

--- a/src/llm-coding-tools-agents/src/types/tool_settings.rs
+++ b/src/llm-coding-tools-agents/src/types/tool_settings.rs
@@ -21,8 +21,10 @@
 //!     limit: 1000               # default: 1000 (tool_metadata::glob::MAX_RESULTS)
 //!   bash:
 //!     timeout_ms: 120000        # default: 120000ms (tool_metadata::bash::DEFAULT_TIMEOUT_MS)
+//!     max_timeout_ms: 600000    # default: 600000ms (tool_metadata::bash::MAX_TIMEOUT_MS)
 //!   webfetch:
 //!     timeout_ms: 30000         # default: 30000ms (tool_metadata::webfetch::DEFAULT_TIMEOUT_MS)
+//!     max_timeout_ms: 600000    # default: 600000ms (tool_metadata::webfetch::MAX_TIMEOUT_MS)
 //!     max_response_size_mib: 5  # default: 5 MiB (tool_metadata::webfetch::MAX_RESPONSE_SIZE_MIB)
 //! ---
 //! ```
@@ -144,12 +146,16 @@ pub struct BashToolSettings {
         deserialize_with = "deserialize_min_timeout_ms"
     )]
     pub timeout_ms: u32,
+    /// Maximum timeout allowed for LLM requests (default: 600000, min: timeout_ms).
+    #[serde(default = "bash_default_max_timeout_ms")]
+    pub max_timeout_ms: u32,
 }
 
 impl Default for BashToolSettings {
     fn default() -> Self {
         Self {
             timeout_ms: bash_default_timeout_ms(),
+            max_timeout_ms: bash_default_max_timeout_ms(),
         }
     }
 }
@@ -164,6 +170,9 @@ pub struct WebFetchToolSettings {
         deserialize_with = "deserialize_min_timeout_ms"
     )]
     pub timeout_ms: u32,
+    /// Maximum timeout allowed for LLM requests (default: 600000, min: timeout_ms).
+    #[serde(default = "webfetch_default_max_timeout_ms")]
+    pub max_timeout_ms: u32,
     /// Maximum response size in MiB (default: 5, min: 1).
     #[serde(
         default = "webfetch_default_max_response_size_mib",
@@ -176,6 +185,7 @@ impl Default for WebFetchToolSettings {
     fn default() -> Self {
         Self {
             timeout_ms: webfetch_default_timeout_ms(),
+            max_timeout_ms: webfetch_default_max_timeout_ms(),
             max_response_size_mib: webfetch_default_max_response_size_mib(),
         }
     }
@@ -218,8 +228,18 @@ const fn bash_default_timeout_ms() -> u32 {
 }
 
 #[inline]
+const fn bash_default_max_timeout_ms() -> u32 {
+    bash::MAX_TIMEOUT_MS
+}
+
+#[inline]
 const fn webfetch_default_timeout_ms() -> u32 {
     webfetch::DEFAULT_TIMEOUT_MS
+}
+
+#[inline]
+const fn webfetch_default_max_timeout_ms() -> u32 {
+    webfetch::MAX_TIMEOUT_MS
 }
 
 #[inline]
@@ -294,6 +314,33 @@ pub(crate) fn deserialize_non_null_tool_settings<'de, D>(
 where
     D: serde::Deserializer<'de>,
 {
-    let value = Option::<AgentToolSettings>::deserialize(deserializer)?;
-    value.ok_or_else(|| serde::de::Error::custom("tool_settings cannot be null"))
+    let value = Option::<AgentToolSettings>::deserialize(deserializer)?
+        .ok_or_else(|| serde::de::Error::custom("tool_settings cannot be null"))?;
+
+    value.validate().map_err(serde::de::Error::custom)?;
+    Ok(value)
+}
+
+impl AgentToolSettings {
+    /// Validates cross-field constraints (e.g., timeout_ms <= max_timeout_ms).
+    #[inline]
+    fn validate(&self) -> Result<(), String> {
+        validate_timeout_pair("bash", self.bash.timeout_ms, self.bash.max_timeout_ms)?;
+        validate_timeout_pair(
+            "webfetch",
+            self.webfetch.timeout_ms,
+            self.webfetch.max_timeout_ms,
+        )?;
+        Ok(())
+    }
+}
+
+#[inline]
+fn validate_timeout_pair(tool: &str, timeout_ms: u32, max_timeout_ms: u32) -> Result<(), String> {
+    if max_timeout_ms < timeout_ms {
+        return Err(format!(
+            "{tool}.max_timeout_ms ({max_timeout_ms}) must be >= {tool}.timeout_ms ({timeout_ms})"
+        ));
+    }
+    Ok(())
 }

--- a/src/llm-coding-tools-agents/src/types/tool_settings.rs
+++ b/src/llm-coding-tools-agents/src/types/tool_settings.rs
@@ -28,7 +28,7 @@
 //! ```
 
 use llm_coding_tools_core::tool_metadata::{bash, glob, grep, read, webfetch};
-use llm_coding_tools_core::util::MIN_LINE_LENGTH;
+use llm_coding_tools_core::util::{MIN_LIMIT, MIN_LINE_LENGTH, MIN_TIMEOUT_MS};
 use serde::{Deserialize, Serialize};
 
 /// Per-agent tool settings controlling tool behaviour.
@@ -60,7 +60,10 @@ pub struct ReadToolSettings {
     #[serde(default = "default_line_numbers")]
     pub line_numbers: bool,
     /// Maximum lines to return per read (default: 2000, min: 1).
-    #[serde(default = "read_default_limit")]
+    #[serde(
+        default = "read_default_limit",
+        deserialize_with = "deserialize_min_limit"
+    )]
     pub limit: usize,
     /// Maximum characters per line before truncation (default: 2000, min: 4).
     #[serde(
@@ -88,7 +91,10 @@ pub struct GrepToolSettings {
     #[serde(default = "default_line_numbers")]
     pub line_numbers: bool,
     /// Maximum matches to return (default: 100, min: 1).
-    #[serde(default = "grep_default_limit")]
+    #[serde(
+        default = "grep_default_limit",
+        deserialize_with = "deserialize_min_limit"
+    )]
     pub limit: usize,
     /// Maximum characters per line before truncation (default: 2000, min: 4).
     #[serde(
@@ -113,7 +119,10 @@ impl Default for GrepToolSettings {
 #[serde(deny_unknown_fields)]
 pub struct GlobToolSettings {
     /// Maximum files to return (default: 1000, min: 1).
-    #[serde(default = "glob_default_limit")]
+    #[serde(
+        default = "glob_default_limit",
+        deserialize_with = "deserialize_min_limit"
+    )]
     pub limit: usize,
 }
 
@@ -130,7 +139,10 @@ impl Default for GlobToolSettings {
 #[serde(deny_unknown_fields)]
 pub struct BashToolSettings {
     /// Default timeout in milliseconds (default: 120000, min: 1000).
-    #[serde(default = "bash_default_timeout_ms")]
+    #[serde(
+        default = "bash_default_timeout_ms",
+        deserialize_with = "deserialize_min_timeout_ms"
+    )]
     pub timeout_ms: u64,
 }
 
@@ -147,10 +159,16 @@ impl Default for BashToolSettings {
 #[serde(deny_unknown_fields)]
 pub struct WebFetchToolSettings {
     /// Timeout in milliseconds (default: 30000, min: 1000).
-    #[serde(default = "webfetch_default_timeout_ms")]
+    #[serde(
+        default = "webfetch_default_timeout_ms",
+        deserialize_with = "deserialize_min_timeout_ms"
+    )]
     pub timeout_ms: u64,
     /// Maximum response size in MiB (default: 5, min: 1).
-    #[serde(default = "webfetch_default_max_response_size_mib")]
+    #[serde(
+        default = "webfetch_default_max_response_size_mib",
+        deserialize_with = "deserialize_min_limit"
+    )]
     pub max_response_size_mib: usize,
 }
 
@@ -235,6 +253,34 @@ where
         return Err(serde::de::Error::custom(format!(
             "{field_name} must be >= {}",
             MIN_LINE_LENGTH
+        )));
+    }
+    Ok(value)
+}
+
+fn deserialize_min_limit<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = usize::deserialize(deserializer)?;
+    if value < MIN_LIMIT {
+        return Err(serde::de::Error::custom(format!(
+            "value must be >= {}",
+            MIN_LIMIT
+        )));
+    }
+    Ok(value)
+}
+
+fn deserialize_min_timeout_ms<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = u64::deserialize(deserializer)?;
+    if value < MIN_TIMEOUT_MS {
+        return Err(serde::de::Error::custom(format!(
+            "value must be >= {}",
+            MIN_TIMEOUT_MS
         )));
     }
     Ok(value)

--- a/src/llm-coding-tools-agents/src/types/tool_settings.rs
+++ b/src/llm-coding-tools-agents/src/types/tool_settings.rs
@@ -146,8 +146,11 @@ pub struct BashToolSettings {
         deserialize_with = "deserialize_min_timeout_ms"
     )]
     pub timeout_ms: u32,
-    /// Maximum timeout allowed for LLM requests (default: 600000, min: timeout_ms).
-    #[serde(default = "bash_default_max_timeout_ms")]
+    /// Maximum timeout allowed for LLM requests (default: 600000, min: 1).
+    #[serde(
+        default = "bash_default_max_timeout_ms",
+        deserialize_with = "deserialize_min_max_timeout_ms"
+    )]
     pub max_timeout_ms: u32,
 }
 
@@ -170,8 +173,11 @@ pub struct WebFetchToolSettings {
         deserialize_with = "deserialize_min_timeout_ms"
     )]
     pub timeout_ms: u32,
-    /// Maximum timeout allowed for LLM requests (default: 600000, min: timeout_ms).
-    #[serde(default = "webfetch_default_max_timeout_ms")]
+    /// Maximum timeout allowed for LLM requests (default: 600000, min: 1).
+    #[serde(
+        default = "webfetch_default_max_timeout_ms",
+        deserialize_with = "deserialize_min_max_timeout_ms"
+    )]
     pub max_timeout_ms: u32,
     /// Maximum response size in MiB (default: 5, min: 1).
     #[serde(
@@ -302,6 +308,20 @@ where
             "value must be >= {}",
             MIN_TIMEOUT_MS
         )));
+    }
+    Ok(value)
+}
+
+/// Deserializes max_timeout_ms ensuring it's at least 1.
+fn deserialize_min_max_timeout_ms<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = u32::deserialize(deserializer)?;
+    if value == 0 {
+        return Err(serde::de::Error::custom(
+            "max_timeout_ms must be at least 1",
+        ));
     }
     Ok(value)
 }

--- a/src/llm-coding-tools-agents/src/types/tool_settings.rs
+++ b/src/llm-coding-tools-agents/src/types/tool_settings.rs
@@ -2,18 +2,32 @@
 //!
 //! Per-agent configuration for tool behaviour.
 //!
-//! ## Frontmatter Schema
+//! All settings use defaults from the tool metadata constants when not specified.
+//!
+//! ## Frontmatter Schema Example
 //! ```yaml
 //! ---
 //! name: example-agent
 //! tool_settings:
 //!   read:
-//!     line_numbers: false
+//!     line_numbers: true        # default: true
+//!     limit: 2000               # default: 2000 (tool_metadata::read::DEFAULT_LIMIT)
+//!     max_line_length: 2000     # default: 2000 (tool_metadata::read::MAX_LINE_LENGTH)
 //!   grep:
-//!     line_numbers: false
+//!     line_numbers: true        # default: true
+//!     limit: 100                # default: 100 (tool_metadata::grep::DEFAULT_LIMIT)
+//!     max_line_length: 2000     # default: 2000 (tool_metadata::tools::DEFAULT_MAX_LINE_LENGTH)
+//!   glob:
+//!     limit: 1000               # default: 1000 (tool_metadata::glob::MAX_RESULTS)
+//!   bash:
+//!     timeout_ms: 120000        # default: 120000ms (tool_metadata::bash::DEFAULT_TIMEOUT_MS)
+//!   webfetch:
+//!     timeout_ms: 30000         # default: 30000ms (tool_metadata::webfetch::DEFAULT_TIMEOUT_MS)
+//!     max_response_size_mib: 5  # default: 5 MiB (tool_metadata::webfetch::MAX_RESPONSE_SIZE_MIB)
 //! ---
 //! ```
 
+use llm_coding_tools_core::tool_metadata::{bash, glob, grep, read, webfetch};
 use serde::{Deserialize, Serialize};
 
 /// Per-agent tool settings controlling tool behaviour.
@@ -26,6 +40,15 @@ pub struct AgentToolSettings {
     /// Settings for the grep tool.
     #[serde(default)]
     pub grep: GrepToolSettings,
+    /// Settings for the glob tool.
+    #[serde(default)]
+    pub glob: GlobToolSettings,
+    /// Settings for the bash tool.
+    #[serde(default)]
+    pub bash: BashToolSettings,
+    /// Settings for the webfetch tool.
+    #[serde(default)]
+    pub webfetch: WebFetchToolSettings,
 }
 
 /// Settings for the read tool.
@@ -35,11 +58,21 @@ pub struct ReadToolSettings {
     /// Whether to include line numbers in output (default: true).
     #[serde(default = "default_line_numbers")]
     pub line_numbers: bool,
+    /// Maximum lines to return per read (default: 2000, min: 1).
+    #[serde(default = "read_default_limit")]
+    pub limit: usize,
+    /// Maximum characters per line before truncation (default: 2000, min: 100).
+    #[serde(default = "read_default_max_line_length")]
+    pub max_line_length: usize,
 }
 
 impl Default for ReadToolSettings {
     fn default() -> Self {
-        Self { line_numbers: true }
+        Self {
+            line_numbers: true,
+            limit: read_default_limit(),
+            max_line_length: read_default_max_line_length(),
+        }
     }
 }
 
@@ -50,17 +83,123 @@ pub struct GrepToolSettings {
     /// Whether to include line numbers in output (default: true).
     #[serde(default = "default_line_numbers")]
     pub line_numbers: bool,
+    /// Maximum matches to return (default: 100, min: 1).
+    #[serde(default = "grep_default_limit")]
+    pub limit: usize,
+    /// Maximum characters per line before truncation (default: 2000, min: 100).
+    #[serde(default = "grep_default_max_line_length")]
+    pub max_line_length: usize,
 }
 
 impl Default for GrepToolSettings {
     fn default() -> Self {
-        Self { line_numbers: true }
+        Self {
+            line_numbers: true,
+            limit: grep_default_limit(),
+            max_line_length: grep_default_max_line_length(),
+        }
+    }
+}
+
+/// Settings for the glob tool.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GlobToolSettings {
+    /// Maximum files to return (default: 1000, min: 1).
+    #[serde(default = "glob_default_limit")]
+    pub limit: usize,
+}
+
+impl Default for GlobToolSettings {
+    fn default() -> Self {
+        Self {
+            limit: glob_default_limit(),
+        }
+    }
+}
+
+/// Settings for the bash tool.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BashToolSettings {
+    /// Default timeout in milliseconds (default: 120000, min: 1000).
+    #[serde(default = "bash_default_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
+impl Default for BashToolSettings {
+    fn default() -> Self {
+        Self {
+            timeout_ms: bash_default_timeout_ms(),
+        }
+    }
+}
+
+/// Settings for the webfetch tool.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WebFetchToolSettings {
+    /// Timeout in milliseconds (default: 30000, min: 1000).
+    #[serde(default = "webfetch_default_timeout_ms")]
+    pub timeout_ms: u64,
+    /// Maximum response size in MiB (default: 5, min: 1).
+    #[serde(default = "webfetch_default_max_response_size_mib")]
+    pub max_response_size_mib: usize,
+}
+
+impl Default for WebFetchToolSettings {
+    fn default() -> Self {
+        Self {
+            timeout_ms: webfetch_default_timeout_ms(),
+            max_response_size_mib: webfetch_default_max_response_size_mib(),
+        }
     }
 }
 
 #[inline]
 const fn default_line_numbers() -> bool {
     true
+}
+
+#[inline]
+const fn read_default_limit() -> usize {
+    read::DEFAULT_LIMIT
+}
+
+#[inline]
+const fn read_default_max_line_length() -> usize {
+    read::MAX_LINE_LENGTH
+}
+
+#[inline]
+const fn grep_default_limit() -> usize {
+    grep::DEFAULT_LIMIT
+}
+
+#[inline]
+const fn grep_default_max_line_length() -> usize {
+    // Grep uses the same max line length as read
+    read::MAX_LINE_LENGTH
+}
+
+#[inline]
+const fn glob_default_limit() -> usize {
+    glob::MAX_RESULTS
+}
+
+#[inline]
+const fn bash_default_timeout_ms() -> u64 {
+    bash::DEFAULT_TIMEOUT_MS
+}
+
+#[inline]
+const fn webfetch_default_timeout_ms() -> u64 {
+    webfetch::DEFAULT_TIMEOUT_MS
+}
+
+#[inline]
+const fn webfetch_default_max_response_size_mib() -> usize {
+    webfetch::MAX_RESPONSE_SIZE_MIB
 }
 
 /// Deserializes `tool_settings`, rejecting explicit `null` while allowing

--- a/src/llm-coding-tools-agents/src/types/tool_settings.rs
+++ b/src/llm-coding-tools-agents/src/types/tool_settings.rs
@@ -143,7 +143,7 @@ pub struct BashToolSettings {
         default = "bash_default_timeout_ms",
         deserialize_with = "deserialize_min_timeout_ms"
     )]
-    pub timeout_ms: u64,
+    pub timeout_ms: u32,
 }
 
 impl Default for BashToolSettings {
@@ -163,7 +163,7 @@ pub struct WebFetchToolSettings {
         default = "webfetch_default_timeout_ms",
         deserialize_with = "deserialize_min_timeout_ms"
     )]
-    pub timeout_ms: u64,
+    pub timeout_ms: u32,
     /// Maximum response size in MiB (default: 5, min: 1).
     #[serde(
         default = "webfetch_default_max_response_size_mib",
@@ -213,12 +213,12 @@ const fn glob_default_limit() -> usize {
 }
 
 #[inline]
-const fn bash_default_timeout_ms() -> u64 {
+const fn bash_default_timeout_ms() -> u32 {
     bash::DEFAULT_TIMEOUT_MS
 }
 
 #[inline]
-const fn webfetch_default_timeout_ms() -> u64 {
+const fn webfetch_default_timeout_ms() -> u32 {
     webfetch::DEFAULT_TIMEOUT_MS
 }
 
@@ -272,11 +272,11 @@ where
     Ok(value)
 }
 
-fn deserialize_min_timeout_ms<'de, D>(deserializer: D) -> Result<u64, D::Error>
+fn deserialize_min_timeout_ms<'de, D>(deserializer: D) -> Result<u32, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let value = u64::deserialize(deserializer)?;
+    let value = u32::deserialize(deserializer)?;
     if value < MIN_TIMEOUT_MS {
         return Err(serde::de::Error::custom(format!(
             "value must be >= {}",

--- a/src/llm-coding-tools-core/Cargo.toml
+++ b/src/llm-coding-tools-core/Cargo.toml
@@ -109,6 +109,7 @@ wiremock = "0.6"
 indoc = "2"
 criterion = "0.8"
 temp-env = "0.3.6"
+rstest = "0.26"
 
 [[bench]]
 name = "model_catalog_builder"

--- a/src/llm-coding-tools-core/src/tool_metadata/bash.rs
+++ b/src/llm-coding-tools-core/src/tool_metadata/bash.rs
@@ -6,10 +6,10 @@ use super::ParamMetadata;
 pub const NAME: &str = "bash";
 
 /// Default timeout in milliseconds.
-pub const DEFAULT_TIMEOUT_MS: u64 = 120_000;
+pub const DEFAULT_TIMEOUT_MS: u32 = 120_000;
 
 /// Maximum timeout in milliseconds.
-pub const MAX_TIMEOUT_MS: u64 = 600_000;
+pub const MAX_TIMEOUT_MS: u32 = 600_000;
 
 /// Tool description.
 pub const DESCRIPTION: &str = "Run a shell command in a fresh process.";

--- a/src/llm-coding-tools-core/src/tool_metadata/webfetch.rs
+++ b/src/llm-coding-tools-core/src/tool_metadata/webfetch.rs
@@ -6,10 +6,10 @@ use super::ParamMetadata;
 pub const NAME: &str = "webfetch";
 
 /// Default timeout in milliseconds.
-pub const DEFAULT_TIMEOUT_MS: u64 = 30_000;
+pub const DEFAULT_TIMEOUT_MS: u32 = 30_000;
 
 /// Maximum timeout in milliseconds.
-pub const MAX_TIMEOUT_MS: u64 = 600_000;
+pub const MAX_TIMEOUT_MS: u32 = 600_000;
 
 /// Maximum response size in mebibytes (for display in prompts).
 pub const MAX_RESPONSE_SIZE_MIB: usize = 5;

--- a/src/llm-coding-tools-core/src/tools/bash/blocking_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/bash/blocking_impl.rs
@@ -31,12 +31,30 @@ enum WaitOutcome {
 /// Uses bash on Unix, cmd on Windows. Process tree is killed on timeout via:
 /// - Windows: Job Objects
 /// - Unix: Process groups
+///
+/// # Arguments
+///
+/// * `command` - The shell command to execute
+/// * `workdir` - Optional working directory (must be absolute if provided)
+/// * `timeout_ms` - Timeout in milliseconds (must be >= 1 and <= max_timeout_ms)
+/// * `max_timeout_ms` - Maximum allowed timeout in milliseconds
+///
+/// # Errors
+///
+/// Returns `ToolError::Validation` if timeout_ms is 0 or exceeds max_timeout_ms.
 pub fn execute_command(
     command: &str,
     workdir: Option<&Path>,
-    timeout: Duration,
+    timeout_ms: u32,
+    max_timeout_ms: u32,
 ) -> ToolResult<BashOutput> {
-    execute_command_with_mode(&BashExecutionMode::Host, command, workdir, timeout)
+    execute_command_with_mode(
+        &BashExecutionMode::Host,
+        command,
+        workdir,
+        timeout_ms,
+        max_timeout_ms,
+    )
 }
 
 /// Executes a shell command with explicit mode selection.
@@ -45,9 +63,11 @@ pub fn execute_command(
 /// - `mode` - The execution mode (host or Linux sandbox).
 /// - `command` - The shell command to execute.
 /// - `workdir` - Optional working directory (must be absolute if provided).
-/// - `timeout` - Maximum time to wait for command completion.
+/// - `timeout_ms` - Timeout in milliseconds (must be >= 1 and <= max_timeout_ms).
+/// - `max_timeout_ms` - Maximum allowed timeout in milliseconds.
 ///
 /// # Errors
+/// - Returns `ToolError::Validation` if timeout_ms is 0 or exceeds max_timeout_ms.
 /// - Returns [`ToolError::InvalidPath`] if workdir is not absolute or doesn't exist.
 /// - Returns [`ToolError::Execution`] for sandbox mode when bwrap is missing or unusable.
 /// - Returns [`ToolError::Timeout`] or [`ToolError::TimeoutWithKillFailure`] on timeout.
@@ -55,8 +75,23 @@ pub fn execute_command_with_mode(
     mode: &BashExecutionMode,
     command: &str,
     workdir: Option<&Path>,
-    timeout: Duration,
+    timeout_ms: u32,
+    max_timeout_ms: u32,
 ) -> ToolResult<BashOutput> {
+    // Validate timeout_ms
+    if timeout_ms == 0 {
+        return Err(ToolError::Validation(
+            "timeout_ms must be at least 1".to_string(),
+        ));
+    }
+    if timeout_ms > max_timeout_ms {
+        return Err(ToolError::Validation(format!(
+            "timeout_ms exceeds maximum allowed value of {}",
+            max_timeout_ms
+        )));
+    }
+
+    let timeout = Duration::from_millis(timeout_ms as u64);
     let wrap = match mode {
         BashExecutionMode::Host => build_host_wrap(command, workdir),
         #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
@@ -188,7 +223,7 @@ mod tests {
 
     #[test]
     fn execute_echo_returns_output() {
-        let result = execute_command("echo hello", None, Duration::from_secs(5)).unwrap();
+        let result = execute_command("echo hello", None, 5000, 10000).unwrap();
 
         assert_eq!(result.exit_code, Some(0));
         assert!(result.stdout.contains("hello"));
@@ -203,7 +238,7 @@ mod tests {
             "pwd"
         };
 
-        let result = execute_command(cmd, Some(temp.path()), Duration::from_secs(5)).unwrap();
+        let result = execute_command(cmd, Some(temp.path()), 5000, 10000).unwrap();
 
         assert_eq!(result.exit_code, Some(0));
         let temp_path = temp.path().to_string_lossy();
@@ -218,7 +253,7 @@ mod tests {
             "sleep 10"
         };
 
-        let result = execute_command(cmd, None, Duration::from_millis(100));
+        let result = execute_command(cmd, None, 100, 10000);
         assert!(matches!(
             result,
             Err(ToolError::Timeout(_) | ToolError::TimeoutWithKillFailure { .. })
@@ -230,7 +265,8 @@ mod tests {
         let result = execute_command(
             "echo hello",
             Some(Path::new("/nonexistent/path")),
-            Duration::from_secs(5),
+            5000,
+            10000,
         );
 
         assert!(matches!(result, Err(ToolError::InvalidPath(_))));
@@ -244,7 +280,7 @@ mod tests {
             "exit 42"
         };
 
-        let result = execute_command(cmd, None, Duration::from_secs(5)).unwrap();
+        let result = execute_command(cmd, None, 5000, 10000).unwrap();
 
         assert_eq!(result.exit_code, Some(42));
     }
@@ -278,7 +314,7 @@ mod tests {
             format!("cat {}", large_file.display())
         };
 
-        let result = execute_command(&cmd, None, Duration::from_secs(30)).unwrap();
+        let result = execute_command(&cmd, None, 30000, 60000).unwrap();
 
         assert_eq!(result.exit_code, Some(0));
         // Verify we got all the output (102400 bytes written)

--- a/src/llm-coding-tools-core/src/tools/bash/tokio_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/bash/tokio_impl.rs
@@ -89,12 +89,31 @@ async fn await_pipe_drain_task_with_grace(task: PipeDrainTask, grace: Duration) 
 /// Uses bash on Unix, cmd on Windows. Process tree is killed on timeout via:
 /// - Windows: Job Objects
 /// - Unix: Process groups
+///
+/// # Arguments
+///
+/// * `command` - The shell command to execute
+/// * `workdir` - Optional working directory (must be absolute if provided)
+/// * `timeout_ms` - Timeout in milliseconds (must be >= 1 and <= max_timeout_ms)
+/// * `max_timeout_ms` - Maximum allowed timeout in milliseconds
+///
+/// # Errors
+///
+/// Returns `ToolError::Validation` if timeout_ms is 0 or exceeds max_timeout_ms.
 pub async fn execute_command(
     command: &str,
     workdir: Option<&Path>,
-    timeout: Duration,
+    timeout_ms: u32,
+    max_timeout_ms: u32,
 ) -> ToolResult<BashOutput> {
-    execute_command_with_mode(&BashExecutionMode::Host, command, workdir, timeout).await
+    execute_command_with_mode(
+        &BashExecutionMode::Host,
+        command,
+        workdir,
+        timeout_ms,
+        max_timeout_ms,
+    )
+    .await
 }
 
 /// Executes a shell command with explicit mode selection.
@@ -103,9 +122,11 @@ pub async fn execute_command(
 /// - `mode` - The execution mode (host or Linux sandbox).
 /// - `command` - The shell command to execute.
 /// - `workdir` - Optional working directory (must be absolute if provided).
-/// - `timeout` - Maximum time to wait for command completion.
+/// - `timeout_ms` - Timeout in milliseconds (must be >= 1 and <= max_timeout_ms).
+/// - `max_timeout_ms` - Maximum allowed timeout in milliseconds.
 ///
 /// # Errors
+/// - Returns `ToolError::Validation` if timeout_ms is 0 or exceeds max_timeout_ms.
 /// - Returns [`ToolError::InvalidPath`] if workdir is not absolute or doesn't exist.
 /// - Returns [`ToolError::Execution`] for sandbox mode when bwrap is missing or unusable.
 /// - Returns [`ToolError::Timeout`] or [`ToolError::TimeoutWithKillFailure`] on timeout.
@@ -113,8 +134,23 @@ pub async fn execute_command_with_mode(
     mode: &BashExecutionMode,
     command: &str,
     workdir: Option<&Path>,
-    timeout: Duration,
+    timeout_ms: u32,
+    max_timeout_ms: u32,
 ) -> ToolResult<BashOutput> {
+    // Validate timeout_ms
+    if timeout_ms == 0 {
+        return Err(ToolError::Validation(
+            "timeout_ms must be at least 1".to_string(),
+        ));
+    }
+    if timeout_ms > max_timeout_ms {
+        return Err(ToolError::Validation(format!(
+            "timeout_ms exceeds maximum allowed value of {}",
+            max_timeout_ms
+        )));
+    }
+
+    let timeout = Duration::from_millis(timeout_ms as u64);
     let wrap = match mode {
         BashExecutionMode::Host => build_host_wrap(command, workdir),
         #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
@@ -228,7 +264,7 @@ mod tests {
 
     #[tokio::test]
     async fn execute_echo_returns_output() {
-        let result = execute_command("echo hello", None, Duration::from_secs(5))
+        let result = execute_command("echo hello", None, 5000, 10000)
             .await
             .unwrap();
 
@@ -245,7 +281,7 @@ mod tests {
             "pwd"
         };
 
-        let result = execute_command(cmd, Some(temp.path()), Duration::from_secs(5))
+        let result = execute_command(cmd, Some(temp.path()), 5000, 10000)
             .await
             .unwrap();
 
@@ -262,7 +298,7 @@ mod tests {
             "sleep 10"
         };
 
-        let result = execute_command(cmd, None, Duration::from_millis(100)).await;
+        let result = execute_command(cmd, None, 100, 10000).await;
         assert!(matches!(
             result,
             Err(ToolError::Timeout(_) | ToolError::TimeoutWithKillFailure { .. })
@@ -277,7 +313,7 @@ mod tests {
             "echo stdout-before-timeout; echo stderr-before-timeout 1>&2; sleep 10"
         };
 
-        let result = execute_command(cmd, None, Duration::from_millis(500)).await;
+        let result = execute_command(cmd, None, 500, 10000).await;
         match result {
             Err(ToolError::Timeout(message))
             | Err(ToolError::TimeoutWithKillFailure { message, .. }) => {
@@ -319,7 +355,8 @@ mod tests {
         let result = execute_command(
             "echo hello",
             Some(Path::new("/nonexistent/path")),
-            Duration::from_secs(5),
+            5000,
+            10000,
         )
         .await;
 
@@ -334,9 +371,7 @@ mod tests {
             "exit 42"
         };
 
-        let result = execute_command(cmd, None, Duration::from_secs(5))
-            .await
-            .unwrap();
+        let result = execute_command(cmd, None, 5000, 10000).await.unwrap();
 
         assert_eq!(result.exit_code, Some(42));
     }
@@ -370,9 +405,7 @@ mod tests {
             format!("cat {}", large_file.display())
         };
 
-        let result = execute_command(&cmd, None, Duration::from_secs(30))
-            .await
-            .unwrap();
+        let result = execute_command(&cmd, None, 30000, 60000).await.unwrap();
 
         assert_eq!(result.exit_code, Some(0));
         // Verify we got all the output (102400 bytes written)

--- a/src/llm-coding-tools-core/src/tools/glob.rs
+++ b/src/llm-coding-tools-core/src/tools/glob.rs
@@ -2,7 +2,6 @@
 
 use crate::error::{ToolError, ToolResult};
 use crate::path::PathResolver;
-use crate::tool_metadata::glob::MAX_RESULTS;
 use globset::Glob;
 use ignore::WalkBuilder;
 use serde::Serialize;
@@ -27,10 +26,12 @@ pub struct GlobOutput {
 /// Finds files matching a glob pattern in the given directory.
 ///
 /// Results are sorted by modification time (newest first) and respect `.gitignore`.
+/// The `limit` parameter controls the maximum number of files returned.
 pub fn glob_files<R: PathResolver>(
     resolver: &R,
     pattern: &str,
     search_path: &str,
+    limit: usize,
 ) -> ToolResult<GlobOutput> {
     let path = resolver.resolve(search_path)?;
 
@@ -39,6 +40,10 @@ pub fn glob_files<R: PathResolver>(
             "path is not a directory: {}",
             path.display()
         )));
+    }
+
+    if limit == 0 {
+        return Err(ToolError::Validation("limit must be >= 1".into()));
     }
 
     let matcher = Glob::new(pattern)?.compile_matcher();
@@ -82,7 +87,7 @@ pub fn glob_files<R: PathResolver>(
             }
         };
 
-        // Normalize Windows backslashes to forward slashes for glob pattern matching
+        // Normalise Windows backslashes to forward slashes for glob pattern matching
         #[cfg(windows)]
         let rel_path = rel_path.replace('\\', "/");
 
@@ -105,11 +110,11 @@ pub fn glob_files<R: PathResolver>(
 
     files_with_mtime.sort_by_key(|entry| std::cmp::Reverse(entry.1));
 
-    let truncated = files_with_mtime.len() > MAX_RESULTS;
+    let truncated = files_with_mtime.len() > limit;
 
     let files: Vec<String> = files_with_mtime
         .into_iter()
-        .take(MAX_RESULTS)
+        .take(limit)
         .map(|(path, _)| path)
         .collect();
 
@@ -148,7 +153,7 @@ mod tests {
     fn glob_matches_pattern() {
         let dir = create_test_tree();
         let resolver = AbsolutePathResolver;
-        let result = glob_files(&resolver, "**/*.rs", dir.path().to_str().unwrap()).unwrap();
+        let result = glob_files(&resolver, "**/*.rs", dir.path().to_str().unwrap(), 1000).unwrap();
         assert!(result.files.iter().any(|f| f.ends_with("lib.rs")));
     }
 
@@ -156,7 +161,7 @@ mod tests {
     fn glob_respects_gitignore() {
         let dir = create_test_tree();
         let resolver = AbsolutePathResolver;
-        let result = glob_files(&resolver, "**/*", dir.path().to_str().unwrap()).unwrap();
+        let result = glob_files(&resolver, "**/*", dir.path().to_str().unwrap(), 1000).unwrap();
         assert!(!result.files.iter().any(|f| f.contains("target")));
     }
 
@@ -180,7 +185,7 @@ mod tests {
             .set_times(FileTimes::new().set_modified(newer_time))
             .unwrap();
 
-        let result = glob_files(&resolver, "**/*.txt", base.to_str().unwrap()).unwrap();
+        let result = glob_files(&resolver, "**/*.txt", base.to_str().unwrap(), 1000).unwrap();
 
         let newer_index = result
             .files
@@ -205,7 +210,7 @@ mod tests {
         // Patterns and returned paths use forward slashes on all platforms
         let dir = create_test_tree();
         let resolver = AbsolutePathResolver;
-        let result = glob_files(&resolver, "**/*.rs", dir.path().to_str().unwrap()).unwrap();
+        let result = glob_files(&resolver, "**/*.rs", dir.path().to_str().unwrap(), 1000).unwrap();
 
         // Verify matching works with forward-slash patterns
         assert_eq!(result.files.len(), 1);

--- a/src/llm-coding-tools-core/src/tools/grep.rs
+++ b/src/llm-coding-tools-core/src/tools/grep.rs
@@ -2,6 +2,7 @@
 
 use crate::error::{ToolError, ToolResult};
 use crate::path::PathResolver;
+use crate::util::{truncate_line_with_ellipsis, TRUNCATION_ELLIPSIS};
 use globset::Glob;
 use grep_regex::RegexMatcher;
 use grep_searcher::sinks::UTF8;
@@ -12,7 +13,7 @@ use std::fmt::Write;
 use std::path::Path;
 use std::time::SystemTime;
 
-/// Default maximum line length (in bytes) for formatted grep output.
+/// Default maximum line length (in characters) for formatted grep output.
 pub const DEFAULT_MAX_LINE_LENGTH: usize = 2000;
 
 /// Estimated characters per grep match for buffer pre-allocation.
@@ -65,7 +66,7 @@ impl GrepOutput {
     /// # Arguments
     ///
     /// * `limit` - The original match limit (used in truncation message)
-    /// * `max_line_len` - Truncate lines exceeding this byte length at UTF-8 boundary
+    /// * `max_line_len` - Truncate lines exceeding this character length and append `...`
     pub fn format<const LINE_NUMBERS: bool>(&self, limit: usize, max_line_len: usize) -> String {
         let estimated_capacity = self.match_count * ESTIMATED_CHARS_PER_MATCH;
         let mut output = String::with_capacity(estimated_capacity);
@@ -75,16 +76,20 @@ impl GrepOutput {
         for file in &self.files {
             let _ = writeln!(&mut output, "\n{}:", file.path);
             for m in &file.matches {
-                let truncated_text = if m.line_text.len() > max_line_len {
-                    &m.line_text[..m.line_text.floor_char_boundary(max_line_len)]
-                } else {
-                    &m.line_text
-                };
+                let (display_text, was_truncated) =
+                    truncate_line_with_ellipsis(&m.line_text, max_line_len);
+
                 if LINE_NUMBERS {
-                    let _ = writeln!(&mut output, "  L{}: {}", m.line_num, truncated_text);
+                    let _ = write!(&mut output, "  L{}: {}", m.line_num, display_text);
                 } else {
-                    let _ = writeln!(&mut output, "  {}", truncated_text);
+                    let _ = write!(&mut output, "  {}", display_text);
                 }
+
+                if was_truncated {
+                    output.push_str(TRUNCATION_ELLIPSIS);
+                }
+
+                output.push('\n');
             }
         }
 
@@ -256,6 +261,7 @@ fn collect_file_matches(
 mod tests {
     use super::*;
     use crate::path::AbsolutePathResolver;
+    use rstest::rstest;
     use tempfile::tempdir;
 
     #[test]
@@ -334,5 +340,41 @@ mod tests {
         assert_eq!(result.match_count, 0);
         assert!(!result.truncated);
         assert!(!result.errors.is_empty());
+    }
+
+    #[rstest]
+    #[case(true, 6, "L1: abc...")] // With line numbers, truncates to "abc..."
+    #[case(false, 4, "  a...")] // Without line numbers, at min limit "  a..."
+    fn grep_format_truncates_lines_with_ellipsis(
+        #[case] with_line_numbers: bool,
+        #[case] max_len: usize,
+        #[case] expected: &str,
+    ) {
+        let output = GrepOutput {
+            files: vec![GrepFileMatches {
+                path: "file.txt".to_string(),
+                matches: vec![GrepLineMatch {
+                    line_num: 1,
+                    line_text: "abcdefghij".to_string(),
+                }],
+                mtime: SystemTime::UNIX_EPOCH,
+            }],
+            match_count: 1,
+            truncated: false,
+            partial: false,
+            errors: Vec::new(),
+        };
+
+        let formatted = if with_line_numbers {
+            output.format::<true>(10, max_len)
+        } else {
+            output.format::<false>(10, max_len)
+        };
+        assert!(
+            formatted.contains(expected),
+            "Expected '{}' in:\n{}",
+            expected,
+            formatted
+        );
     }
 }

--- a/src/llm-coding-tools-core/src/tools/read.rs
+++ b/src/llm-coding-tools-core/src/tools/read.rs
@@ -4,7 +4,9 @@ use crate::error::{ToolError, ToolResult};
 use crate::fs;
 use crate::output::ToolOutput;
 use crate::path::PathResolver;
-use crate::util::{truncate_line, ESTIMATED_CHARS_PER_LINE};
+use crate::util::{
+    truncate_line_with_ellipsis, ESTIMATED_CHARS_PER_LINE, MIN_LINE_LENGTH, TRUNCATION_ELLIPSIS,
+};
 use memchr::memchr;
 use std::borrow::Cow;
 use std::fmt::Write;
@@ -26,16 +28,20 @@ fn process_line<const LINE_NUMBERS: bool>(
 ) {
     let line_bytes = strip_cr(line_bytes);
     let content: Cow<'_, str> = String::from_utf8_lossy(line_bytes);
-    let (truncated_content, _) = truncate_line(&content, max_line_length);
+    let (display_content, was_truncated) = truncate_line_with_ellipsis(&content, max_line_length);
 
     if *lines_output > 0 {
         output.push('\n');
     }
 
     if LINE_NUMBERS {
-        let _ = write!(output, "L{}: {}", line_number, truncated_content);
+        let _ = write!(output, "L{}: {}", line_number, display_content);
     } else {
-        output.push_str(truncated_content);
+        output.push_str(display_content);
+    }
+
+    if was_truncated {
+        output.push_str(TRUNCATION_ELLIPSIS);
     }
 
     *lines_output += 1;
@@ -66,6 +72,12 @@ pub async fn read_file<R: PathResolver, const LINE_NUMBERS: bool>(
     }
     if limit == 0 {
         return Err(ToolError::OutOfBounds("limit must be >= 1".into()));
+    }
+    if max_line_length < MIN_LINE_LENGTH {
+        return Err(ToolError::Validation(format!(
+            "max_line_length must be >= {}",
+            MIN_LINE_LENGTH
+        )));
     }
 
     let path = resolver.resolve(file_path)?;
@@ -207,5 +219,44 @@ mod tests {
     async fn errors_on_offset_zero() {
         let err = read_temp_file::<true>(b"test\n", 0, 10).await.unwrap_err();
         assert!(matches!(err, ToolError::OutOfBounds(_)));
+    }
+
+    #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]
+    async fn errors_on_invalid_max_line_length() {
+        let mut temp = NamedTempFile::new().unwrap();
+        temp.write_all(b"test\n").unwrap();
+        let resolver = AbsolutePathResolver;
+
+        let err = read_file::<_, true>(
+            &resolver,
+            temp.path().to_str().unwrap(),
+            1,
+            10,
+            3, // below MIN_LINE_LENGTH of 4
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, ToolError::Validation(_)));
+        assert!(err.to_string().contains("max_line_length must be >= 4"));
+    }
+
+    #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]
+    async fn truncates_long_line_with_ellipsis() {
+        let mut temp = NamedTempFile::new().unwrap();
+        temp.write_all(b"abcdefghij\n").unwrap();
+        let resolver = AbsolutePathResolver;
+
+        let result = read_file::<_, false>(
+            &resolver,
+            temp.path().to_str().unwrap(),
+            1,
+            10,
+            6, // keep 3 chars + "..."
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.content, "abc...");
     }
 }

--- a/src/llm-coding-tools-core/src/tools/read.rs
+++ b/src/llm-coding-tools-core/src/tools/read.rs
@@ -4,7 +4,6 @@ use crate::error::{ToolError, ToolResult};
 use crate::fs;
 use crate::output::ToolOutput;
 use crate::path::PathResolver;
-use crate::tool_metadata::read::MAX_LINE_LENGTH;
 use crate::util::{truncate_line, ESTIMATED_CHARS_PER_LINE};
 use memchr::memchr;
 use std::borrow::Cow;
@@ -23,10 +22,11 @@ fn process_line<const LINE_NUMBERS: bool>(
     line_number: usize,
     output: &mut String,
     lines_output: &mut usize,
+    max_line_length: usize,
 ) {
     let line_bytes = strip_cr(line_bytes);
     let content: Cow<'_, str> = String::from_utf8_lossy(line_bytes);
-    let (truncated_content, _) = truncate_line(&content, MAX_LINE_LENGTH);
+    let (truncated_content, _) = truncate_line(&content, max_line_length);
 
     if *lines_output > 0 {
         output.push('\n');
@@ -51,6 +51,7 @@ pub async fn read_file<R: PathResolver, const LINE_NUMBERS: bool>(
     file_path: &str,
     offset: usize,
     limit: usize,
+    max_line_length: usize,
 ) -> ToolResult<ToolOutput> {
     // Conditional trait import for consume() method
     #[cfg(feature = "blocking")]
@@ -91,6 +92,7 @@ pub async fn read_file<R: PathResolver, const LINE_NUMBERS: bool>(
                         line_number,
                         &mut output,
                         &mut lines_output,
+                        max_line_length,
                     );
                 }
             }
@@ -113,6 +115,7 @@ pub async fn read_file<R: PathResolver, const LINE_NUMBERS: bool>(
                             line_number,
                             &mut output,
                             &mut lines_output,
+                            max_line_length,
                         );
                     } else {
                         // Slow path: prepend buffered fragment.
@@ -122,6 +125,7 @@ pub async fn read_file<R: PathResolver, const LINE_NUMBERS: bool>(
                             line_number,
                             &mut output,
                             &mut lines_output,
+                            max_line_length,
                         );
                         overflow.clear();
                     }
@@ -173,7 +177,14 @@ mod tests {
         let mut temp = NamedTempFile::new().unwrap();
         temp.write_all(content).unwrap();
         let resolver = AbsolutePathResolver;
-        read_file::<_, LINE_NUMBERS>(&resolver, temp.path().to_str().unwrap(), offset, limit).await
+        read_file::<_, LINE_NUMBERS>(
+            &resolver,
+            temp.path().to_str().unwrap(),
+            offset,
+            limit,
+            2000, // max_line_length
+        )
+        .await
     }
 
     #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]

--- a/src/llm-coding-tools-core/src/tools/webfetch/blocking_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/webfetch/blocking_impl.rs
@@ -2,7 +2,6 @@
 
 use super::{categorize_reqwest_error, check_size, process_content, WebFetchOutput};
 use crate::error::{ToolError, ToolResult};
-use crate::tool_metadata::webfetch::MAX_TIMEOUT_MS;
 use std::io::{BufRead, BufReader};
 use std::time::Duration;
 
@@ -12,20 +11,38 @@ use std::time::Duration;
 /// - JSON is pretty-printed
 /// - Other content types returned as-is
 /// - Response size is limited to `max_response_size` bytes
+///
+/// # Arguments
+///
+/// * `client` - The HTTP client to use
+/// * `url` - The URL to fetch
+/// * `timeout_ms` - Timeout in milliseconds (must be >= 1 and <= max_timeout_ms)
+/// * `max_timeout_ms` - Maximum allowed timeout in milliseconds
+/// * `max_response_size` - Maximum response size in bytes
+///
+/// # Errors
+///
+/// Returns `ToolError::Validation` if timeout_ms is 0 or exceeds max_timeout_ms.
 pub fn fetch_url(
     client: &reqwest::blocking::Client,
     url: &str,
-    timeout_ms: u64,
+    timeout_ms: u32,
+    max_timeout_ms: u32,
     max_response_size: usize,
 ) -> ToolResult<WebFetchOutput> {
-    if timeout_ms == 0 || timeout_ms > MAX_TIMEOUT_MS {
+    if timeout_ms == 0 {
+        return Err(ToolError::Validation(
+            "timeout_ms must be at least 1".to_string(),
+        ));
+    }
+    if timeout_ms > max_timeout_ms {
         return Err(ToolError::Validation(format!(
-            "timeout_ms must be between 1 and {}",
-            MAX_TIMEOUT_MS
+            "timeout_ms exceeds maximum allowed value of {}",
+            max_timeout_ms
         )));
     }
 
-    let timeout = Duration::from_millis(timeout_ms);
+    let timeout = Duration::from_millis(timeout_ms as u64);
     let response = client
         .get(url)
         .timeout(timeout)
@@ -113,6 +130,7 @@ mod tests {
             &client,
             "https://httpbin.org/robots.txt",
             10_000,
+            20_000,
             5 * 1024 * 1024,
         );
 
@@ -131,6 +149,7 @@ mod tests {
             &client,
             "https://httpbin.org/status/404",
             10_000,
+            20_000,
             5 * 1024 * 1024,
         );
 
@@ -143,7 +162,7 @@ mod tests {
     #[test]
     fn rejects_timeout_zero() {
         let client = test_client();
-        let result = fetch_url(&client, "http://localhost:1", 0, 5 * 1024 * 1024);
+        let result = fetch_url(&client, "http://localhost:1", 0, 10_000, 5 * 1024 * 1024);
         assert!(matches!(result, Err(ToolError::Validation(_))));
     }
 
@@ -153,7 +172,8 @@ mod tests {
         let result = fetch_url(
             &client,
             "http://localhost:1",
-            MAX_TIMEOUT_MS + 1,
+            11_000,
+            10_000,
             5 * 1024 * 1024,
         );
         assert!(matches!(result, Err(ToolError::Validation(_))));

--- a/src/llm-coding-tools-core/src/tools/webfetch/blocking_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/webfetch/blocking_impl.rs
@@ -11,10 +11,12 @@ use std::time::Duration;
 /// - HTML is converted to markdown
 /// - JSON is pretty-printed
 /// - Other content types returned as-is
+/// - Response size is limited to `max_response_size` bytes
 pub fn fetch_url(
     client: &reqwest::blocking::Client,
     url: &str,
     timeout_ms: u64,
+    max_response_size: usize,
 ) -> ToolResult<WebFetchOutput> {
     if timeout_ms == 0 || timeout_ms > MAX_TIMEOUT_MS {
         return Err(ToolError::Validation(format!(
@@ -55,7 +57,7 @@ pub fn fetch_url(
         })
         .transpose()?;
     if let Some(len) = content_length {
-        check_size(len, url)?;
+        check_size(len, url, max_response_size)?;
     }
 
     // Stream response body with incremental size checks to avoid memory exhaustion
@@ -76,7 +78,7 @@ pub fn fetch_url(
         total_len = total_len
             .checked_add(n)
             .ok_or_else(|| ToolError::Http(format!("Response size overflow for {}", url)))?;
-        check_size(total_len, url)?;
+        check_size(total_len, url, max_response_size)?;
 
         bytes.extend_from_slice(chunk);
         reader.consume(n);
@@ -107,7 +109,12 @@ mod tests {
     fn fetches_plain_text() {
         // Use httpbin.org for blocking tests since wiremock is async-only
         let client = test_client();
-        let result = fetch_url(&client, "https://httpbin.org/robots.txt", 10_000);
+        let result = fetch_url(
+            &client,
+            "https://httpbin.org/robots.txt",
+            10_000,
+            5 * 1024 * 1024,
+        );
 
         // This test requires network access, so we just check it doesn't panic
         // In CI, this might fail due to network restrictions
@@ -120,7 +127,12 @@ mod tests {
     #[test]
     fn handles_404() {
         let client = test_client();
-        let result = fetch_url(&client, "https://httpbin.org/status/404", 10_000);
+        let result = fetch_url(
+            &client,
+            "https://httpbin.org/status/404",
+            10_000,
+            5 * 1024 * 1024,
+        );
 
         // In case of network issues, just verify we get some result
         if let Err(e) = result {
@@ -131,14 +143,19 @@ mod tests {
     #[test]
     fn rejects_timeout_zero() {
         let client = test_client();
-        let result = fetch_url(&client, "http://localhost:1", 0);
+        let result = fetch_url(&client, "http://localhost:1", 0, 5 * 1024 * 1024);
         assert!(matches!(result, Err(ToolError::Validation(_))));
     }
 
     #[test]
     fn rejects_timeout_exceeding_max() {
         let client = test_client();
-        let result = fetch_url(&client, "http://localhost:1", MAX_TIMEOUT_MS + 1);
+        let result = fetch_url(
+            &client,
+            "http://localhost:1",
+            MAX_TIMEOUT_MS + 1,
+            5 * 1024 * 1024,
+        );
         assert!(matches!(result, Err(ToolError::Validation(_))));
     }
 }

--- a/src/llm-coding-tools-core/src/tools/webfetch/mod.rs
+++ b/src/llm-coding-tools-core/src/tools/webfetch/mod.rs
@@ -3,9 +3,6 @@
 use crate::error::{ToolError, ToolResult};
 use html_to_markdown_rs::{convert, ConversionOptions, PreprocessingOptions, PreprocessingPreset};
 
-/// Maximum response size to accept (5MB).
-pub(crate) const MAX_RESPONSE_SIZE: usize = 5 * 1_024 * 1_024;
-
 /// Result from URL fetch operation.
 #[derive(Debug, Clone)]
 pub struct WebFetchOutput {
@@ -28,7 +25,7 @@ pub(crate) fn process_content(raw_content: &str, content_type: &str) -> String {
     }
 }
 
-/// Categorizes reqwest errors into appropriate [`ToolError`] variants.
+/// Categorises reqwest errors into appropriate [`ToolError`] variants.
 pub(crate) fn categorize_reqwest_error(e: reqwest::Error, url: &str) -> ToolError {
     if e.is_timeout() {
         ToolError::Timeout(format!("Request timed out for {}", url))
@@ -43,11 +40,11 @@ pub(crate) fn categorize_reqwest_error(e: reqwest::Error, url: &str) -> ToolErro
 
 /// Returns an error if the response size exceeds the maximum.
 #[inline]
-pub(crate) fn check_size(len: usize, url: &str) -> ToolResult<()> {
-    if len > MAX_RESPONSE_SIZE {
+pub(crate) fn check_size(len: usize, url: &str, max_size: usize) -> ToolResult<()> {
+    if len > max_size {
         return Err(ToolError::Http(format!(
             "Response too large: {} bytes (max {}) for {}",
-            len, MAX_RESPONSE_SIZE, url
+            len, max_size, url
         )));
     }
     Ok(())
@@ -119,11 +116,12 @@ mod tests {
 
     #[test]
     fn check_size_ok_for_small_content() {
-        assert!(check_size(1000, "http://example.com").is_ok());
+        assert!(check_size(1000, "http://example.com", 5 * 1024 * 1024).is_ok());
     }
 
     #[test]
     fn check_size_fails_for_large_content() {
-        assert!(check_size(MAX_RESPONSE_SIZE + 1, "http://example.com").is_err());
+        let max_size = 5 * 1024 * 1024;
+        assert!(check_size(max_size + 1, "http://example.com", max_size).is_err());
     }
 }

--- a/src/llm-coding-tools-core/src/tools/webfetch/tokio_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/webfetch/tokio_impl.rs
@@ -2,7 +2,6 @@
 
 use super::{categorize_reqwest_error, check_size, process_content, WebFetchOutput};
 use crate::error::{ToolError, ToolResult};
-use crate::tool_metadata::webfetch::MAX_TIMEOUT_MS;
 use std::time::Duration;
 
 /// Fetches content from a URL and returns processed content.
@@ -11,20 +10,38 @@ use std::time::Duration;
 /// - JSON is pretty-printed
 /// - Other content types returned as-is
 /// - Response size is limited to `max_response_size` bytes
+///
+/// # Arguments
+///
+/// * `client` - The HTTP client to use
+/// * `url` - The URL to fetch
+/// * `timeout_ms` - Timeout in milliseconds (must be >= 1 and <= max_timeout_ms)
+/// * `max_timeout_ms` - Maximum allowed timeout in milliseconds
+/// * `max_response_size` - Maximum response size in bytes
+///
+/// # Errors
+///
+/// Returns `ToolError::Validation` if timeout_ms is 0 or exceeds max_timeout_ms.
 pub async fn fetch_url(
     client: &reqwest::Client,
     url: &str,
-    timeout_ms: u64,
+    timeout_ms: u32,
+    max_timeout_ms: u32,
     max_response_size: usize,
 ) -> ToolResult<WebFetchOutput> {
-    if timeout_ms == 0 || timeout_ms > MAX_TIMEOUT_MS {
+    if timeout_ms == 0 {
+        return Err(ToolError::Validation(
+            "timeout_ms must be at least 1".to_string(),
+        ));
+    }
+    if timeout_ms > max_timeout_ms {
         return Err(ToolError::Validation(format!(
-            "timeout_ms must be between 1 and {}",
-            MAX_TIMEOUT_MS
+            "timeout_ms exceeds maximum allowed value of {}",
+            max_timeout_ms
         )));
     }
 
-    let timeout = Duration::from_millis(timeout_ms);
+    let timeout = Duration::from_millis(timeout_ms as u64);
     let mut response = client
         .get(url)
         .timeout(timeout)
@@ -117,6 +134,7 @@ mod tests {
             &client,
             &format!("{}/text", server.uri()),
             5_000,
+            10_000,
             5 * 1024 * 1024,
         )
         .await
@@ -144,6 +162,7 @@ mod tests {
             &client,
             &format!("{}/html", server.uri()),
             5_000,
+            10_000,
             5 * 1024 * 1024,
         )
         .await
@@ -169,6 +188,7 @@ mod tests {
             &client,
             &format!("{}/json", server.uri()),
             5_000,
+            10_000,
             5 * 1024 * 1024,
         )
         .await
@@ -191,6 +211,7 @@ mod tests {
             &client,
             &format!("{}/notfound", server.uri()),
             5_000,
+            10_000,
             5 * 1024 * 1024,
         )
         .await;
@@ -201,7 +222,7 @@ mod tests {
     #[tokio::test]
     async fn rejects_timeout_zero() {
         let client = test_client();
-        let result = fetch_url(&client, "http://localhost:1", 0, 5 * 1024 * 1024).await;
+        let result = fetch_url(&client, "http://localhost:1", 0, 10_000, 5 * 1024 * 1024).await;
         assert!(matches!(result, Err(ToolError::Validation(_))));
     }
 
@@ -211,7 +232,8 @@ mod tests {
         let result = fetch_url(
             &client,
             "http://localhost:1",
-            MAX_TIMEOUT_MS + 1,
+            11_000,
+            10_000,
             5 * 1024 * 1024,
         )
         .await;

--- a/src/llm-coding-tools-core/src/tools/webfetch/tokio_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/webfetch/tokio_impl.rs
@@ -10,10 +10,12 @@ use std::time::Duration;
 /// - HTML is converted to markdown
 /// - JSON is pretty-printed
 /// - Other content types returned as-is
+/// - Response size is limited to `max_response_size` bytes
 pub async fn fetch_url(
     client: &reqwest::Client,
     url: &str,
     timeout_ms: u64,
+    max_response_size: usize,
 ) -> ToolResult<WebFetchOutput> {
     if timeout_ms == 0 || timeout_ms > MAX_TIMEOUT_MS {
         return Err(ToolError::Validation(format!(
@@ -55,7 +57,7 @@ pub async fn fetch_url(
         })
         .transpose()?;
     if let Some(len) = content_length {
-        check_size(len, url)?;
+        check_size(len, url, max_response_size)?;
     }
 
     // Stream response body with incremental size checks to avoid memory exhaustion
@@ -70,7 +72,7 @@ pub async fn fetch_url(
         total_len = total_len
             .checked_add(chunk.len())
             .ok_or_else(|| ToolError::Http(format!("Response size overflow for {}", url)))?;
-        check_size(total_len, url)?;
+        check_size(total_len, url, max_response_size)?;
         bytes.extend_from_slice(&chunk);
     }
 
@@ -111,9 +113,14 @@ mod tests {
             .await;
 
         let client = test_client();
-        let result = fetch_url(&client, &format!("{}/text", server.uri()), 5_000)
-            .await
-            .unwrap();
+        let result = fetch_url(
+            &client,
+            &format!("{}/text", server.uri()),
+            5_000,
+            5 * 1024 * 1024,
+        )
+        .await
+        .unwrap();
 
         assert!(result.content.contains("Hello, world!"));
         assert!(result.content_type.contains("text/plain"));
@@ -133,9 +140,14 @@ mod tests {
             .await;
 
         let client = test_client();
-        let result = fetch_url(&client, &format!("{}/html", server.uri()), 5_000)
-            .await
-            .unwrap();
+        let result = fetch_url(
+            &client,
+            &format!("{}/html", server.uri()),
+            5_000,
+            5 * 1024 * 1024,
+        )
+        .await
+        .unwrap();
 
         assert!(result.content.contains("Hello"));
         assert!(!result.content.contains("<h1>"));
@@ -153,9 +165,14 @@ mod tests {
             .await;
 
         let client = test_client();
-        let result = fetch_url(&client, &format!("{}/json", server.uri()), 5_000)
-            .await
-            .unwrap();
+        let result = fetch_url(
+            &client,
+            &format!("{}/json", server.uri()),
+            5_000,
+            5 * 1024 * 1024,
+        )
+        .await
+        .unwrap();
 
         assert!(result.content.contains("\"key\""));
     }
@@ -170,7 +187,13 @@ mod tests {
             .await;
 
         let client = test_client();
-        let result = fetch_url(&client, &format!("{}/notfound", server.uri()), 5_000).await;
+        let result = fetch_url(
+            &client,
+            &format!("{}/notfound", server.uri()),
+            5_000,
+            5 * 1024 * 1024,
+        )
+        .await;
 
         assert!(matches!(result, Err(ToolError::Http(_))));
     }
@@ -178,14 +201,20 @@ mod tests {
     #[tokio::test]
     async fn rejects_timeout_zero() {
         let client = test_client();
-        let result = fetch_url(&client, "http://localhost:1", 0).await;
+        let result = fetch_url(&client, "http://localhost:1", 0, 5 * 1024 * 1024).await;
         assert!(matches!(result, Err(ToolError::Validation(_))));
     }
 
     #[tokio::test]
     async fn rejects_timeout_exceeding_max() {
         let client = test_client();
-        let result = fetch_url(&client, "http://localhost:1", MAX_TIMEOUT_MS + 1).await;
+        let result = fetch_url(
+            &client,
+            "http://localhost:1",
+            MAX_TIMEOUT_MS + 1,
+            5 * 1024 * 1024,
+        )
+        .await;
         assert!(matches!(result, Err(ToolError::Validation(_))));
     }
 }

--- a/src/llm-coding-tools-core/src/util.rs
+++ b/src/llm-coding-tools-core/src/util.rs
@@ -3,6 +3,12 @@
 /// Generous estimate of average characters per line for buffer pre-allocation.
 pub const ESTIMATED_CHARS_PER_LINE: usize = 64;
 
+/// Suffix added to truncated lines.
+pub(crate) const TRUNCATION_ELLIPSIS: &str = "...";
+
+/// Minimum characters per output line when using `...` truncation.
+pub const MIN_LINE_LENGTH: usize = TRUNCATION_ELLIPSIS.len() + 1;
+
 /// A number of characters per line that's likely to not be exceeded in most files.
 pub const LIKELY_CHARS_PER_LINE_MAX: usize = ESTIMATED_CHARS_PER_LINE * 4;
 
@@ -16,7 +22,7 @@ pub fn format_numbered_line(line_number: usize, content: &str, max_line_number: 
     format!("{:>width$}\t{}", line_number, content)
 }
 
-/// Truncates text to a maximum byte length, appending a truncation notice.
+/// Truncates text to a maximum byte length at a UTF-8 boundary.
 ///
 /// Returns `(truncated_text, was_truncated)`.
 pub fn truncate_text(text: &str, max_bytes: usize) -> (&str, bool) {
@@ -33,67 +39,114 @@ pub fn truncate_text(text: &str, max_bytes: usize) -> (&str, bool) {
     (&text[..end], true)
 }
 
-/// Truncates a single line to a maximum character count.
-pub fn truncate_line(line: &str, max_chars: usize) -> (&str, bool) {
-    // Fast path: UTF-8 guarantees byte_count >= char_count,
-    // so if byte length fits, no truncation needed.
+/// Truncates a line for display with a trailing [`TRUNCATION_ELLIPSIS`].
+///
+/// Returns `(prefix, was_truncated)` where callers should append
+/// [`TRUNCATION_ELLIPSIS`] when `was_truncated` is `true`.
+///
+/// The returned `prefix` is sized so that `prefix + "..."` fits within
+/// `max_chars`. Callers must pass `max_chars >= 4`.
+///
+/// Edge case: for invalid `max_chars < 4`, this function falls back to plain
+/// character-count truncation (`prefix.len() <= max_chars` in chars).
+#[inline]
+pub(crate) fn truncate_line_with_ellipsis(line: &str, max_chars: usize) -> (&str, bool) {
+    const ELLIPSIS_LEN: usize = TRUNCATION_ELLIPSIS.len();
+
+    // Fast path: if byte length fits, char length must also fit.
     if line.len() <= max_chars {
         return (line, false);
     }
 
-    // Find byte position at max_chars character boundary
-    let Some((byte_pos, _)) = line.char_indices().nth(max_chars) else {
-        // Fewer than max_chars characters exist
+    // Defensive fallback for invalid settings where `max_chars < 4`.
+    // If content exceeds the char limit, do plain char-count truncation.
+    if max_chars <= ELLIPSIS_LEN {
+        let Some((keep_byte, _)) = line.char_indices().nth(max_chars) else {
+            return (line, false);
+        };
+        return (&line[..keep_byte], true);
+    }
+
+    let keep_chars = max_chars - ELLIPSIS_LEN;
+
+    // Hot path for source-like text: if first max_chars+1 bytes are ASCII,
+    // byte and character boundaries are identical.
+
+    // ASCII check is fast (it's SIMD), and text being ASCII is the hot path
+    // so almost always, this check is true.
+    if line.as_bytes()[..max_chars + 1].is_ascii() {
+        return (&line[..keep_chars], true);
+    }
+
+    let mut iter = line.char_indices();
+
+    let Some((keep_byte, _)) = iter.nth(keep_chars) else {
+        // More bytes than max_chars but no more than max_chars in UTF-8.
         return (line, false);
     };
 
-    (&line[..byte_pos], true)
+    // Okay. truncate at keep_byte; if possible, that is.
+    if iter.nth(ELLIPSIS_LEN - 1).is_some() {
+        (&line[..keep_byte], true)
+    } else {
+        (line, false)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn format_numbered_line_pads_correctly() {
-        assert_eq!(format_numbered_line(1, "hello", 9), "1\thello");
-        assert_eq!(format_numbered_line(1, "hello", 10), " 1\thello");
-        assert_eq!(format_numbered_line(1, "hello", 100), "  1\thello");
+    #[rstest]
+    #[case::single_digit_max(1, 9, "1\thello")] // 1-9, no padding needed
+    #[case::double_digit_max(1, 10, " 1\thello")] // 10, 1 space padding
+    #[case::triple_digit_max(1, 100, "  1\thello")] // 100, 2 space padding
+    fn format_numbered_line_pads_correctly(
+        #[case] line: usize,
+        #[case] max: usize,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(format_numbered_line(line, "hello", max), expected);
     }
 
-    #[test]
-    fn truncate_text_preserves_short_text() {
-        let (text, truncated) = truncate_text("hello", 10);
-        assert_eq!(text, "hello");
-        assert!(!truncated);
-    }
-
-    #[test]
-    fn truncate_text_truncates_long_text() {
-        let (text, truncated) = truncate_text("hello world", 5);
-        assert_eq!(text, "hello");
-        assert!(truncated);
+    #[rstest]
+    #[case::shorter_than_max("hello", 10, "hello", false)] // Text shorter than max, no truncation
+    #[case::longer_than_max("hello world", 5, "hello", true)] // Text longer than max, truncates
+    fn truncate_text_cases(
+        #[case] input: &str,
+        #[case] max: usize,
+        #[case] expected: &str,
+        #[case] was_truncated: bool,
+    ) {
+        let (text, truncated) = truncate_text(input, max);
+        assert_eq!(text, expected);
+        assert_eq!(truncated, was_truncated);
     }
 
     #[test]
     fn truncate_text_respects_utf8_boundaries() {
-        // "héllo" has é which is 2 bytes
+        // "héllo" has é which is 2 bytes - truncation must happen at char boundary, not byte boundary
         let (text, truncated) = truncate_text("héllo", 2);
         assert_eq!(text, "h");
         assert!(truncated);
     }
 
-    #[test]
-    fn truncate_line_preserves_short_line() {
-        let (line, truncated) = truncate_line("hello", 10);
-        assert_eq!(line, "hello");
-        assert!(!truncated);
-    }
-
-    #[test]
-    fn truncate_line_truncates_by_char_count() {
-        let (line, truncated) = truncate_line("héllo", 3);
-        assert_eq!(line, "hél");
-        assert!(truncated);
+    #[rstest]
+    #[case::short_line_preserved("hello", 10, "hello", false)] // Line shorter than max, preserved unchanged
+    #[case::ascii_truncation("abcdefgh", 6, "abc", true)] // ASCII: keeps max-3 chars, adds "..."
+    #[case::utf8_multi_byte("héllö", 4, "h", true)] // UTF-8: respects char boundaries (é=2 bytes)
+    #[case::minimum_limit("abcdefgh", 4, "a", true)] // Min limit 4: keeps only 1 char + "..."
+    #[case::short_utf8_preserved("ééé", 4, "ééé", false)] // 3 UTF-8 chars fit in limit, not truncated
+    #[case::tiny_limit_fallback("éééé", 3, "ééé", true)] // Limit too small: fallback to char count
+    fn truncate_line_with_ellipsis_cases(
+        #[case] input: &str,
+        #[case] max: usize,
+        #[case] expected: &str,
+        #[case] was_truncated: bool,
+    ) {
+        let (line, truncated) = truncate_line_with_ellipsis(input, max);
+        assert_eq!(line, expected);
+        assert_eq!(truncated, was_truncated);
     }
 }

--- a/src/llm-coding-tools-core/src/util.rs
+++ b/src/llm-coding-tools-core/src/util.rs
@@ -16,7 +16,7 @@ pub const LIKELY_CHARS_PER_LINE_MAX: usize = ESTIMATED_CHARS_PER_LINE * 4;
 pub const MIN_LIMIT: usize = 1;
 
 /// Minimum value for timeout fields in milliseconds (e.g., bash.timeout_ms, webfetch.timeout_ms).
-pub const MIN_TIMEOUT_MS: u64 = 1000;
+pub const MIN_TIMEOUT_MS: u32 = 1000;
 
 /// Formats a line with its line number for output.
 ///

--- a/src/llm-coding-tools-core/src/util.rs
+++ b/src/llm-coding-tools-core/src/util.rs
@@ -12,6 +12,12 @@ pub const MIN_LINE_LENGTH: usize = TRUNCATION_ELLIPSIS.len() + 1;
 /// A number of characters per line that's likely to not be exceeded in most files.
 pub const LIKELY_CHARS_PER_LINE_MAX: usize = ESTIMATED_CHARS_PER_LINE * 4;
 
+/// Minimum value for limit/count fields (e.g., read.limit, grep.limit, glob.limit).
+pub const MIN_LIMIT: usize = 1;
+
+/// Minimum value for timeout fields in milliseconds (e.g., bash.timeout_ms, webfetch.timeout_ms).
+pub const MIN_TIMEOUT_MS: u64 = 1000;
+
 /// Formats a line with its line number for output.
 ///
 /// Uses the format: `{spaces}{line_number}\t{content}` where spaces

--- a/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed-bash.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed-bash.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let bash = BashTool::host()
         .with_linux_bwrap(profile)
-        .with_default_timeout_ms(20_000)
+        .with_timeouts(Some(20_000), None)
         .with_default_workdir(&workspace);
 
     let mut pb = SystemPromptBuilder::new().working_directory(workspace.display().to_string());

--- a/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed-bash.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed-bash.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let bash = BashTool::host()
         .with_linux_bwrap(profile)
-        .with_default_timeout(std::time::Duration::from_secs(20))
+        .with_default_timeout_ms(20_000)
         .with_default_workdir(&workspace);
 
     let mut pb = SystemPromptBuilder::new().working_directory(workspace.display().to_string());

--- a/src/llm-coding-tools-serdesai/src/absolute/glob.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/glob.rs
@@ -27,6 +27,7 @@ struct GlobArgs {
 #[derive(Debug, Clone)]
 pub struct GlobTool {
     definition: ToolDefinition,
+    limit: usize,
 }
 
 impl Default for GlobTool {
@@ -36,11 +37,25 @@ impl Default for GlobTool {
 }
 
 impl GlobTool {
-    /// Creates a new glob tool instance.
+    /// Creates a new glob tool instance with default settings.
+    ///
+    /// Uses `limit` of 1000 files.
     #[inline]
     pub fn new() -> Self {
+        Self::with_settings(glob_meta::MAX_RESULTS)
+    }
+
+    /// Creates a new glob tool instance with custom settings.
+    ///
+    /// # Arguments
+    ///
+    /// * `limit` - Maximum number of files to return per glob call.
+    ///   Results are sorted by modification time (newest first) and truncated
+    ///   to this limit if more files match the pattern.
+    pub fn with_settings(limit: usize) -> Self {
         Self {
             definition: build_definition(),
+            limit,
         }
     }
 }
@@ -56,7 +71,7 @@ impl<Deps: Send + Sync> Tool<Deps> for GlobTool {
             .map_err(|e| ToolError::validation_error(glob_meta::NAME, None, e.to_string()))?;
 
         let resolver = AbsolutePathResolver;
-        let result = glob_files(&resolver, &args.pattern, &args.path);
+        let result = glob_files(&resolver, &args.pattern, &args.path, self.limit);
 
         match result {
             Err(e) => to_serdes_result(glob_meta::NAME, Err(e)),

--- a/src/llm-coding-tools-serdesai/src/absolute/grep.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/grep.rs
@@ -35,6 +35,8 @@ struct GrepArgs {
 #[derive(Debug, Clone)]
 pub struct GrepTool<const LINE_NUMBERS: bool = true> {
     definition: ToolDefinition,
+    max_line_length: usize,
+    limit: usize,
 }
 
 impl<const LINE_NUMBERS: bool> Default for GrepTool<LINE_NUMBERS> {
@@ -44,11 +46,26 @@ impl<const LINE_NUMBERS: bool> Default for GrepTool<LINE_NUMBERS> {
 }
 
 impl<const LINE_NUMBERS: bool> GrepTool<LINE_NUMBERS> {
-    /// Creates a new grep tool instance.
+    /// Creates a new grep tool instance with default settings.
+    ///
+    /// Uses `max_line_length` of 2000 characters and `limit` of 100 matches.
     #[inline]
     pub fn new() -> Self {
+        Self::with_settings(DEFAULT_MAX_LINE_LENGTH, grep_meta::DEFAULT_LIMIT)
+    }
+
+    /// Creates a new grep tool instance with custom settings.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_line_length` - Maximum characters per matching line before truncation.
+    ///   Longer lines will be truncated with "..." appended.
+    /// * `limit` - Maximum number of matches to return when not specified in args.
+    pub fn with_settings(max_line_length: usize, limit: usize) -> Self {
         Self {
             definition: build_definition::<LINE_NUMBERS>(),
+            max_line_length,
+            limit,
         }
     }
 }
@@ -72,10 +89,7 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
             ));
         }
 
-        let limit = args
-            .limit
-            .unwrap_or(grep_meta::DEFAULT_LIMIT)
-            .min(grep_meta::MAX_LIMIT);
+        let limit = args.limit.unwrap_or(self.limit);
         if limit == 0 {
             return Err(ToolError::validation_error(
                 grep_meta::NAME,
@@ -101,7 +115,7 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
             Ok(grep_output) => Ok(grep_output_to_return::<LINE_NUMBERS>(
                 grep_output,
                 limit,
-                DEFAULT_MAX_LINE_LENGTH,
+                self.max_line_length,
             )),
         }
     }
@@ -140,7 +154,7 @@ fn build_definition<const LINE_NUMBERS: bool>() -> ToolDefinition {
             grep_meta::param::LIMIT.description,
             grep_meta::param::LIMIT.required,
             Some(1),
-            Some(grep_meta::MAX_LIMIT as i64),
+            None,
         )
         .build()
         .expect("schema build should not fail");

--- a/src/llm-coding-tools-serdesai/src/absolute/read.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/read.rs
@@ -19,9 +19,9 @@ struct ReadArgs {
     /// Line offset to start reading from (1-based). Defaults to 1.
     #[serde(default = "read_meta::default_offset")]
     offset: usize,
-    /// Maximum number of lines to return. Defaults to 2000.
-    #[serde(default = "read_meta::default_limit")]
-    limit: usize,
+    /// Maximum number of lines to return. Uses tool default if not specified.
+    #[serde(default)]
+    limit: Option<usize>,
 }
 
 /// Tool for reading file contents with optional line numbers.
@@ -32,6 +32,8 @@ struct ReadArgs {
 #[derive(Debug, Clone)]
 pub struct ReadTool<const LINE_NUMBERS: bool = true> {
     definition: ToolDefinition,
+    limit: usize,
+    max_line_length: usize,
 }
 
 impl<const LINE_NUMBERS: bool> Default for ReadTool<LINE_NUMBERS> {
@@ -41,11 +43,27 @@ impl<const LINE_NUMBERS: bool> Default for ReadTool<LINE_NUMBERS> {
 }
 
 impl<const LINE_NUMBERS: bool> ReadTool<LINE_NUMBERS> {
-    /// Creates a new read tool instance.
+    /// Creates a new read tool instance with default settings.
+    ///
+    /// Uses `limit` of 2000 lines and `max_line_length` of 2000 characters.
     #[inline]
     pub fn new() -> Self {
+        Self::with_settings(read_meta::DEFAULT_LIMIT, read_meta::MAX_LINE_LENGTH)
+    }
+
+    /// Creates a new read tool instance with custom settings.
+    ///
+    /// # Arguments
+    ///
+    /// * `limit` - Maximum number of lines to return per read call.
+    ///   This is the default used when the LLM doesn't specify a limit.
+    /// * `max_line_length` - Maximum characters per line before truncation.
+    ///   Longer lines will be truncated with "..." appended.
+    pub fn with_settings(limit: usize, max_line_length: usize) -> Self {
         Self {
             definition: build_definition::<LINE_NUMBERS>(),
+            limit,
+            max_line_length,
         }
     }
 }
@@ -61,9 +79,17 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for ReadTool<LINE_N
             .map_err(|e| ToolError::validation_error(read_meta::NAME, None, e.to_string()))?;
 
         let resolver = AbsolutePathResolver;
+        // Use provided limit or fall back to settings default
+        let effective_limit = args.limit.unwrap_or(self.limit);
         // Core uses 1-indexed offset directly; args.offset defaults to 1
-        let result =
-            read_file::<_, LINE_NUMBERS>(&resolver, &args.file_path, args.offset, args.limit).await;
+        let result = read_file::<_, LINE_NUMBERS>(
+            &resolver,
+            &args.file_path,
+            args.offset,
+            effective_limit,
+            self.max_line_length,
+        )
+        .await;
         to_serdes_result(read_meta::NAME, result)
     }
 }

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
@@ -160,15 +160,18 @@ where
             ToolCatalogKind::Bash => {
                 let settings = &prepared.tool_settings.bash;
                 builder = builder.tool(
-                    prompt_builder
-                        .track(BashTool::new().with_default_timeout_ms(settings.timeout_ms)),
+                    prompt_builder.track(
+                        BashTool::new()
+                            .with_default_timeout_ms(settings.timeout_ms)
+                            .with_max_timeout_ms(settings.max_timeout_ms),
+                    ),
                 );
             }
             ToolCatalogKind::WebFetch => {
                 let settings = &prepared.tool_settings.webfetch;
                 builder = builder.tool(prompt_builder.track(WebFetchTool::with_settings(
                     settings.timeout_ms,
-                    None, // Use default max_timeout_ms
+                    Some(settings.max_timeout_ms),
                     settings.max_response_size_mib,
                 )));
             }

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
@@ -159,13 +159,13 @@ where
             }
             ToolCatalogKind::Bash => {
                 let settings = &prepared.tool_settings.bash;
-                builder = builder.tool(
-                    prompt_builder.track(
-                        BashTool::new()
-                            .with_default_timeout_ms(settings.timeout_ms)
-                            .with_max_timeout_ms(settings.max_timeout_ms),
-                    ),
-                );
+                builder =
+                    builder.tool(prompt_builder.track(
+                        BashTool::new().with_timeouts(
+                            Some(settings.timeout_ms),
+                            Some(settings.max_timeout_ms),
+                        ),
+                    ));
             }
             ToolCatalogKind::WebFetch => {
                 let settings = &prepared.tool_settings.webfetch;

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
@@ -19,6 +19,7 @@ use llm_coding_tools_agents::{
 use llm_coding_tools_core::{CredentialLookup, models::ModelCatalog};
 use serdes_ai::AgentBuilder;
 use serdes_ai_models::BoxedModel;
+use std::time::Duration;
 
 /// Resolved build parameters ready for agent construction.
 #[derive(Clone)]
@@ -27,7 +28,7 @@ pub(super) struct PreparedBuild {
     agent_name: Box<str>,
     /// Concrete SerdesAI model.
     model: BoxedModel,
-    /// Normalized SerdesAI `provider:model` specification for diagnostics.
+    /// Normalised SerdesAI `provider:model` specification for diagnostics.
     #[cfg_attr(not(test), allow(dead_code))]
     model_spec: Box<str>,
     /// Agent system prompt template.
@@ -121,27 +122,57 @@ where
     for entry in &prepared.tools {
         match entry.kind {
             ToolCatalogKind::Read => {
-                if prepared.tool_settings.read.line_numbers {
-                    builder = builder.tool(prompt_builder.track(ReadTool::<true>::new()));
+                let settings = &prepared.tool_settings.read;
+                if settings.line_numbers {
+                    builder = builder.tool(prompt_builder.track(ReadTool::<true>::with_settings(
+                        settings.limit,
+                        settings.max_line_length,
+                    )));
                 } else {
-                    builder = builder.tool(prompt_builder.track(ReadTool::<false>::new()));
+                    builder = builder.tool(prompt_builder.track(ReadTool::<false>::with_settings(
+                        settings.limit,
+                        settings.max_line_length,
+                    )));
                 }
             }
             ToolCatalogKind::Write => {
                 builder = builder.tool(prompt_builder.track(WriteTool::new()))
             }
             ToolCatalogKind::Edit => builder = builder.tool(prompt_builder.track(EditTool::new())),
-            ToolCatalogKind::Glob => builder = builder.tool(prompt_builder.track(GlobTool::new())),
+            ToolCatalogKind::Glob => {
+                let settings = &prepared.tool_settings.glob;
+                builder =
+                    builder.tool(prompt_builder.track(GlobTool::with_settings(settings.limit)));
+            }
             ToolCatalogKind::Grep => {
-                if prepared.tool_settings.grep.line_numbers {
-                    builder = builder.tool(prompt_builder.track(GrepTool::<true>::new()));
+                let settings = &prepared.tool_settings.grep;
+                if settings.line_numbers {
+                    builder = builder.tool(prompt_builder.track(GrepTool::<true>::with_settings(
+                        settings.max_line_length,
+                        settings.limit,
+                    )));
                 } else {
-                    builder = builder.tool(prompt_builder.track(GrepTool::<false>::new()));
+                    builder = builder.tool(prompt_builder.track(GrepTool::<false>::with_settings(
+                        settings.max_line_length,
+                        settings.limit,
+                    )));
                 }
             }
-            ToolCatalogKind::Bash => builder = builder.tool(prompt_builder.track(BashTool::new())),
+            ToolCatalogKind::Bash => {
+                let settings = &prepared.tool_settings.bash;
+                builder = builder.tool(
+                    prompt_builder.track(
+                        BashTool::new()
+                            .with_default_timeout(Duration::from_millis(settings.timeout_ms)),
+                    ),
+                );
+            }
             ToolCatalogKind::WebFetch => {
-                builder = builder.tool(prompt_builder.track(WebFetchTool::new()))
+                let settings = &prepared.tool_settings.webfetch;
+                builder = builder.tool(prompt_builder.track(WebFetchTool::with_settings(
+                    settings.timeout_ms,
+                    settings.max_response_size_mib,
+                )));
             }
             ToolCatalogKind::TodoRead => {
                 builder = builder.tool(prompt_builder.track(todo_read.clone()))
@@ -180,7 +211,7 @@ pub enum AgentBuildError {
         /// The missing agent name.
         name: Box<str>,
     },
-    /// The runtime contains a tool kind this adapter cannot materialize.
+    /// The runtime contains a tool kind this adapter cannot materialise.
     #[error("tool `{name}` is not supported")]
     UnsupportedToolKind {
         /// The unsupported tool name.
@@ -190,7 +221,7 @@ pub enum AgentBuildError {
     #[error(transparent)]
     ModelResolution(#[from] ModelResolutionError),
     /// Initializing the SerdesAI model failed.
-    #[error("failed to initialize model: {0}")]
+    #[error("failed to initialise model: {0}")]
     ModelInit(#[from] serdes_ai_models::ModelError),
 }
 

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
@@ -19,7 +19,6 @@ use llm_coding_tools_agents::{
 use llm_coding_tools_core::{CredentialLookup, models::ModelCatalog};
 use serdes_ai::AgentBuilder;
 use serdes_ai_models::BoxedModel;
-use std::time::Duration;
 
 /// Resolved build parameters ready for agent construction.
 #[derive(Clone)]
@@ -161,16 +160,15 @@ where
             ToolCatalogKind::Bash => {
                 let settings = &prepared.tool_settings.bash;
                 builder = builder.tool(
-                    prompt_builder.track(
-                        BashTool::new()
-                            .with_default_timeout(Duration::from_millis(settings.timeout_ms)),
-                    ),
+                    prompt_builder
+                        .track(BashTool::new().with_default_timeout_ms(settings.timeout_ms)),
                 );
             }
             ToolCatalogKind::WebFetch => {
                 let settings = &prepared.tool_settings.webfetch;
                 builder = builder.tool(prompt_builder.track(WebFetchTool::with_settings(
                     settings.timeout_ms,
+                    None, // Use default max_timeout_ms
                     settings.max_response_size_mib,
                 )));
             }

--- a/src/llm-coding-tools-serdesai/src/allowed/glob.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/glob.rs
@@ -26,18 +26,34 @@ struct GlobArgs {
 pub struct GlobTool {
     definition: ToolDefinition,
     resolver: AllowedPathResolver,
+    limit: usize,
 }
 
 impl GlobTool {
-    /// Creates a new glob tool with a shared resolver.
+    /// Creates a new glob tool with a shared resolver and default settings.
+    ///
+    /// Uses `limit` of 1000 files.
     ///
     /// See [`ReadTool::new`] for usage example.
     ///
     /// [`ReadTool::new`]: super::ReadTool::new
     pub fn new(resolver: AllowedPathResolver) -> Self {
+        Self::with_settings(resolver, glob_meta::MAX_RESULTS)
+    }
+
+    /// Creates a new glob tool with custom settings.
+    ///
+    /// # Arguments
+    ///
+    /// * `resolver` - The path resolver for allowed directory access.
+    /// * `limit` - Maximum number of files to return per glob call.
+    ///   Results are sorted by modification time (newest first) and truncated
+    ///   to this limit if more files match the pattern.
+    pub fn with_settings(resolver: AllowedPathResolver, limit: usize) -> Self {
         Self {
             definition: build_definition(),
             resolver,
+            limit,
         }
     }
 }
@@ -52,7 +68,7 @@ impl<Deps: Send + Sync> Tool<Deps> for GlobTool {
         let args: GlobArgs = serde_json::from_value(args)
             .map_err(|e| ToolError::validation_error(glob_meta::NAME, None, e.to_string()))?;
 
-        let result = glob_files(&self.resolver, &args.pattern, &args.path);
+        let result = glob_files(&self.resolver, &args.pattern, &args.path, self.limit);
         match result {
             Err(e) => to_serdes_result(glob_meta::NAME, Err(e)),
             Ok(output) => Ok(glob_output_to_return(output)),

--- a/src/llm-coding-tools-serdesai/src/allowed/grep.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/grep.rs
@@ -32,18 +32,40 @@ struct GrepArgs {
 pub struct GrepTool<const LINE_NUMBERS: bool = true> {
     definition: ToolDefinition,
     resolver: AllowedPathResolver,
+    max_line_length: usize,
+    limit: usize,
 }
 
 impl<const LINE_NUMBERS: bool> GrepTool<LINE_NUMBERS> {
-    /// Creates a new grep tool with a shared resolver.
+    /// Creates a new grep tool with a shared resolver and default settings.
+    ///
+    /// Uses `max_line_length` of 2000 characters and `limit` of 100 matches.
     ///
     /// See [`ReadTool::new`] for usage example.
     ///
     /// [`ReadTool::new`]: super::ReadTool::new
     pub fn new(resolver: AllowedPathResolver) -> Self {
+        Self::with_settings(resolver, DEFAULT_MAX_LINE_LENGTH, grep_meta::DEFAULT_LIMIT)
+    }
+
+    /// Creates a new grep tool with custom settings.
+    ///
+    /// # Arguments
+    ///
+    /// * `resolver` - The path resolver for allowed directory access.
+    /// * `max_line_length` - Maximum characters per matching line before truncation.
+    ///   Longer lines will be truncated with "..." appended.
+    /// * `limit` - Maximum number of matches to return when not specified in args.
+    pub fn with_settings(
+        resolver: AllowedPathResolver,
+        max_line_length: usize,
+        limit: usize,
+    ) -> Self {
         Self {
             definition: build_definition::<LINE_NUMBERS>(),
             resolver,
+            max_line_length,
+            limit,
         }
     }
 }
@@ -67,10 +89,7 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
             ));
         }
 
-        let limit = args
-            .limit
-            .unwrap_or(grep_meta::DEFAULT_LIMIT)
-            .min(grep_meta::MAX_LIMIT);
+        let limit = args.limit.unwrap_or(self.limit);
         if limit == 0 {
             return Err(ToolError::validation_error(
                 grep_meta::NAME,
@@ -95,7 +114,7 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
             Ok(grep_output) => Ok(grep_output_to_return::<LINE_NUMBERS>(
                 grep_output,
                 limit,
-                DEFAULT_MAX_LINE_LENGTH,
+                self.max_line_length,
             )),
         }
     }
@@ -134,7 +153,7 @@ fn build_definition<const LINE_NUMBERS: bool>() -> ToolDefinition {
             grep_meta::param::LIMIT.description,
             grep_meta::param::LIMIT.required,
             Some(1),
-            Some(grep_meta::MAX_LIMIT as i64),
+            None,
         )
         .build()
         .expect("schema build should not fail");

--- a/src/llm-coding-tools-serdesai/src/allowed/read.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/read.rs
@@ -19,9 +19,9 @@ struct ReadArgs {
     /// Line offset to start reading from (1-based). Defaults to 1.
     #[serde(default = "read_meta::default_offset")]
     offset: usize,
-    /// Maximum number of lines to return. Defaults to 2000.
-    #[serde(default = "read_meta::default_limit")]
-    limit: usize,
+    /// Maximum number of lines to return. Uses tool default if not specified.
+    #[serde(default)]
+    limit: Option<usize>,
 }
 
 /// Tool for reading file contents with optional line numbers.
@@ -31,32 +31,45 @@ struct ReadArgs {
 pub struct ReadTool<const LINE_NUMBERS: bool = true> {
     definition: ToolDefinition,
     resolver: AllowedPathResolver,
+    limit: usize,
+    max_line_length: usize,
 }
 
 impl<const LINE_NUMBERS: bool> ReadTool<LINE_NUMBERS> {
-    /// Creates a new read tool with a shared resolver.
+    /// Creates a new read tool with a shared resolver and default settings.
     ///
-    /// Use a single [`AllowedPathResolver`] across all allowed tools to ensure
-    /// consistent path access:
+    /// Uses `limit` of 2000 lines and `max_line_length` of 2000 characters.
     ///
-    /// ```no_run
-    /// use llm_coding_tools_core::path::AllowedPathResolver;
-    /// use llm_coding_tools_serdesai::allowed::{ReadTool, WriteTool, EditTool};
-    /// use std::path::PathBuf;
+    /// See [`ReadTool::new`] for usage example.
     ///
-    /// let resolver = AllowedPathResolver::new(vec![
-    ///     std::env::current_dir().unwrap(),
-    ///     PathBuf::from("/tmp"),
-    /// ]).unwrap();
-    ///
-    /// let read: ReadTool<true> = ReadTool::new(resolver.clone());
-    /// let write = WriteTool::new(resolver.clone());
-    /// let edit = EditTool::new(resolver);
-    /// ```
+    /// [`ReadTool::new`]: super::ReadTool::new
     pub fn new(resolver: AllowedPathResolver) -> Self {
+        Self::with_settings(
+            resolver,
+            read_meta::DEFAULT_LIMIT,
+            read_meta::MAX_LINE_LENGTH,
+        )
+    }
+
+    /// Creates a new read tool with custom settings.
+    ///
+    /// # Arguments
+    ///
+    /// * `resolver` - The path resolver for allowed directory access.
+    /// * `limit` - Maximum number of lines to return per read call.
+    ///   This is the default used when the LLM doesn't specify a limit.
+    /// * `max_line_length` - Maximum characters per line before truncation.
+    ///   Longer lines will be truncated with "..." appended.
+    pub fn with_settings(
+        resolver: AllowedPathResolver,
+        limit: usize,
+        max_line_length: usize,
+    ) -> Self {
         Self {
             definition: build_definition::<LINE_NUMBERS>(),
             resolver,
+            limit,
+            max_line_length,
         }
     }
 }
@@ -71,9 +84,16 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for ReadTool<LINE_N
         let args: ReadArgs = serde_json::from_value(args)
             .map_err(|e| ToolError::validation_error(read_meta::NAME, None, e.to_string()))?;
 
-        let result =
-            read_file::<_, LINE_NUMBERS>(&self.resolver, &args.file_path, args.offset, args.limit)
-                .await;
+        // Use provided limit or fall back to settings default
+        let effective_limit = args.limit.unwrap_or(self.limit);
+        let result = read_file::<_, LINE_NUMBERS>(
+            &self.resolver,
+            &args.file_path,
+            args.offset,
+            effective_limit,
+            self.max_line_length,
+        )
+        .await;
         to_serdes_result(read_meta::NAME, result)
     }
 }

--- a/src/llm-coding-tools-serdesai/src/bash.rs
+++ b/src/llm-coding-tools-serdesai/src/bash.rs
@@ -171,7 +171,7 @@ impl<Deps: Send + Sync> Tool<Deps> for BashTool {
             .or(self.default_timeout)
             .unwrap_or(Duration::from_millis(bash_meta::DEFAULT_TIMEOUT_MS));
 
-        // Route execution through mode-aware entrypoint to honor explicit mode selection
+        // Route execution through mode-aware entrypoint to honour explicit mode selection
         let result = execute_command_with_mode(&self.mode, &args.command, workdir, timeout).await;
 
         to_serdes_result(bash_meta::NAME, result.map(|output| output.format_output()))
@@ -244,7 +244,7 @@ fn build_definition() -> ToolDefinition {
                 bash_meta::param::TIMEOUT_MS.description,
                 bash_meta::param::TIMEOUT_MS.required,
                 Some(1),
-                Some(bash_meta::MAX_TIMEOUT_MS as i64),
+                None,
             )
             .build()
             .expect("schema serialization should never fail"),

--- a/src/llm-coding-tools-serdesai/src/bash.rs
+++ b/src/llm-coding-tools-serdesai/src/bash.rs
@@ -32,7 +32,6 @@ use llm_coding_tools_core::tools::{BashExecutionMode, execute_command_with_mode}
 use serde::Deserialize;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
 use llm_coding_tools_bubblewrap::profile::{NetworkPolicy, Profile};
@@ -45,7 +44,7 @@ struct BashArgs {
     /// Optional working directory (must be absolute path).
     workdir: Option<String>,
     /// Timeout in milliseconds. Optional - falls back to constructor default or 120000ms.
-    timeout_ms: Option<u64>,
+    timeout_ms: Option<u32>,
 }
 
 /// Tool for executing shell commands.
@@ -56,8 +55,10 @@ pub struct BashTool {
     definition: ToolDefinition,
     /// Explicit execution mode for this tool instance.
     mode: BashExecutionMode, // ZST. 0 bytes when all optionals disabled.
-    /// Default timeout for commands when not specified in args.
-    default_timeout: Option<Duration>,
+    /// Default timeout in milliseconds for commands when not specified in args.
+    default_timeout_ms: u32,
+    /// Maximum timeout allowed for LLM requests.
+    max_timeout_ms: u32,
     /// Default working directory when not specified in args.
     default_workdir: Option<PathBuf>,
 }
@@ -85,7 +86,8 @@ impl BashTool {
         Self {
             definition: build_definition(),
             mode: BashExecutionMode::Host,
-            default_timeout: None,
+            default_timeout_ms: bash_meta::DEFAULT_TIMEOUT_MS,
+            max_timeout_ms: bash_meta::MAX_TIMEOUT_MS,
             default_workdir: None,
         }
     }
@@ -95,11 +97,30 @@ impl BashTool {
         &self.mode
     }
 
-    /// Sets the default timeout for commands.
+    /// Sets the default timeout for commands in milliseconds.
     ///
     /// This timeout is used when `timeout_ms` is not provided in the tool arguments.
-    pub fn with_default_timeout(mut self, timeout: Duration) -> Self {
-        self.default_timeout = Some(timeout);
+    ///
+    /// # Panics
+    ///
+    /// Panics if the timeout is 0 or exceeds `max_timeout_ms`.
+    pub fn with_default_timeout_ms(mut self, timeout_ms: u32) -> Self {
+        if timeout_ms == 0 {
+            panic!("default timeout must be at least 1ms");
+        }
+        if timeout_ms > self.max_timeout_ms {
+            panic!(
+                "default timeout ({}ms) cannot exceed max_timeout_ms ({}ms)",
+                timeout_ms, self.max_timeout_ms
+            );
+        }
+        self.default_timeout_ms = timeout_ms;
+        self
+    }
+
+    /// Sets the maximum timeout allowed for LLM requests.
+    pub fn with_max_timeout_ms(mut self, max_timeout_ms: u32) -> Self {
+        self.max_timeout_ms = max_timeout_ms;
         self
     }
 
@@ -149,7 +170,7 @@ impl<Deps: Send + Sync> Tool<Deps> for BashTool {
     ///
     /// # Errors
     ///
-    /// - [`ToolError::ValidationFailed`] if the JSON arguments fail deserialization.
+    /// - [`ToolError::ValidationFailed`] if the JSON arguments fail deserialization or timeout_ms is invalid.
     /// - [`ToolError::ExecutionFailed`] if the command cannot be spawned, the per-command
     ///   workdir is invalid, or a timeout or I/O failure occurs while collecting
     ///   output.
@@ -164,15 +185,19 @@ impl<Deps: Send + Sync> Tool<Deps> for BashTool {
             .map(|s| Path::new(s.as_str()))
             .or(self.default_workdir.as_deref());
 
-        // Priority: args.timeout_ms > self.default_timeout > DEFAULT_TIMEOUT_MS
-        let timeout = args
-            .timeout_ms
-            .map(Duration::from_millis)
-            .or(self.default_timeout)
-            .unwrap_or(Duration::from_millis(bash_meta::DEFAULT_TIMEOUT_MS));
+        // Priority: args.timeout_ms > self.default_timeout_ms
+        let timeout_ms = args.timeout_ms.unwrap_or(self.default_timeout_ms);
 
         // Route execution through mode-aware entrypoint to honour explicit mode selection
-        let result = execute_command_with_mode(&self.mode, &args.command, workdir, timeout).await;
+        // Core validates timeout_ms against max_timeout_ms
+        let result = execute_command_with_mode(
+            &self.mode,
+            &args.command,
+            workdir,
+            timeout_ms,
+            self.max_timeout_ms,
+        )
+        .await;
 
         to_serdes_result(bash_meta::NAME, result.map(|output| output.format_output()))
     }
@@ -335,7 +360,7 @@ mod tests {
     #[serial]
     async fn per_call_timeout_overrides_default() {
         // Constructor sets 10s default, but per-call arg specifies 100ms
-        let tool = BashTool::new().with_default_timeout(Duration::from_secs(10));
+        let tool = BashTool::new().with_default_timeout_ms(10_000);
         let cmd = if cfg!(target_os = "windows") {
             "ping -n 10 127.0.0.1"
         } else {
@@ -353,7 +378,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn default_timeout_used_when_arg_omitted() {
-        let tool = BashTool::new().with_default_timeout(Duration::from_millis(100));
+        let tool = BashTool::new().with_default_timeout_ms(100);
         let cmd = if cfg!(target_os = "windows") {
             "ping -n 10 127.0.0.1"
         } else {

--- a/src/llm-coding-tools-serdesai/src/bash.rs
+++ b/src/llm-coding-tools-serdesai/src/bash.rs
@@ -119,7 +119,20 @@ impl BashTool {
     }
 
     /// Sets the maximum timeout allowed for LLM requests.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_timeout_ms` is 0 or less than the current `default_timeout_ms`.
     pub fn with_max_timeout_ms(mut self, max_timeout_ms: u32) -> Self {
+        if max_timeout_ms == 0 {
+            panic!("max_timeout_ms must be at least 1");
+        }
+        if max_timeout_ms < self.default_timeout_ms {
+            panic!(
+                "max_timeout_ms ({}) must be >= default_timeout_ms ({})",
+                max_timeout_ms, self.default_timeout_ms
+            );
+        }
         self.max_timeout_ms = max_timeout_ms;
         self
     }

--- a/src/llm-coding-tools-serdesai/src/bash.rs
+++ b/src/llm-coding-tools-serdesai/src/bash.rs
@@ -97,43 +97,52 @@ impl BashTool {
         &self.mode
     }
 
-    /// Sets the default timeout for commands in milliseconds.
+    /// Sets both default and maximum timeout in a single, atomic operation.
     ///
-    /// This timeout is used when `timeout_ms` is not provided in the tool arguments.
+    /// This method validates that `1 <= default_timeout_ms <= max_timeout_ms` and sets
+    /// both values together. Use `None` to preserve the current value for either timeout.
     ///
     /// # Panics
     ///
-    /// Panics if the timeout is 0 or exceeds `max_timeout_ms`.
-    pub fn with_default_timeout_ms(mut self, timeout_ms: u32) -> Self {
-        if timeout_ms == 0 {
-            panic!("default timeout must be at least 1ms");
-        }
-        if timeout_ms > self.max_timeout_ms {
-            panic!(
-                "default timeout ({}ms) cannot exceed max_timeout_ms ({}ms)",
-                timeout_ms, self.max_timeout_ms
-            );
-        }
-        self.default_timeout_ms = timeout_ms;
-        self
-    }
+    /// Panics if a non-None `default_timeout_ms` is 0, a non-None `max_timeout_ms` is 0,
+    /// or if the resulting `default_timeout_ms > max_timeout_ms`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use llm_coding_tools_serdesai::bash::BashTool;
+    ///
+    /// // Set both timeouts atomically
+    /// let tool = BashTool::new().with_timeouts(Some(5_000), Some(30_000));
+    ///
+    /// // Change only the default, keep max at its current/default value
+    /// let tool = BashTool::new().with_timeouts(Some(10_000), None);
+    ///
+    /// // Change only the max, keep default at its current/default value
+    /// let tool = BashTool::new().with_timeouts(None, Some(300_000));
+    /// ```
+    pub fn with_timeouts(
+        mut self,
+        default_timeout_ms: Option<u32>,
+        max_timeout_ms: Option<u32>,
+    ) -> Self {
+        let new_default = default_timeout_ms.unwrap_or(self.default_timeout_ms);
+        let new_max = max_timeout_ms.unwrap_or(self.max_timeout_ms);
 
-    /// Sets the maximum timeout allowed for LLM requests.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `max_timeout_ms` is 0 or less than the current `default_timeout_ms`.
-    pub fn with_max_timeout_ms(mut self, max_timeout_ms: u32) -> Self {
-        if max_timeout_ms == 0 {
-            panic!("max_timeout_ms must be at least 1");
+        if let Some(0) = default_timeout_ms {
+            panic!("with_timeouts: default_timeout_ms must be at least 1 (got 0)");
         }
-        if max_timeout_ms < self.default_timeout_ms {
+        if let Some(0) = max_timeout_ms {
+            panic!("with_timeouts: max_timeout_ms must be at least 1 (got 0)");
+        }
+        if new_default > new_max {
             panic!(
-                "max_timeout_ms ({}) must be >= default_timeout_ms ({})",
-                max_timeout_ms, self.default_timeout_ms
+                "with_timeouts: default_timeout_ms ({}) cannot exceed max_timeout_ms ({})",
+                new_default, new_max
             );
         }
-        self.max_timeout_ms = max_timeout_ms;
+        self.default_timeout_ms = new_default;
+        self.max_timeout_ms = new_max;
         self
     }
 
@@ -373,7 +382,7 @@ mod tests {
     #[serial]
     async fn per_call_timeout_overrides_default() {
         // Constructor sets 10s default, but per-call arg specifies 100ms
-        let tool = BashTool::new().with_default_timeout_ms(10_000);
+        let tool = BashTool::new().with_timeouts(Some(10_000), Some(bash_meta::MAX_TIMEOUT_MS));
         let cmd = if cfg!(target_os = "windows") {
             "ping -n 10 127.0.0.1"
         } else {
@@ -391,7 +400,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn default_timeout_used_when_arg_omitted() {
-        let tool = BashTool::new().with_default_timeout_ms(100);
+        let tool = BashTool::new().with_timeouts(Some(100), Some(200));
         let cmd = if cfg!(target_os = "windows") {
             "ping -n 10 127.0.0.1"
         } else {

--- a/src/llm-coding-tools-serdesai/src/bash.rs
+++ b/src/llm-coding-tools-serdesai/src/bash.rs
@@ -84,7 +84,7 @@ impl BashTool {
     /// to sandbox commands.
     pub fn host() -> Self {
         Self {
-            definition: build_definition(),
+            definition: build_definition(bash_meta::MAX_TIMEOUT_MS),
             mode: BashExecutionMode::Host,
             default_timeout_ms: bash_meta::DEFAULT_TIMEOUT_MS,
             max_timeout_ms: bash_meta::MAX_TIMEOUT_MS,
@@ -143,6 +143,10 @@ impl BashTool {
         }
         self.default_timeout_ms = new_default;
         self.max_timeout_ms = new_max;
+        // Regenerate schema if max_timeout changed to reflect new ceiling in TIMEOUT_MS parameter
+        if max_timeout_ms.is_some() {
+            self.definition = build_definition(new_max);
+        }
         self
     }
 
@@ -268,7 +272,7 @@ impl ToolContext for BashTool {
     }
 }
 
-fn build_definition() -> ToolDefinition {
+fn build_definition(max_timeout_ms: u32) -> ToolDefinition {
     ToolDefinition {
         name: bash_meta::NAME.to_owned(),
         description: bash_meta::DESCRIPTION.to_owned(),
@@ -291,7 +295,7 @@ fn build_definition() -> ToolDefinition {
                 bash_meta::param::TIMEOUT_MS.description,
                 bash_meta::param::TIMEOUT_MS.required,
                 Some(1),
-                None,
+                Some(i64::from(max_timeout_ms)),
             )
             .build()
             .expect("schema serialization should never fail"),

--- a/src/llm-coding-tools-serdesai/src/webfetch.rs
+++ b/src/llm-coding-tools-serdesai/src/webfetch.rs
@@ -30,7 +30,8 @@ struct WebFetchArgs {
 pub struct WebFetchTool {
     client: reqwest::Client,
     definition: ToolDefinition,
-    default_timeout_ms: u64,
+    default_timeout_ms: u32,
+    max_timeout_ms: u32,
     max_response_size: usize,
 }
 
@@ -45,6 +46,7 @@ impl WebFetchTool {
     pub fn new() -> Self {
         Self::with_settings(
             webfetch_meta::DEFAULT_TIMEOUT_MS,
+            None,
             webfetch_meta::MAX_RESPONSE_SIZE_MIB,
         )
     }
@@ -55,17 +57,45 @@ impl WebFetchTool {
             client,
             definition: build_definition(),
             default_timeout_ms: webfetch_meta::DEFAULT_TIMEOUT_MS,
+            max_timeout_ms: webfetch_meta::MAX_TIMEOUT_MS,
             max_response_size: webfetch_meta::MAX_RESPONSE_SIZE_MIB * 1024 * 1024,
         }
     }
 
     /// Creates a webfetch tool with custom settings.
-    pub fn with_settings(timeout_ms: u64, max_response_size_mib: usize) -> Self {
+    ///
+    /// # Arguments
+    ///
+    /// * `default_timeout_ms` - Default timeout for web requests (must be >= 1)
+    /// * `max_timeout_ms` - Maximum timeout allowed for LLM requests (defaults to MAX_TIMEOUT_MS)
+    /// * `max_response_size_mib` - Maximum response size in mebibytes
+    ///
+    /// # Panics
+    ///
+    /// Panics if `default_timeout_ms` is 0 or exceeds `max_timeout_ms`.
+    pub fn with_settings(
+        default_timeout_ms: u32,
+        max_timeout_ms: Option<u32>,
+        max_response_size_mib: usize,
+    ) -> Self {
+        let max_timeout_ms = max_timeout_ms.unwrap_or(webfetch_meta::MAX_TIMEOUT_MS);
+
+        if default_timeout_ms == 0 {
+            panic!("default_timeout_ms must be at least 1");
+        }
+        if default_timeout_ms > max_timeout_ms {
+            panic!(
+                "default_timeout_ms ({}) cannot exceed max_timeout_ms ({})",
+                default_timeout_ms, max_timeout_ms
+            );
+        }
+
         let max_response_size = max_response_size_mib.saturating_mul(1024 * 1024);
         Self {
             client: reqwest::Client::new(),
             definition: build_definition(),
-            default_timeout_ms: timeout_ms,
+            default_timeout_ms,
+            max_timeout_ms,
             max_response_size,
         }
     }
@@ -81,13 +111,17 @@ impl<Deps: Send + Sync> Tool<Deps> for WebFetchTool {
         let args: WebFetchArgs = serde_json::from_value(args)
             .map_err(|e| ToolError::validation_error(webfetch_meta::NAME, None, e.to_string()))?;
 
-        // Use per-call timeout if specified, otherwise fall back to default
-        let effective_timeout = args.timeout_ms.unwrap_or(self.default_timeout_ms);
+        // Determine effective timeout: LLM-provided or default
+        let effective_timeout = args
+            .timeout_ms
+            .map(|t| t as u32)
+            .unwrap_or(self.default_timeout_ms);
 
         let result = fetch_url(
             &self.client,
             &args.url,
             effective_timeout,
+            self.max_timeout_ms,
             self.max_response_size,
         )
         .await;

--- a/src/llm-coding-tools-serdesai/src/webfetch.rs
+++ b/src/llm-coding-tools-serdesai/src/webfetch.rs
@@ -53,11 +53,12 @@ impl WebFetchTool {
 
     /// Creates a webfetch tool with a custom client and default settings.
     pub fn with_client(client: reqwest::Client) -> Self {
+        let max_timeout_ms = webfetch_meta::MAX_TIMEOUT_MS;
         Self {
             client,
-            definition: build_definition(),
+            definition: build_definition(max_timeout_ms),
             default_timeout_ms: webfetch_meta::DEFAULT_TIMEOUT_MS,
-            max_timeout_ms: webfetch_meta::MAX_TIMEOUT_MS,
+            max_timeout_ms,
             max_response_size: webfetch_meta::MAX_RESPONSE_SIZE_MIB * 1024 * 1024,
         }
     }
@@ -97,7 +98,7 @@ impl WebFetchTool {
         let max_response_size = max_response_size_mib.saturating_mul(1024 * 1024);
         Self {
             client: reqwest::Client::new(),
-            definition: build_definition(),
+            definition: build_definition(max_timeout_ms),
             default_timeout_ms,
             max_timeout_ms,
             max_response_size,
@@ -139,7 +140,7 @@ impl ToolContext for WebFetchTool {
     }
 }
 
-fn build_definition() -> ToolDefinition {
+fn build_definition(max_timeout_ms: u32) -> ToolDefinition {
     ToolDefinition {
         name: webfetch_meta::NAME.to_owned(),
         description: webfetch_meta::DESCRIPTION.to_owned(),
@@ -154,7 +155,7 @@ fn build_definition() -> ToolDefinition {
                 webfetch_meta::param::TIMEOUT_MS.description,
                 webfetch_meta::param::TIMEOUT_MS.required,
                 Some(1),
-                None,
+                Some(i64::from(max_timeout_ms)),
             )
             .build()
             .expect("schema serialization should never fail"),

--- a/src/llm-coding-tools-serdesai/src/webfetch.rs
+++ b/src/llm-coding-tools-serdesai/src/webfetch.rs
@@ -11,18 +11,14 @@ use llm_coding_tools_core::tools::fetch_url;
 use serde::Deserialize;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolError, ToolResult};
 
-fn default_timeout_ms() -> u64 {
-    webfetch_meta::DEFAULT_TIMEOUT_MS
-}
-
 /// Arguments for the webfetch tool.
 #[derive(Debug, Clone, Deserialize)]
 struct WebFetchArgs {
     /// The URL to fetch.
     url: String,
-    /// Timeout in milliseconds (default: 30000).
-    #[serde(default = "default_timeout_ms")]
-    timeout_ms: u64,
+    /// Timeout in milliseconds. If omitted, uses the tool's default timeout.
+    #[serde(default)]
+    timeout_ms: Option<u64>,
 }
 
 /// Tool for fetching web content.
@@ -34,6 +30,8 @@ struct WebFetchArgs {
 pub struct WebFetchTool {
     client: reqwest::Client,
     definition: ToolDefinition,
+    default_timeout_ms: u64,
+    max_response_size: usize,
 }
 
 impl Default for WebFetchTool {
@@ -43,19 +41,32 @@ impl Default for WebFetchTool {
 }
 
 impl WebFetchTool {
-    /// Creates a new webfetch tool with default client.
+    /// Creates a new webfetch tool with default client and settings.
     pub fn new() -> Self {
-        Self {
-            client: reqwest::Client::new(),
-            definition: build_definition(),
-        }
+        Self::with_settings(
+            webfetch_meta::DEFAULT_TIMEOUT_MS,
+            webfetch_meta::MAX_RESPONSE_SIZE_MIB,
+        )
     }
 
-    /// Creates a webfetch tool with a custom client.
+    /// Creates a webfetch tool with a custom client and default settings.
     pub fn with_client(client: reqwest::Client) -> Self {
         Self {
             client,
             definition: build_definition(),
+            default_timeout_ms: webfetch_meta::DEFAULT_TIMEOUT_MS,
+            max_response_size: webfetch_meta::MAX_RESPONSE_SIZE_MIB * 1024 * 1024,
+        }
+    }
+
+    /// Creates a webfetch tool with custom settings.
+    pub fn with_settings(timeout_ms: u64, max_response_size_mib: usize) -> Self {
+        let max_response_size = max_response_size_mib.saturating_mul(1024 * 1024);
+        Self {
+            client: reqwest::Client::new(),
+            definition: build_definition(),
+            default_timeout_ms: timeout_ms,
+            max_response_size,
         }
     }
 }
@@ -70,7 +81,16 @@ impl<Deps: Send + Sync> Tool<Deps> for WebFetchTool {
         let args: WebFetchArgs = serde_json::from_value(args)
             .map_err(|e| ToolError::validation_error(webfetch_meta::NAME, None, e.to_string()))?;
 
-        let result = fetch_url(&self.client, &args.url, args.timeout_ms).await;
+        // Use per-call timeout if specified, otherwise fall back to default
+        let effective_timeout = args.timeout_ms.unwrap_or(self.default_timeout_ms);
+
+        let result = fetch_url(
+            &self.client,
+            &args.url,
+            effective_timeout,
+            self.max_response_size,
+        )
+        .await;
 
         to_serdes_result(webfetch_meta::NAME, result.map(ToolOutput::from))
     }
@@ -99,7 +119,7 @@ fn build_definition() -> ToolDefinition {
                 webfetch_meta::param::TIMEOUT_MS.description,
                 webfetch_meta::param::TIMEOUT_MS.required,
                 Some(1),
-                Some(webfetch_meta::MAX_TIMEOUT_MS as i64),
+                None,
             )
             .build()
             .expect("schema serialization should never fail"),

--- a/src/llm-coding-tools-serdesai/src/webfetch.rs
+++ b/src/llm-coding-tools-serdesai/src/webfetch.rs
@@ -18,7 +18,7 @@ struct WebFetchArgs {
     url: String,
     /// Timeout in milliseconds. If omitted, uses the tool's default timeout.
     #[serde(default)]
-    timeout_ms: Option<u64>,
+    timeout_ms: Option<u32>,
 }
 
 /// Tool for fetching web content.
@@ -80,6 +80,10 @@ impl WebFetchTool {
     ) -> Self {
         let max_timeout_ms = max_timeout_ms.unwrap_or(webfetch_meta::MAX_TIMEOUT_MS);
 
+        if max_timeout_ms == 0 {
+            panic!("max_timeout_ms must be at least 1");
+        }
+
         if default_timeout_ms == 0 {
             panic!("default_timeout_ms must be at least 1");
         }
@@ -112,10 +116,7 @@ impl<Deps: Send + Sync> Tool<Deps> for WebFetchTool {
             .map_err(|e| ToolError::validation_error(webfetch_meta::NAME, None, e.to_string()))?;
 
         // Determine effective timeout: LLM-provided or default
-        let effective_timeout = args
-            .timeout_ms
-            .map(|t| t as u32)
-            .unwrap_or(self.default_timeout_ms);
+        let effective_timeout = args.timeout_ms.unwrap_or(self.default_timeout_ms);
 
         let result = fetch_url(
             &self.client,


### PR DESCRIPTION
## Summary

Adds support for per-agent configuration of tool behaviour limits, enabling users to customise resource constraints per tool via `tool_settings` in agent frontmatter.

## Changes

- **New settings support** in `tool_settings`:
  - `read`: `limit`, `max_line_length`
  - `grep`: `limit`, `max_line_length`
  - `glob`: `limit`
  - `bash`: `timeout_ms`, `max_timeout_ms`
  - `webfetch`: `timeout_ms`, `max_timeout_ms`, `max_response_size_mib`

- **Maximum timeout enforcement** - New `max_timeout_ms` sets the upper bound on timeouts LLMs can request (default: 600000ms / 10 minutes). Includes validation ensuring `max_timeout_ms >= timeout_ms`.

- **Updated documentation** with comprehensive reference tables in `llm-coding-tools-agents/README.md`

- **Fixed Ellipsis Truncation** tools now properly truncate with `...`

## Usage Example

```yaml
tool_settings:
  read:
    line_numbers: true          # default: true
    limit: 2000                 # default: 2000
    max_line_length: 2000       # default: 2000
  grep:
    line_numbers: true          # default: true
    limit: 100                  # default: 100
    max_line_length: 2000       # default: 2000
  glob:
    limit: 1000                 # default: 1000
  bash:
    timeout_ms: 120000          # default: 120000 (2 minutes)
    max_timeout_ms: 600000        # default: 600000 (10 minutes)
  webfetch:
    timeout_ms: 30000           # default: 30000 (30 seconds)
    max_timeout_ms: 600000        # default: 600000 (10 minutes)
    max_response_size_mib: 5    # default: 5
```