### PR TITLE
Replace httpbin.org with wiremock mocks in blocking webfetch tests

### DIFF
--- a/src/llm-coding-tools-core/Cargo.toml
+++ b/src/llm-coding-tools-core/Cargo.toml
@@ -103,8 +103,8 @@ llm-coding-tools-bubblewrap = { version = "0.1.0", path = "../llm-coding-tools-b
 [dev-dependencies]
 serial_test = "3"
 tempfile = "3.27"
-# For async tests (when async feature enabled)
-tokio = { version = "1.50", features = ["rt", "macros"] }
+# For tests (async and blocking with wiremock)
+tokio = { version = "1.50", features = ["rt-multi-thread", "macros"] }
 wiremock = "0.6"
 indoc = "2"
 criterion = "0.8"

--- a/src/llm-coding-tools-core/src/tools/webfetch/blocking_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/webfetch/blocking_impl.rs
@@ -116,11 +116,71 @@ pub fn fetch_url(
 mod tests {
     use super::*;
     use rstest::rstest;
+    use std::sync::mpsc;
+    use std::sync::Arc;
+    use tokio::runtime::Runtime;
+    use tokio::sync::Notify;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn test_client() -> reqwest::blocking::Client {
         reqwest::blocking::Client::builder()
             .build()
             .expect("client build failed")
+    }
+
+    /// Handle to a running mock server. When dropped, signals the server to shut down
+    /// and waits for the server thread to exit, ensuring proper cleanup.
+    struct MockServerHandle {
+        uri: String,
+        shutdown: Arc<Notify>,
+        thread: Option<std::thread::JoinHandle<()>>,
+    }
+
+    impl MockServerHandle {
+        fn uri(&self) -> &str {
+            &self.uri
+        }
+    }
+
+    impl Drop for MockServerHandle {
+        fn drop(&mut self) {
+            self.shutdown.notify_one();
+            if let Some(thread) = self.thread.take() {
+                thread.join().ok();
+            }
+        }
+    }
+
+    /// Starts a wiremock server in a dedicated tokio thread for blocking tests.
+    /// Returns a handle that shuts down the server and joins the thread when dropped.
+    fn start_mock_server(
+        setup: impl FnOnce(MockServer) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
+            + Send
+            + 'static,
+    ) -> MockServerHandle {
+        let (tx, rx) = mpsc::channel::<String>();
+        let shutdown = Arc::new(Notify::new());
+        let shutdown_clone = shutdown.clone();
+
+        let thread = std::thread::spawn(move || {
+            let rt = Runtime::new().expect("Failed to create tokio runtime");
+            rt.block_on(async {
+                let server = MockServer::start().await;
+                let uri = server.uri();
+                tx.send(uri).expect("Failed to send server URI");
+                setup(server).await;
+                // Wait for shutdown signal
+                shutdown_clone.notified().await;
+            })
+        });
+
+        let uri = rx.recv().expect("Failed to receive server URI");
+        MockServerHandle {
+            uri,
+            shutdown,
+            thread: Some(thread),
+        }
     }
 
     /// Verifies that invalid timeout values are rejected before making any
@@ -144,38 +204,58 @@ mod tests {
 
     #[test]
     fn fetches_plain_text() {
-        // Use httpbin.org for blocking tests since wiremock is async-only
+        let server = start_mock_server(|mock_server| {
+            Box::pin(async move {
+                Mock::given(method("GET"))
+                    .and(path("/robots.txt"))
+                    .respond_with(
+                        ResponseTemplate::new(200)
+                            .set_body_bytes("User-agent: *\nDisallow: /")
+                            .insert_header("content-type", "text/plain"),
+                    )
+                    .mount(&mock_server)
+                    .await;
+            })
+        });
+
         let client = test_client();
         let result = fetch_url(
             &client,
-            "https://httpbin.org/robots.txt",
+            &format!("{}/robots.txt", server.uri()),
             10_000,
             20_000,
             5 * 1024 * 1024,
         );
 
-        // This test requires network access, so we just check it doesn't panic
-        // In CI, this might fail due to network restrictions
-        if let Ok(output) = result {
-            assert!(!output.content.is_empty());
-            assert!(!output.content_type.is_empty());
-        }
+        let output = result.expect("Should successfully fetch");
+        assert!(output.content.contains("User-agent"));
+        assert!(output.content_type.contains("text/plain"));
     }
 
     #[test]
     fn handles_404() {
+        let server = start_mock_server(|mock_server| {
+            Box::pin(async move {
+                Mock::given(method("GET"))
+                    .and(path("/not-found"))
+                    .respond_with(ResponseTemplate::new(404))
+                    .mount(&mock_server)
+                    .await;
+            })
+        });
+
         let client = test_client();
         let result = fetch_url(
             &client,
-            "https://httpbin.org/status/404",
+            &format!("{}/not-found", server.uri()),
             10_000,
             20_000,
             5 * 1024 * 1024,
         );
 
-        // In case of network issues, just verify we get some result
-        if let Err(e) = result {
-            assert!(matches!(e, ToolError::Http(_)));
-        }
+        assert!(
+            matches!(result, Err(ToolError::Http(_))),
+            "Should return HTTP error for 404"
+        );
     }
 }


### PR DESCRIPTION
## Summary
Replaces external network calls to `httpbin.org` with local wiremock servers in blocking webfetch tests. This eliminates test dependencies on external services and enables offline/CI-friendly test execution.

## Changes

### `llm-coding-tools-core/Cargo.toml`
- Updated tokio dev-dependency to include `rt-multi-thread` feature (required for blocking tests with wiremock)

### `llm-coding-tools-core/src/tools/webfetch/blocking_impl.rs`
- Added `MockServerHandle` struct with RAII-based shutdown
- Implemented `start_mock_server()` helper that spawns wiremock in a tokio thread
- `fetches_plain_text`: Now mocks GET /robots.txt returning 200 with text/plain
- `handles_404`: Now mocks GET /not-found returning 404

## Why this matters
- **No external dependencies**: Tests no longer require network access
- **Deterministic**: Mock responses are consistent and predictable
- **CI-friendly**: Works in air-gapped environments
- **Faster**: No network latency
- **Proper lifecycle**: Mock servers shut down cleanly after each test via `Drop` impl