### PR TITLE
Parameterize Tests with rstest

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -67,4 +67,4 @@ This is a high-performance library. Optimize aggressively.
 
 # Post-Change Verification
 
-After you make a change to source code, always run `.cargo/verify.sh` (`.cargo/verify.ps1` on Windows) before returning to the user.
+After code changes, always run `.cargo/verify` script before returning to the user. Search if not found.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2067,6 +2067,7 @@ dependencies = [
  "llm-coding-tools-core",
  "maybe-async",
  "reqwest 0.13.1",
+ "rstest",
  "serde",
  "serde_json",
  "serial_test",

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2012,6 +2012,7 @@ version = "0.1.0"
 dependencies = [
  "parking_lot",
  "process-wrap",
+ "rstest",
  "serial_test",
  "tempfile",
  "thiserror 2.0.18",

--- a/src/llm-coding-tools-agents/src/loader.rs
+++ b/src/llm-coding-tools-agents/src/loader.rs
@@ -415,37 +415,30 @@ mod tests {
         write!(file, "{}", content).unwrap();
     }
 
-    #[test]
-    fn matches_agent_pattern_works() {
-        assert!(matches_agent_pattern("agent/test.md"));
-        assert!(matches_agent_pattern("agents/test.md"));
-        assert!(matches_agent_pattern("agent/nested/deep.md"));
-        assert!(matches_agent_pattern("agents/nested/deep.md"));
-        assert!(!matches_agent_pattern("other/test.md"));
-        assert!(!matches_agent_pattern("agent/test.txt"));
-        assert!(!matches_agent_pattern("notagen/test.md"));
+    #[rstest]
+    #[case::agent_directory("agent/test.md", true)] // top-level agent/ path
+    #[case::agents_directory("agents/test.md", true)] // top-level agents/ path
+    #[case::nested_agent("agent/nested/deep.md", true)] // nested under agent/
+    #[case::nested_agents("agents/nested/deep.md", true)] // nested under agents/
+    #[case::wrong_directory("other/test.md", false)] // non-agent directory
+    #[case::wrong_extension("agent/test.txt", false)] // non-.md extension
+    #[case::wrong_prefix("notagen/test.md", false)] // similar prefix but not agent/
+    fn agent_path_pattern_matching(#[case] rel_path: &str, #[case] expected: bool) {
+        assert_eq!(matches_agent_pattern(rel_path), expected);
     }
 
-    #[test]
-    fn derive_agent_name_from_rel_works() {
+    #[rstest]
+    #[case::agent_directory("agent/test.md", Some("test"))] // strips agent/ prefix
+    #[case::agents_directory("agents/test.md", Some("test"))] // strips agents/ prefix
+    #[case::nested_agent("agent/nested/deep.md", Some("nested/deep"))] // preserves nested path
+    #[case::deep_nested("agents/foo/bar/baz.md", Some("foo/bar/baz"))] // deep nesting under agents/
+    #[case::empty_name_agent("agent/.md", None)] // empty stem → no name
+    #[case::empty_name_agents("agents/.md", None)] // empty stem → no name
+    fn extracts_agent_name_from_rel_path(#[case] rel_path: &str, #[case] expected: Option<&str>) {
         assert_eq!(
-            derive_agent_name_from_rel("agent/test.md"),
-            Some("test".to_string())
+            derive_agent_name_from_rel(rel_path),
+            expected.map(|s| s.to_string())
         );
-        assert_eq!(
-            derive_agent_name_from_rel("agents/test.md"),
-            Some("test".to_string())
-        );
-        assert_eq!(
-            derive_agent_name_from_rel("agent/nested/deep.md"),
-            Some("nested/deep".to_string())
-        );
-        assert_eq!(
-            derive_agent_name_from_rel("agents/foo/bar/baz.md"),
-            Some("foo/bar/baz".to_string())
-        );
-        assert_eq!(derive_agent_name_from_rel("agent/.md"), None);
-        assert_eq!(derive_agent_name_from_rel("agents/.md"), None);
     }
 
     #[test]

--- a/src/llm-coding-tools-agents/src/parser/mod.rs
+++ b/src/llm-coding-tools-agents/src/parser/mod.rs
@@ -250,26 +250,31 @@ mod tests {
     use super::*;
     use crate::types::RawFrontmatter;
     use indoc::indoc;
+    use rstest::rstest;
 
-    #[test]
-    fn parse_extracts_frontmatter_and_content() {
-        let input: &str = indoc! {"
+    /// Expected error variant for parameterized error-case tests.
+    #[derive(Debug, Clone, Copy)]
+    enum ExpectedParseError {
+        MissingFrontmatter,
+        InvalidYaml,
+        SchemaValidation(&'static str),
+    }
+
+    #[rstest]
+    #[case::extracts_frontmatter_and_content(
+        indoc! {"
             ---
             mode: subagent
             description: Test agent
             ---
 
             Prompt body here."
-        };
-        let result: AgentParseResult<RawFrontmatter> = parse_agent(input.to_string()).unwrap();
-
-        assert_eq!(&*result.data.description, "Test agent");
-        assert_eq!(result.content, "Prompt body here.");
-    }
-
-    #[test]
-    fn parse_trims_body_whitespace() {
-        let input = indoc! {"
+        },
+        // prepend_bom, expected_content, expected_description, expected_model, expected_hidden
+        false, "Prompt body here.", "Test agent", None, None
+    )]
+    #[case::trims_body_whitespace(
+        indoc! {"
             ---
             mode: primary
             description: Test
@@ -278,185 +283,178 @@ mod tests {
               indented
 
             trailing
-        "};
-        let result: AgentParseResult<RawFrontmatter> = parse_agent(input.to_string()).unwrap();
-
-        assert_eq!(result.content, "indented\n\ntrailing");
-    }
-
-    #[test]
-    fn parse_trims_ascii_whitespace_with_multibyte_body() {
-        let input = indoc! {"
+        "},
+        // prepend_bom, expected_content, expected_description, expected_model, expected_hidden
+        false, "indented\n\ntrailing", "Test", None, None
+    )]
+    #[case::trims_ascii_whitespace_with_multibyte_body(
+        indoc! {"
             ---
             mode: primary
             description: Test
             ---
 
               🙂 café 漢字  
-        "};
-        let result: AgentParseResult<RawFrontmatter> = parse_agent(input.to_string()).unwrap();
-
-        assert_eq!(result.content, "🙂 café 漢字");
-    }
-
-    #[test]
-    fn parse_handles_empty_body() {
-        let input = indoc! {"
+        "},
+        // prepend_bom, expected_content, expected_description, expected_model, expected_hidden
+        false, "🙂 café 漢字", "Test", None, None
+    )]
+    #[case::handles_empty_body(
+        indoc! {"
             ---
             mode: primary
             description: Test
             ---"
-        };
-        let result: AgentParseResult<RawFrontmatter> = parse_agent(input.to_string()).unwrap();
-
-        assert!(result.content.is_empty());
-    }
-
-    #[test]
-    fn parse_handles_empty_frontmatter() {
-        // Handle frontmatter with only whitespace - should error since
-        // RawFrontmatter requires description field
-        let input = indoc! {"
-            ---
-             
-            ---
-            body"
-        };
-        let result = parse_agent::<RawFrontmatter>(input.to_string());
-
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_trims_crlf_in_body() {
-        // Handle body should normalize CRLF to LF
-        let input = "---\nmode: subagent\ndescription: Test\n---\nline1\r\nline2\r\n";
-        let result: AgentParseResult<RawFrontmatter> = parse_agent(input.to_string()).unwrap();
-
-        assert_eq!(result.content, "line1\nline2");
-    }
-
-    #[test]
-    fn parse_trims_crlf_body_with_crlf_frontmatter() {
-        // FIX #3: CRLF in frontmatter should normalize body
-        let input = "---\r\nmode: subagent\r\ndescription: Test\r\n---\r\nbody\r\nline2\r\n";
-        let result: AgentParseResult<RawFrontmatter> = parse_agent(input.to_string()).unwrap();
-
-        assert_eq!(result.content, "body\nline2");
-    }
-
-    #[test]
-    fn parse_rejects_frontmatter_not_at_start() {
-        let input = indoc! {"
-            some text
-            ---
-            mode: subagent
-            ---
-            body"
-        };
-        let result: Result<AgentParseResult<RawFrontmatter>, AgentParseError> =
-            parse_agent(input.to_string());
-
-        assert!(matches!(result, Err(AgentParseError::MissingFrontmatter)));
-    }
-
-    #[test]
-    fn parse_handles_bom() {
-        let input = indoc! {"
+        },
+        // prepend_bom, expected_content, expected_description, expected_model, expected_hidden
+        false, "", "Test", None, None
+    )]
+    #[case::handles_bom(
+        indoc! {"
             ---
             mode: subagent
             description: Test
             ---
             body"
-        };
-        let input = format!("\u{FEFF}{}", input);
-        let result: AgentParseResult<RawFrontmatter> = parse_agent(input.to_string()).unwrap();
-
-        assert_eq!(result.content, "body");
-    }
-
-    #[test]
-    fn parse_returns_error_for_missing_frontmatter() {
-        let input = "No frontmatter here";
-        let result: Result<AgentParseResult<RawFrontmatter>, AgentParseError> =
-            parse_agent(input.to_string());
-
-        assert!(matches!(result, Err(AgentParseError::MissingFrontmatter)));
-    }
-
-    #[test]
-    fn parse_returns_error_for_invalid_yaml() {
-        let input = indoc! {"
-            ---
-            [invalid yaml
-            ---
-            body"
-        };
-        let result: Result<AgentParseResult<RawFrontmatter>, AgentParseError> =
-            parse_agent(input.to_string());
-
-        assert!(matches!(result, Err(AgentParseError::InvalidYaml { .. })));
-    }
-
-    #[test]
-    fn block_scalar_no_trailing_newline() {
-        let input = indoc! {"
+        },
+        // prepend_bom, expected_content, expected_description, expected_model, expected_hidden
+        true, "body", "Test", None, None
+    )]
+    #[case::block_scalar_no_trailing_newline(
+        indoc! {"
             ---
             model: provider/model:tag
             description: Test
             ---
             body"
+        },
+        // prepend_bom, expected_content, expected_description, expected_model, expected_hidden
+        false, "body", "Test", Some("provider/model:tag"), None
+    )]
+    #[case::accepts_permission_task_allow_scalar(
+        indoc! {"
+            ---
+            description: Test
+            permission:
+              task: allow
+            ---
+            body"
+        },
+        // prepend_bom, expected_content, expected_description, expected_model, expected_hidden
+        false, "body", "Test", None, None
+    )]
+    #[case::accepts_hidden_true_no_validation_failure(
+        indoc! {"
+            ---
+            description: Test
+            hidden: true
+            ---
+            body"
+        },
+        // prepend_bom, expected_content, expected_description, expected_model, expected_hidden
+        false, "body", "Test", None, Some(true)
+    )]
+    fn parse_agent_success_cases(
+        #[case] input: &str,
+        #[case] prepend_bom: bool,
+        #[case] expected_content: &str,
+        #[case] expected_description: &str,
+        #[case] expected_model: Option<&str>,
+        #[case] expected_hidden: Option<bool>,
+    ) {
+        let input = if prepend_bom {
+            format!("\u{FEFF}{input}")
+        } else {
+            input.to_string()
         };
-        let result: AgentParseResult<RawFrontmatter> = parse_agent(input.to_string()).unwrap();
+        let result: AgentParseResult<RawFrontmatter> = parse_agent(input).unwrap();
 
-        // Model should NOT have trailing newline
-        assert_eq!(result.data.model.as_deref(), Some("provider/model:tag"));
-    }
+        assert_eq!(result.content, expected_content);
+        assert_eq!(&*result.data.description, expected_description);
+        assert_eq!(result.data.model.as_deref(), expected_model);
 
-    #[test]
-    fn parse_error_display_messages() {
-        let cases = [
-            (AgentParseError::MissingFrontmatter, "missing frontmatter"),
-            (
-                AgentParseError::InvalidYaml {
-                    message: "bad".to_string(),
-                },
-                "invalid YAML frontmatter: bad",
-            ),
-            (
-                AgentParseError::SchemaValidation {
-                    message: "schema bad".to_string(),
-                },
-                "schema validation failed: schema bad",
-            ),
-        ];
-
-        for (err, expected) in cases {
-            assert_eq!(err.to_string(), expected);
+        if let Some(expected_hidden) = expected_hidden {
+            assert_eq!(result.data.hidden, expected_hidden);
         }
     }
 
-    #[test]
-    fn parse_rejects_permission_task_ask_scalar() {
-        let input = indoc! {"
+    #[rstest]
+    #[case::empty_frontmatter_schema_validation(
+        indoc! {"
+            ---
+             
+            ---
+            body"
+        },
+        ExpectedParseError::SchemaValidation("missing field `description`")
+    )]
+    #[case::frontmatter_not_at_start_returns_missing_frontmatter(
+        indoc! {"
+            some text
+            ---
+            mode: subagent
+            ---
+            body"
+        },
+        ExpectedParseError::MissingFrontmatter
+    )]
+    #[case::missing_frontmatter_returns_missing_frontmatter(
+        "No frontmatter here",
+        ExpectedParseError::MissingFrontmatter
+    )]
+    #[case::invalid_yaml_returns_invalid_yaml(
+        indoc! {"
+            ---
+            [invalid yaml
+            ---
+            body"
+        },
+        ExpectedParseError::InvalidYaml
+    )]
+    fn parse_agent_error_cases(#[case] input: &str, #[case] expected_error: ExpectedParseError) {
+        let result = parse_agent::<RawFrontmatter>(input.to_string());
+
+        match (result, expected_error) {
+            (Err(AgentParseError::MissingFrontmatter), ExpectedParseError::MissingFrontmatter) => {}
+            (Err(AgentParseError::InvalidYaml { .. }), ExpectedParseError::InvalidYaml) => {}
+            (
+                Err(AgentParseError::SchemaValidation { message }),
+                ExpectedParseError::SchemaValidation(expected_fragment),
+            ) => assert!(message.contains(expected_fragment)),
+            (other, expected) => panic!("expected {expected:?}, got {other:?}"),
+        }
+    }
+
+    // CRLF cases use inline string literals (not indoc!) because they need
+    // explicit \r\n escape sequences that indoc! cannot represent.
+    #[rstest]
+    #[case::body_only_crlf_normalizes_to_lf(
+        "---\nmode: subagent\ndescription: Test\n---\nline1\r\nline2\r\n",
+        "line1\nline2"
+    )]
+    #[case::frontmatter_and_body_crlf_normalize_to_lf(
+        "---\r\nmode: subagent\r\ndescription: Test\r\n---\r\nbody\r\nline2\r\n",
+        "body\nline2"
+    )]
+    fn parse_agent_crlf_normalization(#[case] input: &str, #[case] expected_content: &str) {
+        let result: AgentParseResult<RawFrontmatter> = parse_agent(input.to_string()).unwrap();
+
+        assert_eq!(result.content, expected_content);
+    }
+
+    #[rstest]
+    #[case::rejects_task_ask_scalar(
+        indoc! {"
             ---
             description: Test
             permission:
               task: ask
             ---
             body"
-        };
-        let result = parse_agent::<RawFrontmatter>(input.to_string());
-        assert!(matches!(
-            result,
-            Err(AgentParseError::SchemaValidation { message })
-                if message.contains("permission.task: ask is unsupported")
-        ));
-    }
-
-    #[test]
-    fn parse_rejects_permission_task_ask_pattern_map() {
-        let input = indoc! {"
+        }
+    )]
+    #[case::rejects_task_ask_pattern_map(
+        indoc! {"
             ---
             description: Test
             permission:
@@ -464,8 +462,11 @@ mod tests {
                 '*': ask
             ---
             body"
-        };
+        }
+    )]
+    fn parse_agent_permission_validation(#[case] input: &str) {
         let result = parse_agent::<RawFrontmatter>(input.to_string());
+
         assert!(matches!(
             result,
             Err(AgentParseError::SchemaValidation { message })
@@ -473,31 +474,23 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn parse_accepts_permission_task_allow_scalar() {
-        let input = indoc! {"
-            ---
-            description: Test
-            permission:
-              task: allow
-            ---
-            body"
-        };
-        let result: AgentParseResult<RawFrontmatter> = parse_agent(input.to_string()).unwrap();
-        assert_eq!(&*result.data.description, "Test");
-    }
-
-    #[test]
-    fn parse_accepts_hidden_true_no_validation_failure() {
-        let input = indoc! {"
-            ---
-            description: Test
-            hidden: true
-            ---
-            body"
-        };
-        let result: AgentParseResult<RawFrontmatter> = parse_agent(input.to_string()).unwrap();
-        assert_eq!(&*result.data.description, "Test");
-        assert!(result.data.hidden);
+    #[rstest]
+    #[case::missing_frontmatter(
+        AgentParseError::MissingFrontmatter, // error: missing frontmatter variant
+        "missing frontmatter"                // expected: display message
+    )]
+    #[case::invalid_yaml(
+        AgentParseError::InvalidYaml { message: "bad".to_string() }, // error: yaml parse failure
+        "invalid YAML frontmatter: bad"                              // expected: includes error message
+    )]
+    #[case::schema_validation(
+        AgentParseError::SchemaValidation { message: "schema bad".to_string() }, // error: schema check failure
+        "schema validation failed: schema bad"                                   // expected: includes error message
+    )]
+    fn parse_error_display_messages(
+        #[case] error: AgentParseError,
+        #[case] expected_message: &str,
+    ) {
+        assert_eq!(error.to_string(), expected_message);
     }
 }

--- a/src/llm-coding-tools-agents/src/parser/mod.rs
+++ b/src/llm-coding-tools-agents/src/parser/mod.rs
@@ -372,10 +372,7 @@ mod tests {
         assert_eq!(result.content, expected_content);
         assert_eq!(&*result.data.description, expected_description);
         assert_eq!(result.data.model.as_deref(), expected_model);
-
-        if let Some(expected_hidden) = expected_hidden {
-            assert_eq!(result.data.hidden, expected_hidden);
-        }
+        assert_eq!(result.data.hidden, expected_hidden.unwrap_or(false));
     }
 
     #[rstest]

--- a/src/llm-coding-tools-agents/src/parser/preprocessor.rs
+++ b/src/llm-coding-tools-agents/src/parser/preprocessor.rs
@@ -239,88 +239,100 @@ fn is_valid_key(key: &str) -> bool {
 mod tests {
     use super::*;
     use crlf_to_lf_inplace::crlf_to_lf_inplace;
+    use indoc::indoc;
+    use rstest::rstest;
 
-    #[test]
-    fn preprocess_handles_colons_in_value() {
-        let input = "model: provider/model:tag";
-        let output = preprocess_frontmatter_yaml(input);
-        assert!(output.as_ref().contains("model: |-"));
-        assert!(output.as_ref().contains("  provider/model:tag"));
+    /// Verifies that ambiguous YAML values are rewritten as block scalars.
+    #[rstest]
+    // Unquoted colon inside a plain scalar must become a block scalar.
+    #[case::colons_in_value(
+        indoc! {"
+            model: provider/model:tag
+        "},
+        false,
+        indoc! {"
+            model: |-
+              provider/model:tag
+        "},
+        None
+    )]
+    // Key spacing still normalizes to `key: |-`.
+    #[case::whitespace_around_key_separator(
+        indoc! {"
+            model : provider/model:tag
+        "},
+        false,
+        indoc! {"
+            model: |-
+              provider/model:tag
+        "},
+        None
+    )]
+    // CRLF input is normalized before rewrite and both ambiguous values still transform.
+    #[case::crlf_normalized_two_line_frontmatter(
+        "model: provider/model:tag\r\napi_url: http://localhost:8080",
+        true,
+        "model: |-\n  provider/model:tag\napi_url: |-\n  http://localhost:8080",
+        None
+    )]
+    // Transformed output drops the inline comment suffix from the scalar content.
+    #[case::strips_inline_comment_when_rewriting(
+        indoc! {"
+            model: provider/model:tag # inline comment
+        "},
+        false,
+        indoc! {"
+            model: |-
+              provider/model:tag
+        "},
+        Some("# inline comment")
+    )]
+    fn preprocess_transforms_to_block_scalar(
+        #[case] raw_input: &str,
+        #[case] normalize_crlf: bool,
+        #[case] expected_fragment: &str,
+        #[case] forbidden_fragment: Option<&str>,
+    ) {
+        let mut input = raw_input.to_string();
+        if normalize_crlf {
+            // Keep the explicit normalization path covered because the parser expects LF input.
+            crlf_to_lf_inplace(&mut input);
+        }
+
+        let output = preprocess_frontmatter_yaml(&input);
+        assert!(output.as_ref().contains(expected_fragment.trim_end()));
+
+        if let Some(forbidden_fragment) = forbidden_fragment {
+            assert!(!output.as_ref().contains(forbidden_fragment));
+        }
     }
 
-    #[test]
-    fn preprocess_preserves_quoted_values() {
-        let input = "model: \"provider/model:tag\"";
-        let output = preprocess_frontmatter_yaml(input);
-        assert!(output.as_ref().contains("model: \"provider/model:tag\""));
-    }
-
-    #[test]
-    fn preprocess_preserves_block_scalars() {
-        let input = "desc: |\n  multiline";
+    /// Verifies that safe YAML constructs are preserved unchanged.
+    #[rstest]
+    // Quoted scalars are already YAML-safe.
+    #[case::quoted_value("model: \"provider/model:tag\"")]
+    // Block scalar indicators must not be rewritten again.
+    #[case::existing_block_scalar(indoc! {"
+        desc: |
+          multiline
+    "})]
+    // Comment lines with colons are preserved verbatim.
+    #[case::comment_line_is_ignored(indoc! {"
+        # comment: with:colon
+        mode: subagent
+    "})]
+    // Flow syntax is already explicit YAML and must stay untouched.
+    #[case::flow_mapping("task: { \"*\": \"deny\" }")]
+    #[case::flow_array("items: [\"a:b\", \"c:d\"]")]
+    // Nested lines inside a block scalar are not treated as top-level keys.
+    #[case::indented_continuation_line(indoc! {"
+        desc: |
+          line:with:colons
+    "})]
+    // A colon inside the inline comment keeps the original line unchanged to avoid false positives.
+    #[case::ambiguous_inline_comment_with_colon("model: provider/model # note: keep")]
+    fn preprocess_preserves_unchanged(#[case] input: &str) {
         let output = preprocess_frontmatter_yaml(input);
         assert_eq!(input, output.as_ref());
-    }
-
-    #[test]
-    fn preprocess_skips_comments() {
-        let input = "# comment: with:colon\nmode: subagent";
-        let output = preprocess_frontmatter_yaml(input);
-        assert!(output.as_ref().contains("# comment: with:colon"));
-    }
-
-    #[test]
-    fn preprocess_skips_flow_mappings() {
-        let input = "task: { \"*\": \"deny\" }";
-        let output = preprocess_frontmatter_yaml(input);
-        assert!(output.as_ref().contains("task: { \"*\": \"deny\" }"));
-    }
-
-    #[test]
-    fn preprocess_skips_flow_arrays() {
-        let input = "items: [\"a:b\", \"c:d\"]";
-        let output = preprocess_frontmatter_yaml(input);
-        assert!(output.as_ref().contains("items: [\"a:b\", \"c:d\"]"));
-    }
-
-    #[test]
-    fn preprocess_handles_key_with_whitespace_around_colon() {
-        let input = "model : provider/model:tag";
-        let output = preprocess_frontmatter_yaml(input);
-        assert!(output.as_ref().contains("model: |-"));
-        assert!(output.as_ref().contains("  provider/model:tag"));
-    }
-
-    #[test]
-    fn preprocess_handles_crlf_line_endings() {
-        let mut input = "model: provider/model:tag\r\napi_url: http://localhost:8080".to_string();
-        crlf_to_lf_inplace(&mut input);
-        let output = preprocess_frontmatter_yaml(&input);
-        assert!(output.as_ref().contains("model: |-"));
-        assert!(output.as_ref().contains("  provider/model:tag"));
-    }
-
-    #[test]
-    fn preprocess_skips_indented_lines() {
-        let input = "desc: |\n  line:with:colons";
-        let output = preprocess_frontmatter_yaml(input);
-        assert!(output.as_ref().contains("  line:with:colons"));
-        assert!(!output.as_ref().contains("  line: |-"));
-    }
-
-    #[test]
-    fn preprocess_strips_inline_comments_when_rewriting() {
-        let input = "model: provider/model:tag # inline comment";
-        let output = preprocess_frontmatter_yaml(input);
-        assert!(output.as_ref().contains("model: |-"));
-        assert!(output.as_ref().contains("  provider/model:tag"));
-        assert!(!output.as_ref().contains("# inline comment"));
-    }
-
-    #[test]
-    fn preprocess_skips_ambiguous_inline_comment_with_colon() {
-        let input = "model: provider/model # note: keep";
-        let output = preprocess_frontmatter_yaml(input);
-        assert_eq!(output.as_ref(), input);
     }
 }

--- a/src/llm-coding-tools-bubblewrap/Cargo.toml
+++ b/src/llm-coding-tools-bubblewrap/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = "2.0"
 process-wrap = { version = "9", default-features = false, optional = true }
 
 [dev-dependencies]
+rstest = "0.26"
 serial_test = "3"
 tempfile = "3.27"
 tokio = { version = "1.50", features = ["rt", "macros"] }

--- a/src/llm-coding-tools-bubblewrap/src/profile/types.rs
+++ b/src/llm-coding-tools-bubblewrap/src/profile/types.rs
@@ -508,6 +508,7 @@ impl Profile {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
     use std::borrow::Cow;
     use std::ffi::OsString;
 
@@ -561,8 +562,21 @@ mod tests {
         }
     }
 
-    #[test]
-    fn is_prevalidated_workdir_accepts_exact_profile_owned_roots() {
+    #[rstest]
+    #[case::workspace_root("/host/workspace", true)]
+    #[case::synthetic_home_root("/host/home", true)]
+    #[case::cache_root("/host/cache", true)]
+    #[case::tmp_bind_root("/host/tmp", true)]
+    #[case::read_only_mount_root("/host/ro", true)]
+    #[case::read_write_mount_root("/host/rw", true)]
+    #[case::nested_workspace_path("/host/workspace/subdir", false)]
+    #[case::nested_home_path("/host/home/subdir", false)]
+    #[case::nested_cache_path("/host/cache/subdir", false)]
+    #[case::outside_unmounted_path("/outside", false)]
+    fn is_prevalidated_workdir_matches_exact_owned_roots_only(
+        #[case] path: &str,
+        #[case] expected: bool,
+    ) {
         let profile = Profile {
             preset: None,
             workspace: Box::from(Path::new("/host/workspace")),
@@ -588,22 +602,6 @@ mod tests {
             shell: Box::from(Path::new("/bin/sh")),
             static_args: Arc::<[OsString]>::from([]),
         };
-
-        assert!(profile.is_prevalidated_workdir(Path::new("/host/workspace")));
-        assert!(profile.is_prevalidated_workdir(Path::new("/host/home")));
-        assert!(profile.is_prevalidated_workdir(Path::new("/host/cache")));
-        assert!(profile.is_prevalidated_workdir(Path::new("/host/tmp")));
-        assert!(profile.is_prevalidated_workdir(Path::new("/host/ro")));
-        assert!(profile.is_prevalidated_workdir(Path::new("/host/rw")));
-    }
-
-    #[test]
-    fn is_prevalidated_workdir_rejects_nested_or_unmounted_paths() {
-        let profile = profile_with_workspace_dest("/workspace");
-
-        assert!(!profile.is_prevalidated_workdir(Path::new("/host/workspace/subdir")));
-        assert!(!profile.is_prevalidated_workdir(Path::new("/host/home/subdir")));
-        assert!(!profile.is_prevalidated_workdir(Path::new("/host/cache/subdir")));
-        assert!(!profile.is_prevalidated_workdir(Path::new("/outside")));
+        assert_eq!(profile.is_prevalidated_workdir(Path::new(path)), expected);
     }
 }

--- a/src/llm-coding-tools-core/src/path/absolute.rs
+++ b/src/llm-coding-tools-core/src/path/absolute.rs
@@ -40,41 +40,55 @@ impl PathResolver for AbsolutePathResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn accepts_absolute_path() {
+    #[rstest]
+    #[cfg_attr(
+        windows,
+        case::accepts_platform_absolute_path(
+            "C:\\Users\\user\\file.txt",    // input: Windows absolute path
+            Ok("C:\\Users\\user\\file.txt") // expected: accepted as-is
+        )
+    )]
+    #[cfg_attr(
+        not(windows),
+        case::accepts_platform_absolute_path(
+            "/home/user/file.txt",    // input: Unix absolute path
+            Ok("/home/user/file.txt") // expected: accepted as-is
+        )
+    )]
+    #[case::rejects_plain_relative_path(
+        "relative/path.txt", // input: plain relative, no dot prefix
+        Err(())              // expected: rejected as non-absolute
+    )]
+    #[case::rejects_dot_relative_path(
+        "./file.txt", // input: dot-relative path
+        Err(())       // expected: rejected as non-absolute
+    )]
+    #[case::rejects_parent_relative_path(
+        "../file.txt", // input: parent-relative path
+        Err(())        // expected: rejected as non-absolute
+    )]
+    #[cfg_attr(
+        windows,
+        case::accepts_windows_absolute_path(
+            "C:\\Users\\file.txt",    // input: Windows absolute with different path
+            Ok("C:\\Users\\file.txt") // expected: accepted as-is
+        )
+    )]
+    fn resolve_handles_absolute_and_relative_paths(
+        #[case] input: &str,                        // path string to resolve
+        #[case] expected: Result<&'static str, ()>, // Ok(path) if accepted, Err(()) if rejected
+    ) {
         let resolver = AbsolutePathResolver;
-        #[cfg(windows)]
-        let path = "C:\\Users\\user\\file.txt";
-        #[cfg(not(windows))]
-        let path = "/home/user/file.txt";
-
-        let result = resolver.resolve(path);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), PathBuf::from(path));
-    }
-
-    #[test]
-    fn rejects_relative_path() {
-        let resolver = AbsolutePathResolver;
-        let result = resolver.resolve("relative/path.txt");
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err, ToolError::InvalidPath(_)));
-        assert!(err.to_string().contains("must be absolute"));
-    }
-
-    #[test]
-    fn rejects_dot_relative_path() {
-        let resolver = AbsolutePathResolver;
-        assert!(resolver.resolve("./file.txt").is_err());
-        assert!(resolver.resolve("../file.txt").is_err());
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn accepts_windows_absolute_path() {
-        let resolver = AbsolutePathResolver;
-        assert!(resolver.resolve("C:\\Users\\file.txt").is_ok());
+        let result = resolver.resolve(input);
+        match expected {
+            Ok(expected_path) => assert_eq!(result.unwrap(), PathBuf::from(expected_path)),
+            Err(()) => {
+                let err = result.unwrap_err();
+                assert!(matches!(err, ToolError::InvalidPath(_)));
+                assert!(err.to_string().contains("must be absolute"));
+            }
+        }
     }
 }

--- a/src/llm-coding-tools-models-dev/Cargo.toml
+++ b/src/llm-coding-tools-models-dev/Cargo.toml
@@ -64,3 +64,4 @@ tokio = { version = "1.49", features = ["fs", "io-util"], optional = true }
 [dev-dependencies]
 tokio = { version = "1.49", features = ["rt", "macros"] }
 serial_test = "3"
+rstest = "0.26"

--- a/src/llm-coding-tools-models-dev/src/api/catalog_sources.rs
+++ b/src/llm-coding-tools-models-dev/src/api/catalog_sources.rs
@@ -575,6 +575,7 @@ mod tests {
         ProviderType::ClaudeCodeOAuth
     )]
     #[case::antigravity_package(Some("@ai-sdk/antigravity"), ProviderType::Antigravity)]
+    #[case::unknown_package(Some("@unknown/package"), ProviderType::Unknown)]
     #[case::missing_package_unknown(None, ProviderType::Unknown)]
     fn npm_package_maps_to_correct_provider_type(
         #[case] npm_package: Option<&str>,

--- a/src/llm-coding-tools-models-dev/src/api/catalog_sources.rs
+++ b/src/llm-coding-tools-models-dev/src/api/catalog_sources.rs
@@ -164,6 +164,7 @@ mod tests {
     use super::{cache_payload_from_api_json_bytes, provider_type_from_models_dev_npm};
     use crate::cache::payload::catalog_from_cache_payload;
     use llm_coding_tools_core::models::{Modality, ModelCatalog, ProviderIdx, ProviderType};
+    use rstest::rstest;
 
     fn catalog_from_api_json_bytes(json_bytes: &[u8]) -> crate::error::CatalogResult<ModelCatalog> {
         let payload = cache_payload_from_api_json_bytes(json_bytes)?;
@@ -542,75 +543,46 @@ mod tests {
         );
     }
 
-    #[test]
-    fn provider_type_mapping_handles_known_and_unknown_packages() {
+    /// Verifies that npm package names from AI SDK providers are correctly mapped
+    /// to their corresponding ProviderType variants. Tests both known provider
+    /// packages and the fallback case for unknown/missing packages.
+    #[rstest]
+    #[case::openai_package(Some("@ai-sdk/openai"), ProviderType::OpenAiCompletions)]
+    #[case::openai_compatible_package(
+        Some("@ai-sdk/openai-compatible"),
+        ProviderType::OpenAiCompletions
+    )]
+    #[case::openai_responses_package(
+        Some("@ai-sdk/openai-responses"),
+        ProviderType::OpenAiResponses
+    )]
+    #[case::anthropic_package(Some("@ai-sdk/anthropic"), ProviderType::Anthropic)]
+    #[case::google_package(Some("@ai-sdk/google"), ProviderType::Google)]
+    #[case::groq_package(Some("@ai-sdk/groq"), ProviderType::Groq)]
+    #[case::mistral_package(Some("@ai-sdk/mistral"), ProviderType::Mistral)]
+    #[case::ollama_package(Some("@ai-sdk/ollama"), ProviderType::Ollama)]
+    #[case::amazon_bedrock_package(Some("@ai-sdk/amazon-bedrock"), ProviderType::Bedrock)]
+    #[case::azure_package(Some("@ai-sdk/azure"), ProviderType::Azure)]
+    #[case::openrouter_provider_package(
+        Some("@openrouter/ai-sdk-provider"),
+        ProviderType::OpenRouter
+    )]
+    #[case::huggingface_package(Some("@ai-sdk/huggingface"), ProviderType::HuggingFace)]
+    #[case::cohere_package(Some("@ai-sdk/cohere"), ProviderType::Cohere)]
+    #[case::chatgpt_oauth_package(Some("@ai-sdk/chatgpt-oauth"), ProviderType::ChatGptOAuth)]
+    #[case::claude_code_oauth_package(
+        Some("@ai-sdk/claude-code-oauth"),
+        ProviderType::ClaudeCodeOAuth
+    )]
+    #[case::antigravity_package(Some("@ai-sdk/antigravity"), ProviderType::Antigravity)]
+    #[case::missing_package_unknown(None, ProviderType::Unknown)]
+    fn npm_package_maps_to_correct_provider_type(
+        #[case] npm_package: Option<&str>,
+        #[case] expected_provider_type: ProviderType,
+    ) {
         assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/openai")),
-            ProviderType::OpenAiCompletions
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/openai-compatible")),
-            ProviderType::OpenAiCompletions
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/openai-responses")),
-            ProviderType::OpenAiResponses
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/anthropic")),
-            ProviderType::Anthropic
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/google")),
-            ProviderType::Google
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/groq")),
-            ProviderType::Groq
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/mistral")),
-            ProviderType::Mistral
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/ollama")),
-            ProviderType::Ollama
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/amazon-bedrock")),
-            ProviderType::Bedrock
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/azure")),
-            ProviderType::Azure
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(Some("@openrouter/ai-sdk-provider")),
-            ProviderType::OpenRouter
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/huggingface")),
-            ProviderType::HuggingFace
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/cohere")),
-            ProviderType::Cohere
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/chatgpt-oauth")),
-            ProviderType::ChatGptOAuth
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/claude-code-oauth")),
-            ProviderType::ClaudeCodeOAuth
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(Some("@ai-sdk/antigravity")),
-            ProviderType::Antigravity
-        );
-        assert_eq!(
-            provider_type_from_models_dev_npm(None),
-            ProviderType::Unknown
+            provider_type_from_models_dev_npm(npm_package),
+            expected_provider_type
         );
     }
 }

--- a/src/llm-coding-tools-models-dev/src/cache/payload.rs
+++ b/src/llm-coding-tools-models-dev/src/cache/payload.rs
@@ -146,6 +146,7 @@ pub(crate) fn catalog_from_cache_payload(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     fn sample_payload() -> CatalogCachePayload {
         CatalogCachePayload {
@@ -231,46 +232,43 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn all_known_provider_types_round_trip() {
-        let types = [
-            ProviderType::Unknown,
-            ProviderType::OpenAiCompletions,
-            ProviderType::OpenAiResponses,
-            ProviderType::Anthropic,
-            ProviderType::Google,
-            ProviderType::Groq,
-            ProviderType::Mistral,
-            ProviderType::Ollama,
-            ProviderType::Bedrock,
-            ProviderType::Azure,
-            ProviderType::OpenRouter,
-            ProviderType::HuggingFace,
-            ProviderType::Cohere,
-            ProviderType::ChatGptOAuth,
-            ProviderType::ClaudeCodeOAuth,
-            ProviderType::Antigravity,
-        ];
+    #[rstest]
+    #[case::unknown(ProviderType::Unknown)]
+    #[case::openai_completions(ProviderType::OpenAiCompletions)]
+    #[case::openai_responses(ProviderType::OpenAiResponses)]
+    #[case::anthropic(ProviderType::Anthropic)]
+    #[case::google(ProviderType::Google)]
+    #[case::groq(ProviderType::Groq)]
+    #[case::mistral(ProviderType::Mistral)]
+    #[case::ollama(ProviderType::Ollama)]
+    #[case::bedrock(ProviderType::Bedrock)]
+    #[case::azure(ProviderType::Azure)]
+    #[case::openrouter(ProviderType::OpenRouter)]
+    #[case::hugging_face(ProviderType::HuggingFace)]
+    #[case::cohere(ProviderType::Cohere)]
+    #[case::chatgpt_oauth(ProviderType::ChatGptOAuth)]
+    #[case::claude_code_oauth(ProviderType::ClaudeCodeOAuth)]
+    #[case::antigravity(ProviderType::Antigravity)]
+    /// Verifies that all ProviderType variants serialize and deserialize correctly
+    /// through the cache payload conversion, ensuring no data loss on round-trip.
+    fn all_known_provider_types_round_trip(#[case] provider_type: ProviderType) {
+        let payload = CatalogCachePayload {
+            providers: vec![CachedProviderRow {
+                provider_key: "test".to_string(),
+                api_url: "".to_string(),
+                env_vars: vec![],
+                api_type: provider_type,
+            }],
+            models: vec![],
+        };
 
-        for provider_type in types {
-            let payload = CatalogCachePayload {
-                providers: vec![CachedProviderRow {
-                    provider_key: "test".to_string(),
-                    api_url: "".to_string(),
-                    env_vars: vec![],
-                    api_type: provider_type,
-                }],
-                models: vec![],
-            };
-
-            let catalog = catalog_from_cache_payload(payload).expect("should succeed");
-            let provider = catalog
-                .lookup_provider("test")
-                .expect("provider should exist");
-            assert_eq!(
-                provider.api_type, provider_type,
-                "provider type should round-trip correctly"
-            );
-        }
+        let catalog = catalog_from_cache_payload(payload).expect("should succeed");
+        let provider = catalog
+            .lookup_provider("test")
+            .expect("provider should exist");
+        assert_eq!(
+            provider.api_type, provider_type,
+            "provider type should round-trip correctly"
+        );
     }
 }

--- a/src/llm-coding-tools-serdesai/src/convert.rs
+++ b/src/llm-coding-tools-serdesai/src/convert.rs
@@ -88,6 +88,7 @@ pub(crate) fn core_error_to_serdes(tool_name: &str, err: CoreError) -> SerdesErr
 mod tests {
     use super::*;
     use llm_coding_tools_core::{ToolError as CoreError, ToolOutput};
+    use rstest::rstest;
 
     #[test]
     fn tool_output_converts_to_text_when_not_truncated() {
@@ -105,63 +106,73 @@ mod tests {
         assert_eq!(json["truncated"], true);
     }
 
-    #[test]
-    fn invalid_path_error_maps_to_validation_error() {
-        let core_err = CoreError::InvalidPath("not absolute".into());
-        let serdes_err = core_error_to_serdes("test_tool", core_err);
-        // Use pattern matching - is_validation_error() doesn't exist
+    #[rstest]
+    #[case::invalid_path(CoreError::InvalidPath("not absolute".into()), "test_tool")]
+    #[case::invalid_pattern(CoreError::InvalidPattern("bad regex".into()), "test_tool")]
+    #[case::out_of_bounds(CoreError::OutOfBounds("offset too large".into()), "test_tool")]
+    fn validation_errors_map_to_validation_failed(
+        #[case] core_err: CoreError,
+        #[case] tool_name: &str,
+    ) {
+        let serdes_err = core_error_to_serdes(tool_name, core_err);
         assert!(matches!(serdes_err, SerdesError::ValidationFailed { .. }));
     }
 
     #[test]
-    fn invalid_pattern_error_maps_to_validation_error() {
-        let core_err = CoreError::InvalidPattern("bad regex".into());
-        let serdes_err = core_error_to_serdes("test_tool", core_err);
+    fn to_serdes_result_preserves_tool_name_in_validation_errors() {
+        let core_result: CoreResult<ToolOutput> = Err(CoreError::InvalidPath("bad path".into()));
+        let serdes_err = to_serdes_result("read_file", core_result).unwrap_err();
+
         assert!(matches!(serdes_err, SerdesError::ValidationFailed { .. }));
+        match serdes_err {
+            SerdesError::ValidationFailed { tool_name, errors } => {
+                assert_eq!(tool_name, "read_file");
+                assert!(!errors.is_empty());
+                assert!(errors[0].message.contains("bad path"));
+            }
+            _ => unreachable!(),
+        }
     }
 
-    #[test]
-    fn out_of_bounds_error_maps_to_validation_error() {
-        let core_err = CoreError::OutOfBounds("offset too large".into());
-        let serdes_err = core_error_to_serdes("test_tool", core_err);
-        assert!(matches!(serdes_err, SerdesError::ValidationFailed { .. }));
-    }
-
-    #[test]
-    fn io_error_maps_to_execution_error() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
-        let core_err: CoreError = io_err.into();
-        let serdes_err = core_error_to_serdes("test_tool", core_err);
-        // ExecutionFailed is not a ValidationFailed
-        assert!(!matches!(serdes_err, SerdesError::ValidationFailed { .. }));
-    }
-
-    #[test]
-    fn execution_error_maps_to_execution_failed() {
-        let core_err = CoreError::Execution("command failed".into());
-        let serdes_err = core_error_to_serdes("test_tool", core_err);
-        assert!(!matches!(serdes_err, SerdesError::ValidationFailed { .. }));
-        // Use message() which exists, and check the error content
-        assert!(serdes_err.message().contains("execution error"));
-    }
-
-    #[test]
-    fn timeout_error_maps_to_execution_failed() {
-        let core_err = CoreError::Timeout("timed out".into());
-        let serdes_err = core_error_to_serdes("test_tool", core_err);
-        assert!(!matches!(serdes_err, SerdesError::ValidationFailed { .. }));
-    }
-
-    #[test]
-    fn timeout_with_kill_failure_maps_to_execution_failed() {
-        let core_err = CoreError::TimeoutWithKillFailure {
+    /// Ensure execution/runtime errors (Io, Execution, Timeout, etc.) are NOT
+    /// converted to validation errors. They must stay on the runtime failure path.
+    #[rstest]
+    #[case::io_error(
+        CoreError::from(std::io::Error::new(std::io::ErrorKind::NotFound, "file not found")),
+        None,
+        None
+    )]
+    #[case::execution_error(
+        CoreError::Execution("command failed".into()),
+        Some("execution error"),
+        None,
+    )]
+    #[case::timeout(CoreError::Timeout("timed out".into()), None, None)]
+    #[case::timeout_with_kill_failure(
+        CoreError::TimeoutWithKillFailure {
             message: "timed out".into(),
             kill_error: "operation not permitted".into(),
-        };
+        },
+        Some("timed out"),
+        Some("operation not permitted"),
+    )]
+    fn execution_errors_stay_on_runtime_failure_path(
+        #[case] core_err: CoreError,
+        #[case] expected_msg: Option<&str>,
+        #[case] expected_extra: Option<&str>,
+    ) {
         let serdes_err = core_error_to_serdes("test_tool", core_err);
-        assert!(!matches!(serdes_err, SerdesError::ValidationFailed { .. }));
-        assert!(serdes_err.message().contains("timed out"));
-        assert!(serdes_err.message().contains("operation not permitted"));
+        let is_validation_error = matches!(serdes_err, SerdesError::ValidationFailed { .. });
+        assert!(
+            !is_validation_error,
+            "execution errors must not be validation errors"
+        );
+        if let Some(msg) = expected_msg {
+            assert!(serdes_err.message().contains(msg));
+        }
+        if let Some(msg) = expected_extra {
+            assert!(serdes_err.message().contains(msg));
+        }
     }
 
     #[test]
@@ -178,22 +189,5 @@ mod tests {
             Err(CoreError::Execution("command failed".into()));
         let serdes_result = to_serdes_result("test_tool", core_result);
         assert!(serdes_result.is_err());
-    }
-
-    #[test]
-    fn to_serdes_result_includes_tool_name_in_validation_error() {
-        let core_result: CoreResult<ToolOutput> = Err(CoreError::InvalidPath("bad path".into()));
-        let serdes_result = to_serdes_result("read_file", core_result);
-        let err = serdes_result.unwrap_err();
-        assert!(matches!(err, SerdesError::ValidationFailed { .. }));
-        // Validation error should include the error details
-        match err {
-            SerdesError::ValidationFailed { tool_name, errors } => {
-                assert_eq!(tool_name, "read_file");
-                assert!(!errors.is_empty());
-                assert!(errors[0].message.contains("bad path"));
-            }
-            _ => panic!("Expected ValidationFailed"),
-        }
     }
 }

--- a/src/llm-coding-tools-serdesai/src/task/definition.rs
+++ b/src/llm-coding-tools-serdesai/src/task/definition.rs
@@ -73,6 +73,7 @@ pub fn task_tool_definition(targets: &[TaskTargetSummary]) -> ToolDefinition {
 #[cfg(test)]
 mod tests {
     use super::{task_meta, *};
+    use rstest::rstest;
 
     fn summary(name: &str, description: &str) -> TaskTargetSummary {
         TaskTargetSummary {
@@ -81,41 +82,35 @@ mod tests {
         }
     }
 
-    #[test]
-    fn render_task_targets_sorts_output_by_name() {
-        let targets = vec![
-            summary("zebra", "Last alphabetically"),
-            summary("alpha", "First alphabetically"),
-            summary("mike", "Middle"),
-        ];
-
+    #[rstest]
+    // Alphabetical ordering: zebra/alpha/mike → alpha/mike/zebra
+    #[case::sorts_alphabetically(
+        vec![summary("zebra", "Last alphabetically"), summary("alpha", "First alphabetically"), summary("mike", "Middle")],
+        None::<&str>,
+        "Available subagents:\n- alpha: First alphabetically\n- mike: Middle\n- zebra: Last alphabetically\n",
+    )]
+    // Format: only "- name: description" per line, no "tools:" leakage
+    #[case::shows_name_and_description(
+        vec![summary("with-task", "Can delegate"), summary("no-task", "Cannot delegate")],
+        Some("tools:"),
+        "Available subagents:\n- no-task: Cannot delegate\n- with-task: Can delegate\n",
+    )]
+    // Empty input falls back to the dedicated message
+    #[case::handles_empty_input(
+        vec![],
+        None::<&str>,
+        "No callable subagents are available.",
+    )]
+    fn render_task_targets_renders_expected_output(
+        #[case] targets: Vec<TaskTargetSummary>,
+        #[case] forbidden_fragment: Option<&str>,
+        #[case] expected_rendered: &str,
+    ) {
         let rendered = render_task_targets(&targets);
-        let lines: Vec<_> = rendered.lines().skip(1).collect(); // Skip "Available subagents:"
-
-        assert!(lines[0].starts_with("- alpha"));
-        assert!(lines[1].starts_with("- mike"));
-        assert!(lines[2].starts_with("- zebra"));
-    }
-
-    #[test]
-    fn render_task_targets_shows_only_name_and_description() {
-        let targets = vec![
-            summary("with-task", "Can delegate"),
-            summary("no-task", "Cannot delegate"),
-        ];
-
-        let rendered = render_task_targets(&targets);
-
-        assert!(rendered.contains("- with-task: Can delegate"));
-        assert!(rendered.contains("- no-task: Cannot delegate"));
-        assert!(!rendered.contains("tools:"));
-    }
-
-    #[test]
-    fn render_task_targets_handles_empty_input_cleanly() {
-        let targets: Vec<TaskTargetSummary> = vec![];
-        let rendered = render_task_targets(&targets);
-        assert_eq!(rendered, "No callable subagents are available.");
+        assert_eq!(rendered, expected_rendered);
+        if let Some(fragment) = forbidden_fragment {
+            assert!(!rendered.contains(fragment));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR refactors tests across the workspace to use the \`rstest\` crate for parameterized testing, reducing code duplication and improving maintainability.

## Changes

- **llm-coding-tools-agents**: Parameterized loader and parser tests
- **llm-coding-tools-bubblewrap**: Parameterized profile type tests  
- **llm-coding-tools-core**: Parameterized absolute path resolver tests
- **llm-coding-tools-models-dev**: Parameterized catalog sources and cache payload tests
- **llm-coding-tools-serdesai**: Parameterized conversion and task definition tests

## Benefits

- Eliminated repetitive test boilerplate
- Added descriptive test case names via \`#[case::name(...)]\` attributes
- Made test inputs and expected outputs more explicit
- Net reduction in test code while maintaining coverage

## Testing

All existing test cases preserved, now expressed as parameterized rstest cases.