### PR TITLE
Remove const generics from ReadTool and GrepTool

### DIFF
--- a/src/llm-coding-tools-core/src/tools/grep.rs
+++ b/src/llm-coding-tools-core/src/tools/grep.rs
@@ -59,15 +59,12 @@ pub struct GrepOutput {
 impl GrepOutput {
     /// Formats grep results as human-readable text.
     ///
-    /// # Type Parameters
-    ///
-    /// * `LINE_NUMBERS` - When `true`, prefixes each match with `L{num}: `
-    ///
     /// # Arguments
     ///
+    /// * `line_numbers` - When `true`, prefixes each match with `L{num}: `
     /// * `limit` - The original match limit (used in truncation message)
     /// * `max_line_len` - Truncate lines exceeding this character length and append `...`
-    pub fn format<const LINE_NUMBERS: bool>(&self, limit: usize, max_line_len: usize) -> String {
+    pub fn format(&self, line_numbers: bool, limit: usize, max_line_len: usize) -> String {
         let estimated_capacity = self.match_count * ESTIMATED_CHARS_PER_MATCH;
         let mut output = String::with_capacity(estimated_capacity);
 
@@ -79,7 +76,7 @@ impl GrepOutput {
                 let (display_text, was_truncated) =
                     truncate_line_with_ellipsis(&m.line_text, max_line_len);
 
-                if LINE_NUMBERS {
+                if line_numbers {
                     let _ = write!(&mut output, "  L{}: {}", m.line_num, display_text);
                 } else {
                     let _ = write!(&mut output, "  {}", display_text);
@@ -364,7 +361,7 @@ mod tests {
             errors,
         };
 
-        let formatted = output.format::<true>(10, DEFAULT_MAX_LINE_LENGTH);
+        let formatted = output.format(true, 10, DEFAULT_MAX_LINE_LENGTH);
 
         assert_eq!(formatted.contains("Partial results"), expect_partial_msg);
         assert_eq!(
@@ -453,11 +450,7 @@ mod tests {
             errors: Vec::new(),
         };
 
-        let formatted = if with_line_numbers {
-            output.format::<true>(10, max_len)
-        } else {
-            output.format::<false>(10, max_len)
-        };
+        let formatted = output.format(with_line_numbers, 10, max_len);
 
         assert!(
             formatted.contains(expected),

--- a/src/llm-coding-tools-core/src/tools/read.rs
+++ b/src/llm-coding-tools-core/src/tools/read.rs
@@ -19,12 +19,13 @@ fn strip_cr(line: &[u8]) -> &[u8] {
 
 /// Processes a single line, appending it to output with optional line numbers.
 #[inline]
-fn process_line<const LINE_NUMBERS: bool>(
+fn process_line(
     line_bytes: &[u8],
     line_number: usize,
     output: &mut String,
     lines_output: &mut usize,
     max_line_length: usize,
+    line_numbers: bool,
 ) {
     let line_bytes = strip_cr(line_bytes);
     let content: Cow<'_, str> = String::from_utf8_lossy(line_bytes);
@@ -34,7 +35,7 @@ fn process_line<const LINE_NUMBERS: bool>(
         output.push('\n');
     }
 
-    if LINE_NUMBERS {
+    if line_numbers {
         let _ = write!(output, "L{}: {}", line_number, display_content);
     } else {
         output.push_str(display_content);
@@ -49,15 +50,16 @@ fn process_line<const LINE_NUMBERS: bool>(
 
 /// Reads a file and returns formatted content, optionally with line numbers.
 ///
-/// When `LINE_NUMBERS` is `true`, each line is prefixed with `L{number}: `.
+/// When `line_numbers` is `true`, each line is prefixed with `L{number}: `.
 /// When `false`, raw content is returned without prefixes.
 #[maybe_async::maybe_async]
-pub async fn read_file<R: PathResolver, const LINE_NUMBERS: bool>(
+pub async fn read_file<R: PathResolver>(
     resolver: &R,
     file_path: &str,
     offset: usize,
     limit: usize,
     max_line_length: usize,
+    line_numbers: bool,
 ) -> ToolResult<ToolOutput> {
     // Conditional trait import for consume() method
     #[cfg(feature = "blocking")]
@@ -99,12 +101,13 @@ pub async fn read_file<R: PathResolver, const LINE_NUMBERS: bool>(
             if !overflow.is_empty() {
                 line_number += 1;
                 if line_number >= offset && lines_output < limit {
-                    process_line::<LINE_NUMBERS>(
+                    process_line(
                         &overflow,
                         line_number,
                         &mut output,
                         &mut lines_output,
                         max_line_length,
+                        line_numbers,
                     );
                 }
             }
@@ -122,22 +125,24 @@ pub async fn read_file<R: PathResolver, const LINE_NUMBERS: bool>(
                 if line_number >= offset && lines_output < limit {
                     if overflow.is_empty() {
                         // Fast path: line is fully in this buffer.
-                        process_line::<LINE_NUMBERS>(
+                        process_line(
                             &buf[pos..newline_pos],
                             line_number,
                             &mut output,
                             &mut lines_output,
                             max_line_length,
+                            line_numbers,
                         );
                     } else {
                         // Slow path: prepend buffered fragment.
                         overflow.extend_from_slice(&buf[pos..newline_pos]);
-                        process_line::<LINE_NUMBERS>(
+                        process_line(
                             &overflow,
                             line_number,
                             &mut output,
                             &mut lines_output,
                             max_line_length,
+                            line_numbers,
                         );
                         overflow.clear();
                     }
@@ -181,27 +186,29 @@ mod tests {
     use tempfile::NamedTempFile;
 
     #[maybe_async::maybe_async]
-    async fn read_temp_file<const LINE_NUMBERS: bool>(
+    async fn read_temp_file(
         content: &[u8],
         offset: usize,
         limit: usize,
+        line_numbers: bool,
     ) -> ToolResult<ToolOutput> {
         let mut temp = NamedTempFile::new().unwrap();
         temp.write_all(content).unwrap();
         let resolver = AbsolutePathResolver;
-        read_file::<_, LINE_NUMBERS>(
+        read_file::<_>(
             &resolver,
             temp.path().to_str().unwrap(),
             offset,
             limit,
             2000, // max_line_length
+            line_numbers,
         )
         .await
     }
 
     #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]
     async fn reads_basic_file_with_line_numbers() {
-        let result = read_temp_file::<true>(b"hello\nworld\n", 1, 2000)
+        let result = read_temp_file(b"hello\nworld\n", 1, 2000, true)
             .await
             .unwrap();
         assert_eq!(result.content, "L1: hello\nL2: world");
@@ -209,7 +216,7 @@ mod tests {
 
     #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]
     async fn reads_basic_file_without_line_numbers() {
-        let result = read_temp_file::<false>(b"hello\nworld\n", 1, 2000)
+        let result = read_temp_file(b"hello\nworld\n", 1, 2000, false)
             .await
             .unwrap();
         assert_eq!(result.content, "hello\nworld");
@@ -217,7 +224,7 @@ mod tests {
 
     #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]
     async fn errors_on_offset_zero() {
-        let err = read_temp_file::<true>(b"test\n", 0, 10).await.unwrap_err();
+        let err = read_temp_file(b"test\n", 0, 10, true).await.unwrap_err();
         assert!(matches!(err, ToolError::OutOfBounds(_)));
     }
 
@@ -227,12 +234,13 @@ mod tests {
         temp.write_all(b"test\n").unwrap();
         let resolver = AbsolutePathResolver;
 
-        let err = read_file::<_, true>(
+        let err = read_file::<_>(
             &resolver,
             temp.path().to_str().unwrap(),
             1,
             10,
             3, // below MIN_LINE_LENGTH of 4
+            true,
         )
         .await
         .unwrap_err();
@@ -247,12 +255,13 @@ mod tests {
         temp.write_all(b"abcdefghij\n").unwrap();
         let resolver = AbsolutePathResolver;
 
-        let result = read_file::<_, false>(
+        let result = read_file::<_>(
             &resolver,
             temp.path().to_str().unwrap(),
             1,
             10,
             6, // keep 3 chars + "..."
+            false,
         )
         .await
         .unwrap();

--- a/src/llm-coding-tools-serdesai/README.md
+++ b/src/llm-coding-tools-serdesai/README.md
@@ -30,9 +30,9 @@ let mut pb = SystemPromptBuilder::new();
 
 // Build agent with tools - call .system_prompt() last
 let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
-    .tool(pb.track(ReadTool::<true>::new()))
+    .tool(pb.track(ReadTool::new()))
     .tool(pb.track(GlobTool::new()))
-    .tool(pb.track(GrepTool::<true>::new()))
+    .tool(pb.track(GrepTool::new()))
     .tool(pb.track(EditTool::new()))
     .tool(pb.track(BashTool::host()))
     .tool(pb.track(WebFetchTool::new()))
@@ -69,12 +69,12 @@ use llm_coding_tools_serdesai::AllowedPathResolver;
 use std::path::PathBuf;
 
 // Unrestricted access
-let read = ReadTool::<true>::new();
+let read = ReadTool::new();
 
 // Sandboxed access
 let allowed_paths = vec![PathBuf::from("/home/user/project"), PathBuf::from("/tmp")];
 let resolver = AllowedPathResolver::new(allowed_paths).unwrap();
-let sandboxed_read: AllowedReadTool<true> = AllowedReadTool::new(resolver.clone());
+let sandboxed_read: AllowedReadTool = AllowedReadTool::new(resolver.clone());
 let sandboxed_edit = AllowedEditTool::new(resolver.clone());
 let sandboxed_write = AllowedWriteTool::new(resolver);
 ```

--- a/src/llm-coding-tools-serdesai/examples/serdesai-basic.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-basic.rs
@@ -44,9 +44,9 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let agent = AgentBuilder::<(), String>::new(model)
         .instructions("Use tools to answer; call at least one tool before responding.")
         // File operations
-        .tool(pb.track(ReadTool::<true>::new()))
+        .tool(pb.track(ReadTool::new()))
         .tool(pb.track(GlobTool::new()))
-        .tool(pb.track(GrepTool::<true>::new()))
+        .tool(pb.track(GrepTool::new()))
         // Shell execution
         .tool(pb.track(BashTool::host()))
         // Web content fetching

--- a/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-sandboxed.rs
@@ -45,11 +45,11 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // More efficient and ensures consistency.
     let resolver = AllowedPathResolver::new(allowed_paths)?;
 
-    let read: ReadTool<true> = ReadTool::new(resolver.clone());
+    let read: ReadTool = ReadTool::new(resolver.clone());
     let write = WriteTool::new(resolver.clone());
     let edit = EditTool::new(resolver.clone());
     let glob = GlobTool::new(resolver.clone());
-    let grep: GrepTool<true> = GrepTool::new(resolver.clone());
+    let grep = GrepTool::new(resolver.clone());
 
     // === Build agent with sandboxed tools ===
     //

--- a/src/llm-coding-tools-serdesai/src/absolute/grep.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/grep.rs
@@ -29,29 +29,31 @@ struct GrepArgs {
 
 /// Tool for searching file contents using regex patterns.
 ///
-/// The `LINE_NUMBERS` const generic controls output format:
+/// The `line_numbers` field controls output format:
 /// - `true` (default): Lines prefixed with `L{number}: `
 /// - `false`: Raw matching lines
 #[derive(Debug, Clone)]
-pub struct GrepTool<const LINE_NUMBERS: bool = true> {
+pub struct GrepTool {
     definition: ToolDefinition,
     max_line_length: usize,
     limit: usize,
+    line_numbers: bool,
 }
 
-impl<const LINE_NUMBERS: bool> Default for GrepTool<LINE_NUMBERS> {
+impl Default for GrepTool {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<const LINE_NUMBERS: bool> GrepTool<LINE_NUMBERS> {
+impl GrepTool {
     /// Creates a new grep tool instance with default settings.
     ///
-    /// Uses `max_line_length` of 2000 characters and `limit` of 100 matches.
+    /// Uses `max_line_length` of 2000 characters, `limit` of 100 matches,
+    /// and enables line numbers.
     #[inline]
     pub fn new() -> Self {
-        Self::with_settings(DEFAULT_MAX_LINE_LENGTH, grep_meta::DEFAULT_LIMIT)
+        Self::with_settings(DEFAULT_MAX_LINE_LENGTH, grep_meta::DEFAULT_LIMIT, true)
     }
 
     /// Creates a new grep tool instance with custom settings.
@@ -61,17 +63,19 @@ impl<const LINE_NUMBERS: bool> GrepTool<LINE_NUMBERS> {
     /// * `max_line_length` - Maximum characters per matching line before truncation.
     ///   Longer lines will be truncated with "..." appended.
     /// * `limit` - Maximum number of matches to return when not specified in args.
-    pub fn with_settings(max_line_length: usize, limit: usize) -> Self {
+    /// * `line_numbers` - Whether to prefix lines with line numbers.
+    pub fn with_settings(max_line_length: usize, limit: usize, line_numbers: bool) -> Self {
         Self {
-            definition: build_definition::<LINE_NUMBERS>(),
+            definition: build_definition(line_numbers),
             max_line_length,
             limit,
+            line_numbers,
         }
     }
 }
 
 #[async_trait]
-impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_NUMBERS> {
+impl<Deps: Send + Sync> Tool<Deps> for GrepTool {
     fn definition(&self) -> ToolDefinition {
         self.definition.clone()
     }
@@ -112,8 +116,9 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
 
         match result {
             Err(e) => to_serdes_result(grep_meta::NAME, Err(e)),
-            Ok(grep_output) => Ok(grep_output_to_return::<LINE_NUMBERS>(
+            Ok(grep_output) => Ok(grep_output_to_return(
                 grep_output,
+                self.line_numbers,
                 limit,
                 self.max_line_length,
             )),
@@ -121,18 +126,18 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
     }
 }
 
-impl<const LINE_NUMBERS: bool> ToolContext for GrepTool<LINE_NUMBERS> {
+impl ToolContext for GrepTool {
     const NAME: &'static str = grep_meta::NAME;
 
     fn context(&self) -> ToolPrompt {
         ToolPrompt::Grep {
             path_mode: PathMode::Absolute,
-            line_numbers: LINE_NUMBERS,
+            line_numbers: self.line_numbers,
         }
     }
 }
 
-fn build_definition<const LINE_NUMBERS: bool>() -> ToolDefinition {
+fn build_definition(line_numbers: bool) -> ToolDefinition {
     let schema = SchemaBuilder::new()
         .string(
             grep_meta::param::PATTERN.name,
@@ -161,7 +166,7 @@ fn build_definition<const LINE_NUMBERS: bool>() -> ToolDefinition {
 
     ToolDefinition {
         name: grep_meta::NAME.to_owned(),
-        description: grep_meta::description::absolute(LINE_NUMBERS).to_owned(),
+        description: grep_meta::description::absolute(line_numbers).to_owned(),
         parameters_json_schema: schema,
         strict: None,
         outer_typed_dict_key: None,
@@ -184,7 +189,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("test.txt"), "hello world\nfoo bar").unwrap();
 
-        let tool: GrepTool<true> = GrepTool::new();
+        let tool = GrepTool::new();
         let result = tool
             .call(
                 &mock_ctx(),
@@ -206,7 +211,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("test.txt"), "hello").unwrap();
 
-        let tool: GrepTool<true> = GrepTool::new();
+        let tool = GrepTool::new();
         let result = tool
             .call(
                 &mock_ctx(),
@@ -235,7 +240,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("test.txt"), "hello world").unwrap();
 
-        let tool: GrepTool<true> = GrepTool::new();
+        let tool = GrepTool::new();
         let result = tool
             .call(
                 &mock_ctx(),
@@ -258,7 +263,7 @@ mod tests {
         std::fs::write(dir.path().join("code.py"), "def hello(): pass").unwrap();
         std::fs::write(dir.path().join("readme.txt"), "hello world").unwrap();
 
-        let tool: GrepTool<true> = GrepTool::new();
+        let tool = GrepTool::new();
 
         // Search only .rs files
         let result = tool
@@ -284,7 +289,7 @@ mod tests {
     async fn returns_partial_json_when_search_has_errors() {
         let dir = TempDir::new().unwrap();
         let missing_path = dir.path().join("missing-root");
-        let tool: GrepTool<true> = GrepTool::new();
+        let tool = GrepTool::new();
 
         let result = tool
             .call(
@@ -315,7 +320,7 @@ mod tests {
         let long_line = format!("prefix_{}_suffix", "x".repeat(2500));
         std::fs::write(dir.path().join("long.txt"), &long_line).unwrap();
 
-        let tool: GrepTool<true> = GrepTool::new();
+        let tool = GrepTool::new();
         let result = tool
             .call(
                 &mock_ctx(),

--- a/src/llm-coding-tools-serdesai/src/absolute/read.rs
+++ b/src/llm-coding-tools-serdesai/src/absolute/read.rs
@@ -26,29 +26,31 @@ struct ReadArgs {
 
 /// Tool for reading file contents with optional line numbers.
 ///
-/// The `LINE_NUMBERS` const generic controls output format:
+/// The `line_numbers` field controls output format:
 /// - `true` (default): Lines prefixed with `L{number}: `
 /// - `false`: Raw file content
 #[derive(Debug, Clone)]
-pub struct ReadTool<const LINE_NUMBERS: bool = true> {
+pub struct ReadTool {
     definition: ToolDefinition,
     limit: usize,
     max_line_length: usize,
+    line_numbers: bool,
 }
 
-impl<const LINE_NUMBERS: bool> Default for ReadTool<LINE_NUMBERS> {
+impl Default for ReadTool {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<const LINE_NUMBERS: bool> ReadTool<LINE_NUMBERS> {
+impl ReadTool {
     /// Creates a new read tool instance with default settings.
     ///
-    /// Uses `limit` of 2000 lines and `max_line_length` of 2000 characters.
+    /// Uses `limit` of 2000 lines, `max_line_length` of 2000 characters,
+    /// and enables line numbers.
     #[inline]
     pub fn new() -> Self {
-        Self::with_settings(read_meta::DEFAULT_LIMIT, read_meta::MAX_LINE_LENGTH)
+        Self::with_settings(read_meta::DEFAULT_LIMIT, read_meta::MAX_LINE_LENGTH, true)
     }
 
     /// Creates a new read tool instance with custom settings.
@@ -59,17 +61,19 @@ impl<const LINE_NUMBERS: bool> ReadTool<LINE_NUMBERS> {
     ///   This is the default used when the LLM doesn't specify a limit.
     /// * `max_line_length` - Maximum characters per line before truncation.
     ///   Longer lines will be truncated with "..." appended.
-    pub fn with_settings(limit: usize, max_line_length: usize) -> Self {
+    /// * `line_numbers` - Whether to prefix lines with line numbers.
+    pub fn with_settings(limit: usize, max_line_length: usize, line_numbers: bool) -> Self {
         Self {
-            definition: build_definition::<LINE_NUMBERS>(),
+            definition: build_definition(line_numbers),
             limit,
             max_line_length,
+            line_numbers,
         }
     }
 }
 
 #[async_trait]
-impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for ReadTool<LINE_NUMBERS> {
+impl<Deps: Send + Sync> Tool<Deps> for ReadTool {
     fn definition(&self) -> ToolDefinition {
         self.definition.clone()
     }
@@ -82,30 +86,31 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for ReadTool<LINE_N
         // Use provided limit or fall back to settings default
         let effective_limit = args.limit.unwrap_or(self.limit);
         // Core uses 1-indexed offset directly; args.offset defaults to 1
-        let result = read_file::<_, LINE_NUMBERS>(
+        let result = read_file::<_>(
             &resolver,
             &args.file_path,
             args.offset,
             effective_limit,
             self.max_line_length,
+            self.line_numbers,
         )
         .await;
         to_serdes_result(read_meta::NAME, result)
     }
 }
 
-impl<const LINE_NUMBERS: bool> ToolContext for ReadTool<LINE_NUMBERS> {
+impl ToolContext for ReadTool {
     const NAME: &'static str = read_meta::NAME;
 
     fn context(&self) -> ToolPrompt {
         ToolPrompt::Read {
             path_mode: PathMode::Absolute,
-            line_numbers: LINE_NUMBERS,
+            line_numbers: self.line_numbers,
         }
     }
 }
 
-fn build_definition<const LINE_NUMBERS: bool>() -> ToolDefinition {
+fn build_definition(line_numbers: bool) -> ToolDefinition {
     let schema = SchemaBuilder::new()
         .string(
             read_meta::param::FILE_PATH_ABSOLUTE.name,
@@ -131,7 +136,7 @@ fn build_definition<const LINE_NUMBERS: bool>() -> ToolDefinition {
 
     ToolDefinition {
         name: read_meta::NAME.to_owned(),
-        description: read_meta::description::absolute(LINE_NUMBERS).to_owned(),
+        description: read_meta::description::absolute(line_numbers).to_owned(),
         parameters_json_schema: schema,
         strict: None,
         outer_typed_dict_key: None,
@@ -154,7 +159,7 @@ mod tests {
     async fn reads_file_with_offset_and_limit() {
         let mut temp = NamedTempFile::new().unwrap();
         temp.write_all(b"line1\nline2\nline3\nline4\n").unwrap();
-        let tool: ReadTool<true> = ReadTool::new();
+        let tool: ReadTool = ReadTool::new();
 
         let result = tool
             .call(

--- a/src/llm-coding-tools-serdesai/src/agent_ext.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_ext.rs
@@ -12,7 +12,7 @@
 //!
 //! # fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 //! let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
-//!     .tool(ReadTool::<true>::new())
+//!     .tool(ReadTool::new())
 //!     .tool(GlobTool::new())
 //!     .system_prompt("You are helpful.")
 //!     .build();
@@ -65,7 +65,7 @@ pub trait AgentBuilderExt<Deps, Output> {
     ///
     /// # fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     /// let agent = AgentBuilder::<(), String>::from_model("openai:gpt-4o")?
-    ///     .tool(ReadTool::<true>::new())
+    ///     .tool(ReadTool::new())
     ///     .tool(GlobTool::new())
     ///     .build();
     /// # Ok(())

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
@@ -122,17 +122,11 @@ where
         match entry.kind {
             ToolCatalogKind::Read => {
                 let settings = &prepared.tool_settings.read;
-                if settings.line_numbers {
-                    builder = builder.tool(prompt_builder.track(ReadTool::<true>::with_settings(
-                        settings.limit,
-                        settings.max_line_length,
-                    )));
-                } else {
-                    builder = builder.tool(prompt_builder.track(ReadTool::<false>::with_settings(
-                        settings.limit,
-                        settings.max_line_length,
-                    )));
-                }
+                builder = builder.tool(prompt_builder.track(ReadTool::with_settings(
+                    settings.limit,
+                    settings.max_line_length,
+                    settings.line_numbers,
+                )));
             }
             ToolCatalogKind::Write => {
                 builder = builder.tool(prompt_builder.track(WriteTool::new()))
@@ -145,17 +139,11 @@ where
             }
             ToolCatalogKind::Grep => {
                 let settings = &prepared.tool_settings.grep;
-                if settings.line_numbers {
-                    builder = builder.tool(prompt_builder.track(GrepTool::<true>::with_settings(
-                        settings.max_line_length,
-                        settings.limit,
-                    )));
-                } else {
-                    builder = builder.tool(prompt_builder.track(GrepTool::<false>::with_settings(
-                        settings.max_line_length,
-                        settings.limit,
-                    )));
-                }
+                builder = builder.tool(prompt_builder.track(GrepTool::with_settings(
+                    settings.max_line_length,
+                    settings.limit,
+                    settings.line_numbers,
+                )));
             }
             ToolCatalogKind::Bash => {
                 let settings = &prepared.tool_settings.bash;

--- a/src/llm-coding-tools-serdesai/src/allowed/grep.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/grep.rs
@@ -29,23 +29,30 @@ struct GrepArgs {
 
 /// Tool for searching file contents within allowed directories.
 #[derive(Debug, Clone)]
-pub struct GrepTool<const LINE_NUMBERS: bool = true> {
+pub struct GrepTool {
     definition: ToolDefinition,
     resolver: AllowedPathResolver,
     max_line_length: usize,
     limit: usize,
+    line_numbers: bool,
 }
 
-impl<const LINE_NUMBERS: bool> GrepTool<LINE_NUMBERS> {
+impl GrepTool {
     /// Creates a new grep tool with a shared resolver and default settings.
     ///
-    /// Uses `max_line_length` of 2000 characters and `limit` of 100 matches.
+    /// Uses `max_line_length` of 2000 characters, `limit` of 100 matches,
+    /// and enables line numbers.
     ///
     /// See [`ReadTool::new`] for usage example.
     ///
     /// [`ReadTool::new`]: super::ReadTool::new
     pub fn new(resolver: AllowedPathResolver) -> Self {
-        Self::with_settings(resolver, DEFAULT_MAX_LINE_LENGTH, grep_meta::DEFAULT_LIMIT)
+        Self::with_settings(
+            resolver,
+            DEFAULT_MAX_LINE_LENGTH,
+            grep_meta::DEFAULT_LIMIT,
+            true,
+        )
     }
 
     /// Creates a new grep tool with custom settings.
@@ -56,22 +63,25 @@ impl<const LINE_NUMBERS: bool> GrepTool<LINE_NUMBERS> {
     /// * `max_line_length` - Maximum characters per matching line before truncation.
     ///   Longer lines will be truncated with "..." appended.
     /// * `limit` - Maximum number of matches to return when not specified in args.
+    /// * `line_numbers` - Whether to prefix lines with line numbers.
     pub fn with_settings(
         resolver: AllowedPathResolver,
         max_line_length: usize,
         limit: usize,
+        line_numbers: bool,
     ) -> Self {
         Self {
-            definition: build_definition::<LINE_NUMBERS>(),
+            definition: build_definition(line_numbers),
             resolver,
             max_line_length,
             limit,
+            line_numbers,
         }
     }
 }
 
 #[async_trait]
-impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_NUMBERS> {
+impl<Deps: Send + Sync> Tool<Deps> for GrepTool {
     fn definition(&self) -> ToolDefinition {
         self.definition.clone()
     }
@@ -111,8 +121,9 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
 
         match result {
             Err(e) => to_serdes_result(grep_meta::NAME, Err(e)),
-            Ok(grep_output) => Ok(grep_output_to_return::<LINE_NUMBERS>(
+            Ok(grep_output) => Ok(grep_output_to_return(
                 grep_output,
+                self.line_numbers,
                 limit,
                 self.max_line_length,
             )),
@@ -120,18 +131,18 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for GrepTool<LINE_N
     }
 }
 
-impl<const LINE_NUMBERS: bool> ToolContext for GrepTool<LINE_NUMBERS> {
+impl ToolContext for GrepTool {
     const NAME: &'static str = grep_meta::NAME;
 
     fn context(&self) -> ToolPrompt {
         ToolPrompt::Grep {
             path_mode: PathMode::Allowed,
-            line_numbers: LINE_NUMBERS,
+            line_numbers: self.line_numbers,
         }
     }
 }
 
-fn build_definition<const LINE_NUMBERS: bool>() -> ToolDefinition {
+fn build_definition(line_numbers: bool) -> ToolDefinition {
     let schema = SchemaBuilder::new()
         .string(
             grep_meta::param::PATTERN.name,
@@ -160,7 +171,7 @@ fn build_definition<const LINE_NUMBERS: bool>() -> ToolDefinition {
 
     ToolDefinition {
         name: grep_meta::NAME.to_owned(),
-        description: grep_meta::description::allowed(LINE_NUMBERS).to_owned(),
+        description: grep_meta::description::allowed(line_numbers).to_owned(),
         parameters_json_schema: schema,
         strict: None,
         outer_typed_dict_key: None,
@@ -184,7 +195,7 @@ mod tests {
         std::fs::write(dir.path().join("test.txt"), "hello world").unwrap();
 
         let resolver = AllowedPathResolver::new([dir.path()]).unwrap();
-        let tool: GrepTool<true> = GrepTool::new(resolver);
+        let tool = GrepTool::new(resolver);
         let result = tool
             .call(
                 &mock_ctx(),
@@ -205,7 +216,7 @@ mod tests {
     async fn rejects_path_traversal() {
         let dir = TempDir::new().unwrap();
         let resolver = AllowedPathResolver::new([dir.path()]).unwrap();
-        let tool: GrepTool<true> = GrepTool::new(resolver);
+        let tool = GrepTool::new(resolver);
         let result = tool
             .call(
                 &mock_ctx(),
@@ -223,7 +234,7 @@ mod tests {
     async fn rejects_empty_pattern() {
         let dir = TempDir::new().unwrap();
         let resolver = AllowedPathResolver::new([dir.path()]).unwrap();
-        let tool: GrepTool<true> = GrepTool::new(resolver);
+        let tool = GrepTool::new(resolver);
         let result = tool
             .call(
                 &mock_ctx(),
@@ -241,7 +252,7 @@ mod tests {
     async fn returns_partial_json_when_search_has_errors() {
         let dir = TempDir::new().unwrap();
         let resolver = AllowedPathResolver::new([dir.path()]).unwrap();
-        let tool: GrepTool<true> = GrepTool::new(resolver);
+        let tool = GrepTool::new(resolver);
         let result = tool
             .call(
                 &mock_ctx(),

--- a/src/llm-coding-tools-serdesai/src/allowed/read.rs
+++ b/src/llm-coding-tools-serdesai/src/allowed/read.rs
@@ -28,17 +28,19 @@ struct ReadArgs {
 ///
 /// Restricts access to configured allowed directories.
 #[derive(Debug, Clone)]
-pub struct ReadTool<const LINE_NUMBERS: bool = true> {
+pub struct ReadTool {
     definition: ToolDefinition,
     resolver: AllowedPathResolver,
     limit: usize,
     max_line_length: usize,
+    line_numbers: bool,
 }
 
-impl<const LINE_NUMBERS: bool> ReadTool<LINE_NUMBERS> {
+impl ReadTool {
     /// Creates a new read tool with a shared resolver and default settings.
     ///
-    /// Uses `limit` of 2000 lines and `max_line_length` of 2000 characters.
+    /// Uses `limit` of 2000 lines, `max_line_length` of 2000 characters,
+    /// and enables line numbers.
     ///
     /// See [`ReadTool::new`] for usage example.
     ///
@@ -48,6 +50,7 @@ impl<const LINE_NUMBERS: bool> ReadTool<LINE_NUMBERS> {
             resolver,
             read_meta::DEFAULT_LIMIT,
             read_meta::MAX_LINE_LENGTH,
+            true,
         )
     }
 
@@ -60,22 +63,25 @@ impl<const LINE_NUMBERS: bool> ReadTool<LINE_NUMBERS> {
     ///   This is the default used when the LLM doesn't specify a limit.
     /// * `max_line_length` - Maximum characters per line before truncation.
     ///   Longer lines will be truncated with "..." appended.
+    /// * `line_numbers` - Whether to prefix lines with line numbers.
     pub fn with_settings(
         resolver: AllowedPathResolver,
         limit: usize,
         max_line_length: usize,
+        line_numbers: bool,
     ) -> Self {
         Self {
-            definition: build_definition::<LINE_NUMBERS>(),
+            definition: build_definition(line_numbers),
             resolver,
             limit,
             max_line_length,
+            line_numbers,
         }
     }
 }
 
 #[async_trait]
-impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for ReadTool<LINE_NUMBERS> {
+impl<Deps: Send + Sync> Tool<Deps> for ReadTool {
     fn definition(&self) -> ToolDefinition {
         self.definition.clone()
     }
@@ -86,30 +92,31 @@ impl<Deps: Send + Sync, const LINE_NUMBERS: bool> Tool<Deps> for ReadTool<LINE_N
 
         // Use provided limit or fall back to settings default
         let effective_limit = args.limit.unwrap_or(self.limit);
-        let result = read_file::<_, LINE_NUMBERS>(
+        let result = read_file::<_>(
             &self.resolver,
             &args.file_path,
             args.offset,
             effective_limit,
             self.max_line_length,
+            self.line_numbers,
         )
         .await;
         to_serdes_result(read_meta::NAME, result)
     }
 }
 
-impl<const LINE_NUMBERS: bool> ToolContext for ReadTool<LINE_NUMBERS> {
+impl ToolContext for ReadTool {
     const NAME: &'static str = read_meta::NAME;
 
     fn context(&self) -> ToolPrompt {
         ToolPrompt::Read {
             path_mode: PathMode::Allowed,
-            line_numbers: LINE_NUMBERS,
+            line_numbers: self.line_numbers,
         }
     }
 }
 
-fn build_definition<const LINE_NUMBERS: bool>() -> ToolDefinition {
+fn build_definition(line_numbers: bool) -> ToolDefinition {
     let schema = SchemaBuilder::new()
         .string(
             read_meta::param::FILE_PATH_ALLOWED.name,
@@ -135,7 +142,7 @@ fn build_definition<const LINE_NUMBERS: bool>() -> ToolDefinition {
 
     ToolDefinition {
         name: read_meta::NAME.to_owned(),
-        description: read_meta::description::allowed(LINE_NUMBERS).to_owned(),
+        description: read_meta::description::allowed(line_numbers).to_owned(),
         parameters_json_schema: schema,
         strict: None,
         outer_typed_dict_key: None,
@@ -159,7 +166,7 @@ mod tests {
         std::fs::write(dir.path().join("test.txt"), "hello\nworld\n").unwrap();
 
         let resolver = AllowedPathResolver::new([dir.path()]).unwrap();
-        let tool: ReadTool<true> = ReadTool::new(resolver);
+        let tool: ReadTool = ReadTool::new(resolver);
         let result = tool
             .call(
                 &mock_ctx(),
@@ -181,7 +188,7 @@ mod tests {
     async fn rejects_path_traversal() {
         let dir = TempDir::new().unwrap();
         let resolver = AllowedPathResolver::new([dir.path()]).unwrap();
-        let tool: ReadTool<true> = ReadTool::new(resolver);
+        let tool: ReadTool = ReadTool::new(resolver);
         let result = tool
             .call(
                 &mock_ctx(),

--- a/src/llm-coding-tools-serdesai/src/common/grep.rs
+++ b/src/llm-coding-tools-serdesai/src/common/grep.rs
@@ -7,13 +7,14 @@ use serdes_ai::tools::ToolReturn;
 const NO_MATCHES_FOUND: &str = "No matches found.";
 
 #[inline]
-pub(crate) fn output_to_return<const LINE_NUMBERS: bool>(
+pub(crate) fn output_to_return(
     output: GrepOutput,
+    line_numbers: bool,
     limit: usize,
     max_line_len: usize,
 ) -> ToolReturn {
     if output.partial {
-        let content = output.format::<LINE_NUMBERS>(limit, max_line_len);
+        let content = output.format(line_numbers, limit, max_line_len);
         return ToolReturn::json(json!({
             "content": content,
             "partial": true,
@@ -27,5 +28,5 @@ pub(crate) fn output_to_return<const LINE_NUMBERS: bool>(
         return ToolReturn::text(NO_MATCHES_FOUND);
     }
 
-    ToolReturn::text(output.format::<LINE_NUMBERS>(limit, max_line_len))
+    ToolReturn::text(output.format(line_numbers, limit, max_line_len))
 }


### PR DESCRIPTION
## Summary

Replaced `const LINE_NUMBERS: bool` const generics with runtime `line_numbers: bool` fields in `ReadTool` and `GrepTool`.

## Motivation

The const generic approach (`<const LINE_NUMBERS: bool>`) caused monomorphisation bloat - each tool was compiled twice (once for `true`, once for `false`). 

Originally, this was intended behaviour, as I have not added `agents` support yet; so resolving the branches at compile time was faster.

However, with agents, it will become increasingly common to have both configurations that use line numbers and don't use line numbers side by side.

When both cases were instantiated, it meant:
- ~35% larger code size for the hot path functions
- Duplicate instruction cache entries
- No actual runtime performance benefit

## Changes

- `GrepOutput::format()` - now takes `line_numbers: bool` parameter
- `read_file()` and `process_line()` - now use runtime `bool` parameter  
- `ReadTool` and `GrepTool` structs - added `line_numbers: bool` field, removed const generic
- Both `absolute` and `allowed` variants updated
- `agent_runtime/build.rs` - simplified tool construction (no more conditional branches)
- Updated README, examples, tests, and doc comments

## Binary Size Impact

| Function | Before (generics) | After (runtime bool) |
|----------|-----------------|---------------------|
| `grep::format` | ~1224 bytes | ~1269 bytes |
| `read::read_file` | ~3360 bytes | ~1720 bytes |

The read function sees the biggest win since it no longer has two monomorphised copies.

## API Changes

**Before:**
```rust
let tool: ReadTool<true> = ReadTool::new();  // type annotation required
let tool = ReadTool::<false>::new();         // turbofish needed
```

**After:**
```rust
let tool = ReadTool::new();                  // defaults to line_numbers: true
let tool = ReadTool::with_settings(2000, 2000, false);  // explicit control
```

This is a breaking change for consumers using turbofish syntax.