### PR TITLE
Refactor Core Settings with Explicit Constructors and Grouped Setters

### DIFF
--- a/src/llm-coding-tools-agents/README.md
+++ b/src/llm-coding-tools-agents/README.md
@@ -136,7 +136,7 @@ tool_settings:
   webfetch:
     timeout_ms: 30000           # default: 30000 (30 seconds)
     max_timeout_ms: 600000      # default: 600000 (10 minutes)
-    max_response_size_mib: 5    # default: 5
+    max_response_size: 5242880  # default: 5242880 (5 MiB in bytes)
 ```
 
 **Setting reference:**
@@ -154,7 +154,7 @@ tool_settings:
 | bash     | `max_timeout_ms`        | usize | `600000` | *    | Maximum timeout LLM can request (must be >= timeout_ms) |
 | webfetch | `timeout_ms`            | usize | `30000`  | 1000 | Fetch timeout in milliseconds                           |
 | webfetch | `max_timeout_ms`        | usize | `600000` | *    | Maximum timeout LLM can request (must be >= timeout_ms) |
-| webfetch | `max_response_size_mib` | usize | `5`      | 1    | Max response body size in MiB                           |
+| webfetch | `max_response_size`     | usize | `5242880`| 1    | Max response body size in bytes                         |
 
 **Output format:**
 
@@ -207,8 +207,8 @@ fn main() {
 - **`webfetch.max_timeout_ms`** - Maximum timeout the LLM is allowed to request via the
   `timeout_ms` parameter. Must be greater than or equal to `timeout_ms`.
 
-- **`webfetch.max_response_size_mib`** - Maximum response body size in mebibytes.
-  Responses larger than this are rejected.
+- **`webfetch.max_response_size`** - Maximum response body size in bytes.
+  Responses larger than this are rejected. Default is 5242880 bytes (5 MiB).
 
 ## Building agents
 

--- a/src/llm-coding-tools-agents/src/lib.rs
+++ b/src/llm-coding-tools-agents/src/lib.rs
@@ -18,5 +18,6 @@ pub use runtime::{
 };
 pub use types::{
     parse_model_parts, AgentConfig, AgentLoadError, AgentLoadResult, AgentMode, AgentToolSettings,
-    GrepToolSettings, PermissionRule, ReadToolSettings,
+    BashToolSettings, GlobToolSettings, GrepToolSettings, PermissionRule, ReadToolSettings,
+    WebFetchToolSettings,
 };

--- a/src/llm-coding-tools-agents/src/types/mod.rs
+++ b/src/llm-coding-tools-agents/src/types/mod.rs
@@ -5,7 +5,8 @@
 //! ## Re-exports
 //! - Config types: [`AgentConfig`], [`AgentMode`], [`PermissionRule`], [`parse_model_parts`]
 //! - Load errors: [`AgentLoadError`], [`AgentLoadResult`]
-//! - Tool settings: [`AgentToolSettings`], [`ReadToolSettings`], [`GrepToolSettings`]
+//! - Tool settings: [`AgentToolSettings`], [`ReadToolSettings`], [`GrepToolSettings`],
+//!   [`GlobToolSettings`], [`BashToolSettings`], [`WebFetchToolSettings`]
 
 mod config;
 mod error;
@@ -13,6 +14,9 @@ mod tool_settings;
 
 pub use config::{parse_model_parts, AgentConfig, AgentMode, PermissionRule};
 pub use error::{AgentLoadError, AgentLoadResult};
-pub use tool_settings::{AgentToolSettings, GrepToolSettings, ReadToolSettings};
+pub use tool_settings::{
+    AgentToolSettings, BashToolSettings, GlobToolSettings, GrepToolSettings, ReadToolSettings,
+    WebFetchToolSettings,
+};
 
 pub(crate) use config::RawFrontmatter;

--- a/src/llm-coding-tools-agents/src/types/tool_settings.rs
+++ b/src/llm-coding-tools-agents/src/types/tool_settings.rs
@@ -10,22 +10,22 @@
 //! name: example-agent
 //! tool_settings:
 //!   read:
-//!     line_numbers: true        # default: true
-//!     limit: 2000               # default: 2000 (tool_metadata::read::DEFAULT_LIMIT)
-//!     max_line_length: 2000     # default: 2000 (tool_metadata::read::MAX_LINE_LENGTH)
+//!     line_numbers: true         # default: true
+//!     limit: 2000                # default: 2000 (tool_metadata::read::DEFAULT_LIMIT)
+//!     max_line_length: 2000      # default: 2000 (tool_metadata::read::MAX_LINE_LENGTH)
 //!   grep:
-//!     line_numbers: true        # default: true
-//!     limit: 100                # default: 100 (tool_metadata::grep::DEFAULT_LIMIT)
-//!     max_line_length: 2000     # default: 2000 (tool_metadata::tools::DEFAULT_MAX_LINE_LENGTH)
+//!     line_numbers: true         # default: true
+//!     limit: 100                 # default: 100 (tool_metadata::grep::DEFAULT_LIMIT)
+//!     max_line_length: 2000      # default: 2000 (tool_metadata::tools::DEFAULT_MAX_LINE_LENGTH)
 //!   glob:
-//!     limit: 1000               # default: 1000 (tool_metadata::glob::MAX_RESULTS)
+//!     limit: 1000                # default: 1000 (tool_metadata::glob::MAX_RESULTS)
 //!   bash:
-//!     timeout_ms: 120000        # default: 120000ms (tool_metadata::bash::DEFAULT_TIMEOUT_MS)
-//!     max_timeout_ms: 600000    # default: 600000ms (tool_metadata::bash::MAX_TIMEOUT_MS)
+//!     timeout_ms: 120000         # default: 120000ms (tool_metadata::bash::DEFAULT_TIMEOUT_MS)
+//!     max_timeout_ms: 600000     # default: 600000ms (tool_metadata::bash::MAX_TIMEOUT_MS)
 //!   webfetch:
-//!     timeout_ms: 30000         # default: 30000ms (tool_metadata::webfetch::DEFAULT_TIMEOUT_MS)
-//!     max_timeout_ms: 600000    # default: 600000ms (tool_metadata::webfetch::MAX_TIMEOUT_MS)
-//!     max_response_size_mib: 5  # default: 5 MiB (tool_metadata::webfetch::MAX_RESPONSE_SIZE_MIB)
+//!     timeout_ms: 30000          # default: 30000ms (tool_metadata::webfetch::DEFAULT_TIMEOUT_MS)
+//!     max_timeout_ms: 600000     # default: 600000ms (tool_metadata::webfetch::MAX_TIMEOUT_MS)
+//!     max_response_size: 5242880 # default: 5242880 bytes (5 MiB) (tool_metadata::webfetch::MAX_RESPONSE_SIZE)
 //! ---
 //! ```
 
@@ -179,12 +179,12 @@ pub struct WebFetchToolSettings {
         deserialize_with = "deserialize_min_max_timeout_ms"
     )]
     pub max_timeout_ms: u32,
-    /// Maximum response size in MiB (default: 5, min: 1).
+    /// Maximum response size in bytes (default: 5242880 = 5 MiB, min: 1).
     #[serde(
-        default = "webfetch_default_max_response_size_mib",
+        default = "webfetch_default_max_response_size",
         deserialize_with = "deserialize_min_limit"
     )]
-    pub max_response_size_mib: usize,
+    pub max_response_size: usize,
 }
 
 impl Default for WebFetchToolSettings {
@@ -192,7 +192,7 @@ impl Default for WebFetchToolSettings {
         Self {
             timeout_ms: webfetch_default_timeout_ms(),
             max_timeout_ms: webfetch_default_max_timeout_ms(),
-            max_response_size_mib: webfetch_default_max_response_size_mib(),
+            max_response_size: webfetch_default_max_response_size(),
         }
     }
 }
@@ -249,8 +249,8 @@ const fn webfetch_default_max_timeout_ms() -> u32 {
 }
 
 #[inline]
-const fn webfetch_default_max_response_size_mib() -> usize {
-    webfetch::MAX_RESPONSE_SIZE_MIB
+const fn webfetch_default_max_response_size() -> usize {
+    webfetch::MAX_RESPONSE_SIZE
 }
 
 fn deserialize_read_max_line_length<'de, D>(deserializer: D) -> Result<usize, D::Error>
@@ -342,16 +342,12 @@ where
 }
 
 impl AgentToolSettings {
-    /// Validates cross-field constraints (e.g., timeout_ms <= max_timeout_ms).
+    /// Validates cross-field constraints for bash timeout pair.
+    /// Note: read/glob/grep/webfetch validation now happens during agent build
+    /// when these values are converted into Core settings.
     #[inline]
     fn validate(&self) -> Result<(), String> {
-        validate_timeout_pair("bash", self.bash.timeout_ms, self.bash.max_timeout_ms)?;
-        validate_timeout_pair(
-            "webfetch",
-            self.webfetch.timeout_ms,
-            self.webfetch.max_timeout_ms,
-        )?;
-        Ok(())
+        validate_timeout_pair("bash", self.bash.timeout_ms, self.bash.max_timeout_ms)
     }
 }
 

--- a/src/llm-coding-tools-agents/src/types/tool_settings.rs
+++ b/src/llm-coding-tools-agents/src/types/tool_settings.rs
@@ -28,6 +28,13 @@
 //!     max_response_size: 5242880 # default: 5242880 bytes (5 MiB) (tool_metadata::webfetch::MAX_RESPONSE_SIZE)
 //! ---
 //! ```
+//!
+//! Implementation Note:
+//!
+//! We validate settings during deserialization even though `core` already
+//! validates when creating tools. The `core` check is just-in-time, during
+//! final agent build, so configuration errors (e.g. in a subagent) would only
+//! surface at runtime. Validating here catches these issues at startup instead.
 
 use llm_coding_tools_core::tool_metadata::{bash, glob, grep, read, webfetch};
 use llm_coding_tools_core::util::{MIN_LIMIT, MIN_LINE_LENGTH, MIN_TIMEOUT_MS};

--- a/src/llm-coding-tools-core/src/context/tool_prompt/tool_sections.rs
+++ b/src/llm-coding-tools-core/src/context/tool_prompt/tool_sections.rs
@@ -185,9 +185,9 @@ fn write_webfetch_section(output: &mut String) {
         output,
         formatcp!(
             "- Output starts with `[content-type - bytes]`.\n\
-            - Maximum response size is `{}` MiB.\n\
+            - Maximum response size is `{}` bytes.\n\
             - Use this for known URLs, not web search. Prefer a more specialized web tool when one exists.\n",
-            webfetch::MAX_RESPONSE_SIZE_MIB,
+            webfetch::MAX_RESPONSE_SIZE,
         ),
     );
 }

--- a/src/llm-coding-tools-core/src/lib.rs
+++ b/src/llm-coding-tools-core/src/lib.rs
@@ -33,10 +33,10 @@ pub use system_prompt::SystemPromptBuilder;
 pub use tools::{
     edit_file, execute_command, execute_command_with_mode, glob_files, grep_search, read_file,
     read_todos, write_file, write_todos, BashExecutionMode, BashOutput, BashRequest, BashSettings,
-    EditError, EditRequest, GlobOutput, GlobRequest, GlobSettings, GrepFileMatches, GrepLineMatch,
-    GrepOutput, GrepRequest, GrepSettings, ReadRequest, ReadSettings, TaskInput, TaskOutput,
-    TaskSettings, Todo, TodoPriority, TodoReadRequest, TodoState, TodoStatus, TodoWriteRequest,
-    WriteRequest,
+    EditError, EditRequest, GlobOutput, GlobRequest, GlobSettings, GrepFileMatches,
+    GrepFormattingSettings, GrepLineMatch, GrepOutput, GrepRequest, GrepSettings, ReadRequest,
+    ReadSettings, TaskInput, TaskOutput, TaskSettings, Todo, TodoPriority, TodoReadRequest,
+    TodoState, TodoStatus, TodoWriteRequest, WriteRequest,
 };
 
 // Re-export Linux sandbox types (Linux-only, requires linux-bubblewrap feature)

--- a/src/llm-coding-tools-core/src/tool_metadata/webfetch.rs
+++ b/src/llm-coding-tools-core/src/tool_metadata/webfetch.rs
@@ -11,8 +11,8 @@ pub const DEFAULT_TIMEOUT_MS: u32 = 30_000;
 /// Maximum timeout in milliseconds.
 pub const MAX_TIMEOUT_MS: u32 = 600_000;
 
-/// Maximum response size in mebibytes (for display in prompts).
-pub const MAX_RESPONSE_SIZE_MIB: usize = 5;
+/// Maximum response size in bytes (5 MiB).
+pub const MAX_RESPONSE_SIZE: usize = 5 * 1024 * 1024;
 
 /// Tool description.
 pub const DESCRIPTION: &str =

--- a/src/llm-coding-tools-core/src/tools/glob.rs
+++ b/src/llm-coding-tools-core/src/tools/glob.rs
@@ -2,6 +2,7 @@
 
 use crate::error::{ToolError, ToolResult};
 use crate::path::PathResolver;
+use crate::tool_metadata::glob as glob_meta;
 use globset::Glob;
 use ignore::WalkBuilder;
 use serde::{Deserialize, Serialize};
@@ -23,10 +24,44 @@ impl GlobRequest {
 }
 
 /// Runtime settings applied to glob requests.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GlobSettings {
-    /// Maximum number of files to return.
-    pub limit: usize,
+    limit: usize,
+}
+
+impl Default for GlobSettings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GlobSettings {
+    /// Creates valid glob settings with the standard result limit.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            limit: glob_meta::MAX_RESULTS,
+        }
+    }
+
+    /// Updates the maximum number of files returned.
+    pub fn with_limit(mut self, limit: usize) -> ToolResult<Self> {
+        use crate::util::MIN_LIMIT;
+        if limit < MIN_LIMIT {
+            return Err(ToolError::validation_for(
+                "limit",
+                format!("limit must be >= {}", MIN_LIMIT),
+            ));
+        }
+        self.limit = limit;
+        Ok(self)
+    }
+
+    /// Returns the maximum number of files to return.
+    #[must_use]
+    pub const fn limit(self) -> usize {
+        self.limit
+    }
 }
 
 /// Output from glob file matching.
@@ -63,10 +98,7 @@ pub fn glob_files<R: PathResolver>(
         )));
     }
 
-    let limit = settings.limit;
-    if limit == 0 {
-        return Err(ToolError::validation_for("limit", "limit must be >= 1"));
-    }
+    let limit = settings.limit();
 
     let matcher = Glob::new(&request.pattern)?.compile_matcher();
 
@@ -172,6 +204,18 @@ mod tests {
         dir
     }
 
+    // GlobSettings tests
+    #[test]
+    fn glob_settings_should_create_standard_defaults() {
+        let settings = GlobSettings::new();
+        assert_eq!(settings.limit(), glob_meta::MAX_RESULTS);
+    }
+
+    #[test]
+    fn glob_settings_should_reject_zero_limit() {
+        assert!(GlobSettings::new().with_limit(0).is_err());
+    }
+
     /// Verifies that glob patterns correctly include or exclude files based on
     /// both pattern matching and gitignore rules.
     #[rstest]
@@ -191,7 +235,7 @@ mod tests {
                 pattern: pattern.to_string(),
                 path: dir.path().to_str().unwrap().to_string(),
             },
-            GlobSettings { limit: 1000 },
+            GlobSettings::new().with_limit(1000).unwrap(),
         )
         .unwrap();
 
@@ -282,7 +326,7 @@ mod tests {
                 pattern: "**/*.txt".to_string(),
                 path: base.to_str().unwrap().to_string(),
             },
-            GlobSettings { limit: 1000 },
+            GlobSettings::new().with_limit(1000).unwrap(),
         )
         .unwrap();
 
@@ -316,7 +360,7 @@ mod tests {
                 pattern: "**/*.rs".to_string(),
                 path: dir.path().to_str().unwrap().to_string(),
             },
-            GlobSettings { limit: 1000 },
+            GlobSettings::new().with_limit(1000).unwrap(),
         )
         .unwrap();
 

--- a/src/llm-coding-tools-core/src/tools/glob.rs
+++ b/src/llm-coding-tools-core/src/tools/glob.rs
@@ -24,6 +24,8 @@ impl GlobRequest {
 }
 
 /// Runtime settings applied to glob requests.
+///
+/// The `limit` field caps the number of file paths returned.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GlobSettings {
     limit: usize,

--- a/src/llm-coding-tools-core/src/tools/glob.rs
+++ b/src/llm-coding-tools-core/src/tools/glob.rs
@@ -45,6 +45,11 @@ impl GlobSettings {
     }
 
     /// Updates the maximum number of files returned.
+    ///
+    /// # Errors
+    /// - Returns an error when `limit` is below [`MIN_LIMIT`].
+    ///
+    /// [`MIN_LIMIT`]: crate::util::MIN_LIMIT
     pub fn with_limit(mut self, limit: usize) -> ToolResult<Self> {
         use crate::util::MIN_LIMIT;
         if limit < MIN_LIMIT {

--- a/src/llm-coding-tools-core/src/tools/grep.rs
+++ b/src/llm-coding-tools-core/src/tools/grep.rs
@@ -2,6 +2,7 @@
 
 use crate::error::{ToolError, ToolResult};
 use crate::path::PathResolver;
+use crate::tool_metadata::grep as grep_meta;
 use crate::util::{truncate_line_with_ellipsis, TRUNCATION_ELLIPSIS};
 use globset::Glob;
 use grep_regex::RegexMatcher;
@@ -39,10 +40,100 @@ impl GrepRequest {
 }
 
 /// Runtime settings applied to grep requests.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GrepSettings {
-    /// Maximum number of matches returned for a request.
-    pub max_limit: usize,
+    max_limit: usize,
+}
+
+impl Default for GrepSettings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GrepSettings {
+    /// Creates valid grep search settings with the standard defaults.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            max_limit: grep_meta::DEFAULT_LIMIT,
+        }
+    }
+
+    /// Updates the maximum number of matches to return.
+    pub fn with_max_limit(mut self, max_limit: usize) -> ToolResult<Self> {
+        use crate::util::MIN_LIMIT;
+        if max_limit < MIN_LIMIT {
+            return Err(ToolError::validation_for(
+                "max_limit",
+                format!("max_limit must be >= {}", MIN_LIMIT),
+            ));
+        }
+        self.max_limit = max_limit;
+        Ok(self)
+    }
+
+    /// Returns the maximum number of matches to return.
+    #[must_use]
+    pub const fn max_limit(self) -> usize {
+        self.max_limit
+    }
+}
+
+/// Core-owned formatting settings for rendered grep output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GrepFormattingSettings {
+    max_line_length: usize,
+    line_numbers: bool,
+}
+
+impl Default for GrepFormattingSettings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GrepFormattingSettings {
+    /// Creates valid grep formatting settings with the standard line-numbered output.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            max_line_length: DEFAULT_MAX_LINE_LENGTH,
+            line_numbers: true,
+        }
+    }
+
+    /// Updates the maximum line length for formatted output.
+    pub fn with_max_line_length(mut self, max_line_length: usize) -> ToolResult<Self> {
+        use crate::util::MIN_LINE_LENGTH;
+        if max_line_length < MIN_LINE_LENGTH {
+            return Err(ToolError::validation_for(
+                "max_line_length",
+                format!("max_line_length must be >= {}", MIN_LINE_LENGTH),
+            ));
+        }
+        self.max_line_length = max_line_length;
+        Ok(self)
+    }
+
+    /// Enables or disables line numbers in output.
+    #[must_use]
+    pub const fn with_line_numbers(mut self, line_numbers: bool) -> Self {
+        self.line_numbers = line_numbers;
+        self
+    }
+
+    /// Returns the maximum line length for formatted output.
+    #[must_use]
+    pub const fn max_line_length(self) -> usize {
+        self.max_line_length
+    }
+
+    /// Returns whether line numbers are included in output.
+    #[must_use]
+    pub const fn line_numbers(self) -> bool {
+        self.line_numbers
+    }
 }
 
 /// A single line match within a file.
@@ -90,9 +181,10 @@ impl GrepOutput {
     ///
     /// # Arguments
     ///
-    /// * `line_numbers` - When `true`, prefixes each match with `L{num}: `
-    /// * `max_line_len` - Truncate lines exceeding this character length and append `...`
-    pub fn format(&self, line_numbers: bool, max_line_len: usize) -> String {
+    /// * `formatting` - The formatting settings to use for output
+    pub fn format(&self, formatting: GrepFormattingSettings) -> String {
+        let line_numbers = formatting.line_numbers();
+        let max_line_len = formatting.max_line_length();
         let estimated_capacity = self.match_count * ESTIMATED_CHARS_PER_MATCH;
         let mut output = String::with_capacity(estimated_capacity);
 
@@ -157,8 +249,8 @@ pub fn grep_search<R: PathResolver>(
 
     let limit = request
         .limit
-        .unwrap_or(settings.max_limit)
-        .min(settings.max_limit);
+        .unwrap_or(settings.max_limit())
+        .min(settings.max_limit());
     if limit == 0 {
         return Err(ToolError::validation_for("limit", "limit must be >= 1"));
     }
@@ -317,6 +409,32 @@ mod tests {
     use rstest::rstest;
     use tempfile::tempdir;
 
+    // GrepSettings and GrepFormattingSettings tests
+    #[test]
+    fn grep_settings_should_create_standard_defaults() {
+        let settings = GrepSettings::new();
+        assert_eq!(settings.max_limit(), grep_meta::DEFAULT_LIMIT);
+    }
+
+    #[test]
+    fn grep_settings_should_reject_zero_limit() {
+        assert!(GrepSettings::new().with_max_limit(0).is_err());
+    }
+
+    #[test]
+    fn grep_formatting_settings_should_create_standard_defaults() {
+        let settings = GrepFormattingSettings::new();
+        assert_eq!(settings.max_line_length(), DEFAULT_MAX_LINE_LENGTH);
+        assert!(settings.line_numbers());
+    }
+
+    #[test]
+    fn grep_formatting_settings_should_reject_short_line_length() {
+        assert!(GrepFormattingSettings::new()
+            .with_max_line_length(3)
+            .is_err());
+    }
+
     /// Verifies that grep search returns the expected number of files and matches
     /// for different file layouts and optional glob filters.
     #[rstest]
@@ -376,7 +494,7 @@ mod tests {
                 include: include.map(|s| s.to_string()),
                 limit: None,
             },
-            GrepSettings { max_limit: 10 },
+            GrepSettings::new().with_max_limit(10).unwrap(),
         )
         .unwrap();
 
@@ -421,7 +539,7 @@ mod tests {
             effective_limit: 10,
         };
 
-        let formatted = output.format(true, DEFAULT_MAX_LINE_LENGTH);
+        let formatted = output.format(GrepFormattingSettings::new());
 
         assert_eq!(formatted.contains("Partial results"), expect_partial_msg);
         assert_eq!(
@@ -511,7 +629,12 @@ mod tests {
             effective_limit: 10,
         };
 
-        let formatted = output.format(with_line_numbers, max_len);
+        let formatted = output.format(
+            GrepFormattingSettings::new()
+                .with_max_line_length(max_len)
+                .unwrap()
+                .with_line_numbers(with_line_numbers),
+        );
 
         assert!(
             formatted.contains(expected),
@@ -535,7 +658,7 @@ mod tests {
                 include: None,
                 limit: None,
             },
-            GrepSettings { max_limit: 10 },
+            GrepSettings::new().with_max_limit(10).unwrap(),
         )
         .unwrap();
 
@@ -559,7 +682,7 @@ mod tests {
                 include: None,
                 limit: None,
             },
-            GrepSettings { max_limit: 10 },
+            GrepSettings::new().with_max_limit(10).unwrap(),
         )
         .unwrap_err();
 
@@ -585,7 +708,7 @@ mod tests {
                 include: Some("   ".into()),
                 limit: Some(1),
             },
-            GrepSettings { max_limit: 1 },
+            GrepSettings::new().with_max_limit(1).unwrap(),
         )
         .unwrap();
 
@@ -613,7 +736,7 @@ mod tests {
                 include: None,
                 limit: Some(100), // Request asks for 100 matches
             },
-            GrepSettings { max_limit: 2 }, // But max_limit is only 2
+            GrepSettings::new().with_max_limit(2).unwrap(), // But max_limit is only 2
         )
         .unwrap();
 

--- a/src/llm-coding-tools-core/src/tools/grep.rs
+++ b/src/llm-coding-tools-core/src/tools/grep.rs
@@ -61,6 +61,11 @@ impl GrepSettings {
     }
 
     /// Updates the maximum number of matches to return.
+    ///
+    /// # Errors
+    /// - Returns an error when `max_limit` is below [`MIN_LIMIT`].
+    ///
+    /// [`MIN_LIMIT`]: crate::util::MIN_LIMIT
     pub fn with_max_limit(mut self, max_limit: usize) -> ToolResult<Self> {
         use crate::util::MIN_LIMIT;
         if max_limit < MIN_LIMIT {
@@ -104,6 +109,12 @@ impl GrepFormattingSettings {
     }
 
     /// Updates the maximum line length for formatted output.
+    ///
+    /// # Errors
+    /// - Returns an error when `max_line_length` is below
+    ///   [`MIN_LINE_LENGTH`].
+    ///
+    /// [`MIN_LINE_LENGTH`]: crate::util::MIN_LINE_LENGTH
     pub fn with_max_line_length(mut self, max_line_length: usize) -> ToolResult<Self> {
         use crate::util::MIN_LINE_LENGTH;
         if max_line_length < MIN_LINE_LENGTH {

--- a/src/llm-coding-tools-core/src/tools/grep.rs
+++ b/src/llm-coding-tools-core/src/tools/grep.rs
@@ -40,6 +40,9 @@ impl GrepRequest {
 }
 
 /// Runtime settings applied to grep requests.
+///
+/// The `max_limit` field caps the number of matching lines returned, even if
+/// the caller requests more.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GrepSettings {
     max_limit: usize,
@@ -60,7 +63,7 @@ impl GrepSettings {
         }
     }
 
-    /// Updates the maximum number of matches to return.
+    /// Sets the upper bound on matching lines returned per search.
     ///
     /// # Errors
     /// - Returns an error when `max_limit` is below [`MIN_LIMIT`].
@@ -78,14 +81,17 @@ impl GrepSettings {
         Ok(self)
     }
 
-    /// Returns the maximum number of matches to return.
+    /// Returns the upper bound on matching lines returned per search.
     #[must_use]
     pub const fn max_limit(self) -> usize {
         self.max_limit
     }
 }
 
-/// Core-owned formatting settings for rendered grep output.
+/// Formatting settings for rendered grep output.
+///
+/// Controls how matching lines are displayed: truncation length for long lines
+/// and whether to prefix each line with a line number.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GrepFormattingSettings {
     max_line_length: usize,

--- a/src/llm-coding-tools-core/src/tools/mod.rs
+++ b/src/llm-coding-tools-core/src/tools/mod.rs
@@ -23,8 +23,8 @@ pub use bash::{
 pub use edit::{edit_file, EditError, EditRequest};
 pub use glob::{glob_files, GlobOutput, GlobRequest, GlobSettings};
 pub use grep::{
-    grep_search, GrepFileMatches, GrepLineMatch, GrepOutput, GrepRequest, GrepSettings,
-    DEFAULT_MAX_LINE_LENGTH,
+    grep_search, GrepFileMatches, GrepFormattingSettings, GrepLineMatch, GrepOutput, GrepRequest,
+    GrepSettings, DEFAULT_MAX_LINE_LENGTH,
 };
 pub use read::{read_file, ReadRequest, ReadSettings};
 pub use task::{TaskInput, TaskOutput, TaskSettings};

--- a/src/llm-coding-tools-core/src/tools/read.rs
+++ b/src/llm-coding-tools-core/src/tools/read.rs
@@ -5,9 +5,7 @@ use crate::fs;
 use crate::output::ToolOutput;
 use crate::path::PathResolver;
 use crate::tool_metadata::read as read_meta;
-use crate::util::{
-    truncate_line_with_ellipsis, ESTIMATED_CHARS_PER_LINE, MIN_LINE_LENGTH, TRUNCATION_ELLIPSIS,
-};
+use crate::util::{truncate_line_with_ellipsis, ESTIMATED_CHARS_PER_LINE, TRUNCATION_ELLIPSIS};
 use memchr::memchr;
 use serde::Deserialize;
 use serde_json::Value;
@@ -69,16 +67,131 @@ impl ReadRequest {
 }
 
 /// Runtime settings applied to read requests.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReadSettings {
-    /// Default line limit when the request omits one.
-    pub default_limit: usize,
-    /// Maximum line limit the caller may request.
-    pub max_limit: usize,
-    /// Maximum characters per output line before truncation.
-    pub max_line_length: usize,
-    /// Whether line numbers should be included in output.
-    pub line_numbers: bool,
+    default_limit: usize,
+    max_limit: usize,
+    max_line_length: usize,
+    line_numbers: bool,
+}
+
+impl Default for ReadSettings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReadSettings {
+    /// Creates valid read settings with the standard defaults.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            default_limit: read_meta::DEFAULT_LIMIT,
+            max_limit: read_meta::DEFAULT_LIMIT,
+            max_line_length: read_meta::MAX_LINE_LENGTH,
+            line_numbers: true,
+        }
+    }
+
+    /// Updates both read limits in one validated step.
+    ///
+    /// # Arguments
+    /// - `default_limit`: Default line count when the request omits `limit`.
+    /// - `max_limit`: Hard cap applied to any requested limit.
+    ///
+    /// # Returns
+    /// - `Ok(Self)` with both limits updated.
+    ///
+    /// # Errors
+    /// - Returns an error when either limit is below `MIN_LIMIT` or `default_limit > max_limit`.
+    pub fn with_limits(mut self, default_limit: usize, max_limit: usize) -> ToolResult<Self> {
+        ensure_read_limits(default_limit, max_limit)?;
+        self.default_limit = default_limit;
+        self.max_limit = max_limit;
+        Ok(self)
+    }
+
+    /// Updates only the default limit while preserving the current max limit.
+    pub fn with_default_limit(self, default_limit: usize) -> ToolResult<Self> {
+        self.with_limits(default_limit, self.max_limit)
+    }
+
+    /// Updates only the max limit while preserving the current default limit.
+    pub fn with_max_limit(self, max_limit: usize) -> ToolResult<Self> {
+        self.with_limits(self.default_limit, max_limit)
+    }
+
+    /// Updates the per-line truncation length.
+    pub fn with_max_line_length(mut self, max_line_length: usize) -> ToolResult<Self> {
+        ensure_max_line_length(max_line_length)?;
+        self.max_line_length = max_line_length;
+        Ok(self)
+    }
+
+    /// Enables or disables line numbers in output.
+    #[must_use]
+    pub const fn with_line_numbers(mut self, line_numbers: bool) -> Self {
+        self.line_numbers = line_numbers;
+        self
+    }
+
+    /// Returns the default line limit.
+    #[must_use]
+    pub const fn default_limit(self) -> usize {
+        self.default_limit
+    }
+
+    /// Returns the maximum line limit.
+    #[must_use]
+    pub const fn max_limit(self) -> usize {
+        self.max_limit
+    }
+
+    /// Returns the maximum characters per line before truncation.
+    #[must_use]
+    pub const fn max_line_length(self) -> usize {
+        self.max_line_length
+    }
+
+    /// Returns whether line numbers are included in output.
+    #[must_use]
+    pub const fn line_numbers(self) -> bool {
+        self.line_numbers
+    }
+}
+
+fn ensure_read_limits(default_limit: usize, max_limit: usize) -> ToolResult<()> {
+    use crate::util::MIN_LIMIT;
+    if default_limit < MIN_LIMIT {
+        return Err(ToolError::validation_for(
+            "default_limit",
+            format!("default_limit must be >= {}", MIN_LIMIT),
+        ));
+    }
+    if max_limit < MIN_LIMIT {
+        return Err(ToolError::validation_for(
+            "max_limit",
+            format!("max_limit must be >= {}", MIN_LIMIT),
+        ));
+    }
+    if default_limit > max_limit {
+        return Err(ToolError::validation_for(
+            "default_limit",
+            format!("default_limit ({default_limit}) must be <= max_limit ({max_limit})"),
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_max_line_length(max_line_length: usize) -> ToolResult<()> {
+    use crate::util::MIN_LINE_LENGTH;
+    if max_line_length < MIN_LINE_LENGTH {
+        return Err(ToolError::validation_for(
+            "max_line_length",
+            format!("max_line_length must be >= {}", MIN_LINE_LENGTH),
+        ));
+    }
+    Ok(())
 }
 
 /// Reads a file and returns formatted content, optionally with line numbers.
@@ -99,25 +212,19 @@ pub async fn read_file<R: PathResolver>(
 
     let limit = request
         .limit
-        .unwrap_or(settings.default_limit)
-        .min(settings.max_limit);
+        .unwrap_or(settings.default_limit())
+        .min(settings.max_limit());
     if limit == 0 {
         return Err(ToolError::validation_for("limit", "limit must be >= 1"));
     }
 
     let offset = request.offset;
-    let max_line_length = settings.max_line_length;
-    let line_numbers = settings.line_numbers;
+    let max_line_length = settings.max_line_length();
+    let line_numbers = settings.line_numbers();
 
     if offset == 0 {
         return Err(ToolError::OutOfBounds(
             "offset must be >= 1 (1-indexed)".into(),
-        ));
-    }
-    if max_line_length < MIN_LINE_LENGTH {
-        return Err(ToolError::validation_for(
-            "max_line_length",
-            format!("max_line_length must be >= {}", MIN_LINE_LENGTH),
         ));
     }
 
@@ -221,6 +328,7 @@ pub async fn read_file<R: PathResolver>(
 mod tests {
     use super::*;
     use crate::path::AbsolutePathResolver;
+    use rstest::rstest;
     use std::io::Write as _;
     use tempfile::NamedTempFile;
 
@@ -234,6 +342,10 @@ mod tests {
         let mut temp = NamedTempFile::new().unwrap();
         temp.write_all(content).unwrap();
         let resolver = AbsolutePathResolver;
+        let settings = ReadSettings::new()
+            .with_limits(limit, limit)
+            .unwrap()
+            .with_line_numbers(line_numbers);
         read_file::<_>(
             &resolver,
             ReadRequest {
@@ -241,14 +353,56 @@ mod tests {
                 offset,
                 limit: Some(limit),
             },
-            ReadSettings {
-                default_limit: limit,
-                max_limit: limit,
-                max_line_length: 2000,
-                line_numbers,
-            },
+            settings,
         )
         .await
+    }
+
+    // ReadSettings tests
+    #[test]
+    fn read_settings_should_create_standard_defaults() {
+        let settings = ReadSettings::new();
+        assert_eq!(settings.default_limit(), read_meta::DEFAULT_LIMIT);
+        assert_eq!(settings.max_limit(), read_meta::DEFAULT_LIMIT);
+        assert_eq!(settings.max_line_length(), read_meta::MAX_LINE_LENGTH);
+        assert!(settings.line_numbers());
+    }
+
+    #[test]
+    fn read_settings_should_accept_equal_minimum_limits() {
+        let settings = ReadSettings::new().with_limits(1, 1).unwrap();
+        assert_eq!(settings.default_limit(), 1);
+        assert_eq!(settings.max_limit(), 1);
+    }
+
+    #[rstest]
+    #[case::zero_default_limit(0, 1)]
+    #[case::both_zero(0, 0)]
+    #[case::default_limit_above_max(2, 1)]
+    fn read_settings_should_reject_invalid_limit_pairs(
+        #[case] default_limit: usize,
+        #[case] max_limit: usize,
+    ) {
+        assert!(ReadSettings::new()
+            .with_limits(default_limit, max_limit)
+            .is_err());
+    }
+
+    #[test]
+    fn read_settings_should_reject_zero_limits_from_individual_updates() {
+        assert!(ReadSettings::new().with_default_limit(0).is_err());
+        assert!(ReadSettings::new().with_max_limit(0).is_err());
+    }
+
+    #[test]
+    fn read_settings_should_reject_max_limit_below_current_default() {
+        let settings = ReadSettings::new().with_default_limit(100).unwrap();
+        assert!(settings.with_max_limit(50).is_err());
+    }
+
+    #[test]
+    fn read_settings_should_reject_short_max_line_length() {
+        assert!(ReadSettings::new().with_max_line_length(3).is_err());
     }
 
     #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]
@@ -274,37 +428,17 @@ mod tests {
     }
 
     #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]
-    async fn errors_on_invalid_max_line_length() {
-        let mut temp = NamedTempFile::new().unwrap();
-        temp.write_all(b"test\n").unwrap();
-        let resolver = AbsolutePathResolver;
-
-        let err = read_file::<_>(
-            &resolver,
-            ReadRequest {
-                file_path: temp.path().to_str().unwrap().to_string(),
-                offset: 1,
-                limit: Some(10),
-            },
-            ReadSettings {
-                default_limit: 10,
-                max_limit: 10,
-                max_line_length: 3, // below MIN_LINE_LENGTH of 4
-                line_numbers: true,
-            },
-        )
-        .await
-        .unwrap_err();
-
-        assert!(matches!(err, ToolError::Validation { .. }));
-        assert!(err.to_string().contains("max_line_length must be >= 4"));
-    }
-
-    #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]
     async fn truncates_long_line_with_ellipsis() {
         let mut temp = NamedTempFile::new().unwrap();
         temp.write_all(b"abcdefghij\n").unwrap();
         let resolver = AbsolutePathResolver;
+
+        let settings = ReadSettings::new()
+            .with_limits(10, 10)
+            .unwrap()
+            .with_max_line_length(6)
+            .unwrap()
+            .with_line_numbers(false);
 
         let result = read_file::<_>(
             &resolver,
@@ -313,12 +447,7 @@ mod tests {
                 offset: 1,
                 limit: Some(10),
             },
-            ReadSettings {
-                default_limit: 10,
-                max_limit: 10,
-                max_line_length: 6, // keep 3 chars + "..."
-                line_numbers: false,
-            },
+            settings,
         )
         .await
         .unwrap();
@@ -332,6 +461,15 @@ mod tests {
         temp.write_all(b"line1\nline2\nline3\n").unwrap();
         let resolver = AbsolutePathResolver;
 
+        // Valid settings: default_limit (2) <= max_limit (3), but request limit (3)
+        // will be capped at max_limit (3), then min with requested gives 3.
+        // Actually, to test capping, we need max_limit to be lower than requested.
+        // So: default_limit=1, max_limit=1, and request with limit=3 should cap at 1.
+        let settings = ReadSettings::new()
+            .with_limits(1, 1)
+            .unwrap()
+            .with_line_numbers(true);
+
         let result = read_file(
             &resolver,
             ReadRequest {
@@ -339,12 +477,7 @@ mod tests {
                 offset: 1,
                 limit: Some(3),
             },
-            ReadSettings {
-                default_limit: 2,
-                max_limit: 1,
-                max_line_length: 2000,
-                line_numbers: true,
-            },
+            settings,
         )
         .await
         .unwrap();
@@ -353,24 +486,25 @@ mod tests {
     }
 
     #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]
-    async fn read_request_rejects_zero_effective_limit() {
+    async fn read_request_rejects_zero_requested_limit() {
         let mut temp = NamedTempFile::new().unwrap();
         temp.write_all(b"line1\n").unwrap();
         let resolver = AbsolutePathResolver;
+
+        // Use valid settings, but request an explicit limit of 0
+        let settings = ReadSettings::new()
+            .with_limits(10, 10)
+            .unwrap()
+            .with_line_numbers(true);
 
         let err = read_file(
             &resolver,
             ReadRequest {
                 file_path: temp.path().to_string_lossy().into_owned(),
                 offset: 1,
-                limit: None,
+                limit: Some(0), // Request explicitly asks for 0 lines
             },
-            ReadSettings {
-                default_limit: 0,
-                max_limit: 0,
-                max_line_length: 2000,
-                line_numbers: true,
-            },
+            settings,
         )
         .await
         .unwrap_err();

--- a/src/llm-coding-tools-core/src/tools/read.rs
+++ b/src/llm-coding-tools-core/src/tools/read.rs
@@ -67,6 +67,12 @@ impl ReadRequest {
 }
 
 /// Runtime settings applied to read requests.
+///
+/// Controls how many lines a read returns using a two-limit model:
+/// - **Default limit**: line count used when the caller doesn't specify one.
+/// - **Max limit**: hard cap applied regardless of what the caller requests.
+///
+/// Additional settings control per-line truncation and line-number display.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReadSettings {
     default_limit: usize,
@@ -93,14 +99,16 @@ impl ReadSettings {
         }
     }
 
-    /// Updates both read limits in one validated step.
+    /// Sets the default and maximum line count for read operations in one
+    /// validated step.
+    ///
+    /// The default limit is used when the caller doesn't specify a line count;
+    /// the max limit caps any explicitly requested count. Both limits must be
+    /// at least [`MIN_LIMIT`], and `default_limit` must not exceed `max_limit`.
     ///
     /// # Arguments
-    /// - `default_limit`: Default line count when the request omits `limit`.
-    /// - `max_limit`: Hard cap applied to any requested limit.
-    ///
-    /// # Returns
-    /// - `Ok(Self)` with both limits updated.
+    /// - `default_limit`: Line count used when the request omits `limit`.
+    /// - `max_limit`: Upper bound on lines returned regardless of the request.
     ///
     /// # Errors
     /// - Returns an error when either limit is below [`MIN_LIMIT`] or
@@ -114,22 +122,27 @@ impl ReadSettings {
         Ok(self)
     }
 
-    /// Updates only the default limit while preserving the current max limit.
+    /// Sets the line count used when the caller doesn't specify one.
+    ///
+    /// The new value must not exceed the current max limit.
     ///
     /// # Errors
     /// - Returns an error when `default_limit` is below [`MIN_LIMIT`] or
-    ///   exceeds the current `max_limit`.
+    ///   exceeds the current max limit.
     ///
     /// [`MIN_LIMIT`]: crate::util::MIN_LIMIT
     pub fn with_default_limit(self, default_limit: usize) -> ToolResult<Self> {
         self.with_limits(default_limit, self.max_limit)
     }
 
-    /// Updates only the max limit while preserving the current default limit.
+    /// Sets the hard cap on lines returned regardless of what the caller
+    /// requests.
+    ///
+    /// The new value must be at least as large as the current default limit.
     ///
     /// # Errors
     /// - Returns an error when `max_limit` is below [`MIN_LIMIT`] or below
-    ///   the current `default_limit`.
+    ///   the current default limit.
     ///
     /// [`MIN_LIMIT`]: crate::util::MIN_LIMIT
     pub fn with_max_limit(self, max_limit: usize) -> ToolResult<Self> {
@@ -156,13 +169,13 @@ impl ReadSettings {
         self
     }
 
-    /// Returns the default line limit.
+    /// Returns the line count used when the caller doesn't specify one.
     #[must_use]
     pub const fn default_limit(self) -> usize {
         self.default_limit
     }
 
-    /// Returns the maximum line limit.
+    /// Returns the hard cap on lines returned regardless of the request.
     #[must_use]
     pub const fn max_limit(self) -> usize {
         self.max_limit

--- a/src/llm-coding-tools-core/src/tools/read.rs
+++ b/src/llm-coding-tools-core/src/tools/read.rs
@@ -103,7 +103,10 @@ impl ReadSettings {
     /// - `Ok(Self)` with both limits updated.
     ///
     /// # Errors
-    /// - Returns an error when either limit is below `MIN_LIMIT` or `default_limit > max_limit`.
+    /// - Returns an error when either limit is below [`MIN_LIMIT`] or
+    ///   `default_limit > max_limit`.
+    ///
+    /// [`MIN_LIMIT`]: crate::util::MIN_LIMIT
     pub fn with_limits(mut self, default_limit: usize, max_limit: usize) -> ToolResult<Self> {
         ensure_read_limits(default_limit, max_limit)?;
         self.default_limit = default_limit;
@@ -112,16 +115,34 @@ impl ReadSettings {
     }
 
     /// Updates only the default limit while preserving the current max limit.
+    ///
+    /// # Errors
+    /// - Returns an error when `default_limit` is below [`MIN_LIMIT`] or
+    ///   exceeds the current `max_limit`.
+    ///
+    /// [`MIN_LIMIT`]: crate::util::MIN_LIMIT
     pub fn with_default_limit(self, default_limit: usize) -> ToolResult<Self> {
         self.with_limits(default_limit, self.max_limit)
     }
 
     /// Updates only the max limit while preserving the current default limit.
+    ///
+    /// # Errors
+    /// - Returns an error when `max_limit` is below [`MIN_LIMIT`] or below
+    ///   the current `default_limit`.
+    ///
+    /// [`MIN_LIMIT`]: crate::util::MIN_LIMIT
     pub fn with_max_limit(self, max_limit: usize) -> ToolResult<Self> {
         self.with_limits(self.default_limit, max_limit)
     }
 
     /// Updates the per-line truncation length.
+    ///
+    /// # Errors
+    /// - Returns an error when `max_line_length` is below
+    ///   [`MIN_LINE_LENGTH`].
+    ///
+    /// [`MIN_LINE_LENGTH`]: crate::util::MIN_LINE_LENGTH
     pub fn with_max_line_length(mut self, max_line_length: usize) -> ToolResult<Self> {
         ensure_max_line_length(max_line_length)?;
         self.max_line_length = max_line_length;

--- a/src/llm-coding-tools-core/src/tools/webfetch/blocking_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/webfetch/blocking_impl.rs
@@ -20,7 +20,7 @@ pub fn fetch_url(
     request: super::WebFetchRequest,
     settings: super::WebFetchSettings,
 ) -> ToolResult<WebFetchOutput> {
-    let timeout_ms = request.timeout_ms.unwrap_or(settings.default_timeout_ms);
+    let timeout_ms = request.timeout_ms.unwrap_or(settings.default_timeout_ms());
 
     if timeout_ms == 0 {
         return Err(ToolError::validation_for(
@@ -28,12 +28,12 @@ pub fn fetch_url(
             "timeout_ms must be at least 1",
         ));
     }
-    if timeout_ms > settings.max_timeout_ms {
+    if timeout_ms > settings.max_timeout_ms() {
         return Err(ToolError::validation_for(
             "timeout_ms",
             format!(
                 "timeout_ms exceeds maximum allowed value of {}",
-                settings.max_timeout_ms
+                settings.max_timeout_ms()
             ),
         ));
     }
@@ -73,7 +73,7 @@ pub fn fetch_url(
         })
         .transpose()?;
     if let Some(len) = content_length {
-        check_size(len, &request.url, settings.max_response_size)?;
+        check_size(len, &request.url, settings.max_response_size())?;
     }
 
     // Stream response body with incremental size checks to avoid memory exhaustion
@@ -94,7 +94,7 @@ pub fn fetch_url(
         total_len = total_len.checked_add(n).ok_or_else(|| {
             ToolError::Http(format!("Response size overflow for {}", request.url))
         })?;
-        check_size(total_len, &request.url, settings.max_response_size)?;
+        check_size(total_len, &request.url, settings.max_response_size())?;
 
         bytes.extend_from_slice(chunk);
         reader.consume(n);
@@ -114,7 +114,7 @@ pub fn fetch_url(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tools::webfetch::{WebFetchRequest, WebFetchSettings};
+    use crate::tools::webfetch::WebFetchSettings;
     use rstest::rstest;
     use std::sync::mpsc;
     use std::sync::Arc;
@@ -122,6 +122,12 @@ mod tests {
     use tokio::sync::Notify;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_settings() -> WebFetchSettings {
+        WebFetchSettings::new()
+            .with_timeouts(10_000, 20_000)
+            .unwrap()
+    }
 
     fn test_client() -> reqwest::blocking::Client {
         reqwest::blocking::Client::builder()
@@ -190,21 +196,20 @@ mod tests {
     /// network request. The URL is intentionally unreachable.
     #[rstest]
     #[case::zero_timeout(0, 10_000)]
-    #[case::exceeds_max(11_000, 10_000)]
+    #[case::exceeds_max(21_000, 20_000)]
     fn rejects_invalid_timeout(#[case] timeout_ms: u32, #[case] max_timeout_ms: u32) {
         let client = test_client();
+        let settings = WebFetchSettings::new()
+            .with_timeouts(5_000, max_timeout_ms)
+            .unwrap();
 
         let result = fetch_url(
             &client,
-            WebFetchRequest {
+            super::super::WebFetchRequest {
                 url: "http://localhost:1".to_string(),
                 timeout_ms: Some(timeout_ms),
             },
-            WebFetchSettings {
-                default_timeout_ms: 5000,
-                max_timeout_ms,
-                max_response_size: 5 * 1024 * 1024,
-            },
+            settings,
         );
 
         assert!(matches!(result, Err(ToolError::Validation { .. })));
@@ -229,15 +234,11 @@ mod tests {
         let client = test_client();
         let result = fetch_url(
             &client,
-            WebFetchRequest {
+            super::super::WebFetchRequest {
                 url: format!("{}/robots.txt", server.uri()),
                 timeout_ms: None,
             },
-            WebFetchSettings {
-                default_timeout_ms: 10_000,
-                max_timeout_ms: 20_000,
-                max_response_size: 5 * 1024 * 1024,
-            },
+            test_settings(),
         );
 
         let output = result.expect("Should successfully fetch");
@@ -260,15 +261,11 @@ mod tests {
         let client = test_client();
         let result = fetch_url(
             &client,
-            WebFetchRequest {
+            super::super::WebFetchRequest {
                 url: format!("{}/not-found", server.uri()),
                 timeout_ms: None,
             },
-            WebFetchSettings {
-                default_timeout_ms: 10_000,
-                max_timeout_ms: 20_000,
-                max_response_size: 5 * 1024 * 1024,
-            },
+            test_settings(),
         );
 
         assert!(

--- a/src/llm-coding-tools-core/src/tools/webfetch/mod.rs
+++ b/src/llm-coding-tools-core/src/tools/webfetch/mod.rs
@@ -1,6 +1,8 @@
 //! Web content fetching operation.
 
 use crate::error::{ToolError, ToolResult};
+use crate::tool_metadata::webfetch as webfetch_meta;
+use crate::util::MIN_TIMEOUT_MS;
 use html_to_markdown_rs::{convert, ConversionOptions, PreprocessingOptions, PreprocessingPreset};
 use serde::Deserialize;
 use serde_json::Value;
@@ -23,14 +25,106 @@ impl WebFetchRequest {
 }
 
 /// Runtime settings applied to webfetch requests.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WebFetchSettings {
-    /// Default timeout when omitted from the request.
-    pub default_timeout_ms: u32,
-    /// Maximum allowed timeout.
-    pub max_timeout_ms: u32,
-    /// Maximum response size in bytes.
-    pub max_response_size: usize,
+    default_timeout_ms: u32,
+    max_timeout_ms: u32,
+    max_response_size: usize,
+}
+
+impl Default for WebFetchSettings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WebFetchSettings {
+    /// Creates valid webfetch settings with the standard timeout and size limits.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            default_timeout_ms: webfetch_meta::DEFAULT_TIMEOUT_MS,
+            max_timeout_ms: webfetch_meta::MAX_TIMEOUT_MS,
+            max_response_size: webfetch_meta::MAX_RESPONSE_SIZE,
+        }
+    }
+
+    /// Updates both timeout fields in one validated step.
+    pub fn with_timeouts(
+        mut self,
+        default_timeout_ms: u32,
+        max_timeout_ms: u32,
+    ) -> ToolResult<Self> {
+        ensure_timeouts(default_timeout_ms, max_timeout_ms)?;
+        self.default_timeout_ms = default_timeout_ms;
+        self.max_timeout_ms = max_timeout_ms;
+        Ok(self)
+    }
+
+    /// Updates only the default timeout while preserving the current max timeout.
+    pub fn with_default_timeout_ms(self, default_timeout_ms: u32) -> ToolResult<Self> {
+        self.with_timeouts(default_timeout_ms, self.max_timeout_ms)
+    }
+
+    /// Updates only the max timeout while preserving the current default timeout.
+    pub fn with_max_timeout_ms(self, max_timeout_ms: u32) -> ToolResult<Self> {
+        self.with_timeouts(self.default_timeout_ms, max_timeout_ms)
+    }
+
+    /// Updates the maximum response size in bytes.
+    pub fn with_max_response_size(mut self, max_response_size: usize) -> ToolResult<Self> {
+        use crate::util::MIN_LIMIT;
+        if max_response_size < MIN_LIMIT {
+            return Err(ToolError::validation_for(
+                "max_response_size",
+                format!("max_response_size must be >= {}", MIN_LIMIT),
+            ));
+        }
+        self.max_response_size = max_response_size;
+        Ok(self)
+    }
+
+    /// Returns the default timeout in milliseconds.
+    #[must_use]
+    pub const fn default_timeout_ms(self) -> u32 {
+        self.default_timeout_ms
+    }
+
+    /// Returns the maximum timeout in milliseconds.
+    #[must_use]
+    pub const fn max_timeout_ms(self) -> u32 {
+        self.max_timeout_ms
+    }
+
+    /// Returns the maximum response size in bytes.
+    #[must_use]
+    pub const fn max_response_size(self) -> usize {
+        self.max_response_size
+    }
+}
+
+fn ensure_timeouts(default_timeout_ms: u32, max_timeout_ms: u32) -> ToolResult<()> {
+    if default_timeout_ms < MIN_TIMEOUT_MS {
+        return Err(ToolError::validation_for(
+            "default_timeout_ms",
+            format!("default_timeout_ms must be >= {}", MIN_TIMEOUT_MS),
+        ));
+    }
+    if max_timeout_ms < MIN_TIMEOUT_MS {
+        return Err(ToolError::validation_for(
+            "max_timeout_ms",
+            format!("max_timeout_ms must be >= {}", MIN_TIMEOUT_MS),
+        ));
+    }
+    if default_timeout_ms > max_timeout_ms {
+        return Err(ToolError::validation_for(
+            "default_timeout_ms",
+            format!(
+                "default_timeout_ms ({default_timeout_ms}) must be <= max_timeout_ms ({max_timeout_ms})"
+            ),
+        ));
+    }
+    Ok(())
 }
 
 /// Result from URL fetch operation.
@@ -123,6 +217,45 @@ pub use blocking_impl::fetch_url;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::MIN_TIMEOUT_MS;
+
+    // WebFetchSettings tests
+    #[test]
+    fn webfetch_settings_should_create_standard_defaults() {
+        let settings = WebFetchSettings::new();
+        assert_eq!(
+            settings.default_timeout_ms(),
+            webfetch_meta::DEFAULT_TIMEOUT_MS
+        );
+        assert_eq!(settings.max_timeout_ms(), webfetch_meta::MAX_TIMEOUT_MS);
+        assert_eq!(
+            settings.max_response_size(),
+            webfetch_meta::MAX_RESPONSE_SIZE
+        );
+    }
+
+    #[test]
+    fn webfetch_settings_should_reject_timeout_below_minimum() {
+        let below_min = MIN_TIMEOUT_MS - 1;
+        assert!(WebFetchSettings::new()
+            .with_default_timeout_ms(below_min)
+            .is_err());
+        assert!(WebFetchSettings::new()
+            .with_max_timeout_ms(below_min)
+            .is_err());
+    }
+
+    #[test]
+    fn webfetch_settings_should_reject_default_timeout_above_max_timeout() {
+        assert!(WebFetchSettings::new()
+            .with_timeouts(30_001, 30_000)
+            .is_err());
+    }
+
+    #[test]
+    fn webfetch_settings_should_reject_zero_max_response_size() {
+        assert!(WebFetchSettings::new().with_max_response_size(0).is_err());
+    }
 
     #[test]
     fn html_to_markdown_strips_scripts() {

--- a/src/llm-coding-tools-core/src/tools/webfetch/mod.rs
+++ b/src/llm-coding-tools-core/src/tools/webfetch/mod.rs
@@ -25,6 +25,12 @@ impl WebFetchRequest {
 }
 
 /// Runtime settings applied to webfetch requests.
+///
+/// Controls request duration using a two-timeout model:
+/// - **Default timeout**: applied when the request doesn't specify one.
+/// - **Max timeout**: hard cap applied regardless of what the caller requests.
+///
+/// A separate `max_response_size` field limits downloaded bytes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WebFetchSettings {
     default_timeout_ms: u32,
@@ -49,12 +55,16 @@ impl WebFetchSettings {
         }
     }
 
-    /// Updates both timeout fields in one validated step.
+    /// Sets the default and maximum request timeout in one validated step.
+    ///
+    /// The default timeout is used when the request doesn't specify one; the
+    /// max timeout caps any explicitly requested duration. Both must be at
+    /// least [`MIN_TIMEOUT_MS`], and `default_timeout_ms` must not exceed
+    /// `max_timeout_ms`.
     ///
     /// # Arguments
-    /// - `default_timeout_ms`: Default timeout when the request omits
-    ///   `timeout_ms`.
-    /// - `max_timeout_ms`: Hard cap applied to any requested timeout.
+    /// - `default_timeout_ms`: Timeout used when the request omits `timeout_ms`.
+    /// - `max_timeout_ms`: Upper bound on request duration regardless of the request.
     ///
     /// # Errors
     /// - Returns an error when either timeout is below [`MIN_TIMEOUT_MS`] or
@@ -72,24 +82,27 @@ impl WebFetchSettings {
         Ok(self)
     }
 
-    /// Updates only the default timeout while preserving the current max
-    /// timeout.
+    /// Sets the timeout used when the request doesn't specify one.
+    ///
+    /// The new value must not exceed the current max timeout.
     ///
     /// # Errors
     /// - Returns an error when `default_timeout_ms` is below
-    ///   [`MIN_TIMEOUT_MS`] or exceeds the current `max_timeout_ms`.
+    ///   [`MIN_TIMEOUT_MS`] or exceeds the current max timeout.
     ///
     /// [`MIN_TIMEOUT_MS`]: crate::util::MIN_TIMEOUT_MS
     pub fn with_default_timeout_ms(self, default_timeout_ms: u32) -> ToolResult<Self> {
         self.with_timeouts(default_timeout_ms, self.max_timeout_ms)
     }
 
-    /// Updates only the max timeout while preserving the current default
-    /// timeout.
+    /// Sets the hard cap on request duration regardless of what the caller
+    /// specifies.
+    ///
+    /// The new value must be at least as large as the current default timeout.
     ///
     /// # Errors
     /// - Returns an error when `max_timeout_ms` is below
-    ///   [`MIN_TIMEOUT_MS`] or below the current `default_timeout_ms`.
+    ///   [`MIN_TIMEOUT_MS`] or below the current default timeout.
     ///
     /// [`MIN_TIMEOUT_MS`]: crate::util::MIN_TIMEOUT_MS
     pub fn with_max_timeout_ms(self, max_timeout_ms: u32) -> ToolResult<Self> {
@@ -114,13 +127,13 @@ impl WebFetchSettings {
         Ok(self)
     }
 
-    /// Returns the default timeout in milliseconds.
+    /// Returns the timeout used when the request doesn't specify one.
     #[must_use]
     pub const fn default_timeout_ms(self) -> u32 {
         self.default_timeout_ms
     }
 
-    /// Returns the maximum timeout in milliseconds.
+    /// Returns the hard cap on request duration regardless of the request.
     #[must_use]
     pub const fn max_timeout_ms(self) -> u32 {
         self.max_timeout_ms

--- a/src/llm-coding-tools-core/src/tools/webfetch/mod.rs
+++ b/src/llm-coding-tools-core/src/tools/webfetch/mod.rs
@@ -50,6 +50,17 @@ impl WebFetchSettings {
     }
 
     /// Updates both timeout fields in one validated step.
+    ///
+    /// # Arguments
+    /// - `default_timeout_ms`: Default timeout when the request omits
+    ///   `timeout_ms`.
+    /// - `max_timeout_ms`: Hard cap applied to any requested timeout.
+    ///
+    /// # Errors
+    /// - Returns an error when either timeout is below [`MIN_TIMEOUT_MS`] or
+    ///   `default_timeout_ms > max_timeout_ms`.
+    ///
+    /// [`MIN_TIMEOUT_MS`]: crate::util::MIN_TIMEOUT_MS
     pub fn with_timeouts(
         mut self,
         default_timeout_ms: u32,
@@ -61,17 +72,36 @@ impl WebFetchSettings {
         Ok(self)
     }
 
-    /// Updates only the default timeout while preserving the current max timeout.
+    /// Updates only the default timeout while preserving the current max
+    /// timeout.
+    ///
+    /// # Errors
+    /// - Returns an error when `default_timeout_ms` is below
+    ///   [`MIN_TIMEOUT_MS`] or exceeds the current `max_timeout_ms`.
+    ///
+    /// [`MIN_TIMEOUT_MS`]: crate::util::MIN_TIMEOUT_MS
     pub fn with_default_timeout_ms(self, default_timeout_ms: u32) -> ToolResult<Self> {
         self.with_timeouts(default_timeout_ms, self.max_timeout_ms)
     }
 
-    /// Updates only the max timeout while preserving the current default timeout.
+    /// Updates only the max timeout while preserving the current default
+    /// timeout.
+    ///
+    /// # Errors
+    /// - Returns an error when `max_timeout_ms` is below
+    ///   [`MIN_TIMEOUT_MS`] or below the current `default_timeout_ms`.
+    ///
+    /// [`MIN_TIMEOUT_MS`]: crate::util::MIN_TIMEOUT_MS
     pub fn with_max_timeout_ms(self, max_timeout_ms: u32) -> ToolResult<Self> {
         self.with_timeouts(self.default_timeout_ms, max_timeout_ms)
     }
 
     /// Updates the maximum response size in bytes.
+    ///
+    /// # Errors
+    /// - Returns an error when `max_response_size` is below [`MIN_LIMIT`].
+    ///
+    /// [`MIN_LIMIT`]: crate::util::MIN_LIMIT
     pub fn with_max_response_size(mut self, max_response_size: usize) -> ToolResult<Self> {
         use crate::util::MIN_LIMIT;
         if max_response_size < MIN_LIMIT {

--- a/src/llm-coding-tools-core/src/tools/webfetch/tokio_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/webfetch/tokio_impl.rs
@@ -19,7 +19,7 @@ pub async fn fetch_url(
     request: super::WebFetchRequest,
     settings: super::WebFetchSettings,
 ) -> ToolResult<WebFetchOutput> {
-    let timeout_ms = request.timeout_ms.unwrap_or(settings.default_timeout_ms);
+    let timeout_ms = request.timeout_ms.unwrap_or(settings.default_timeout_ms());
 
     if timeout_ms == 0 {
         return Err(ToolError::validation_for(
@@ -27,12 +27,12 @@ pub async fn fetch_url(
             "timeout_ms must be at least 1",
         ));
     }
-    if timeout_ms > settings.max_timeout_ms {
+    if timeout_ms > settings.max_timeout_ms() {
         return Err(ToolError::validation_for(
             "timeout_ms",
             format!(
                 "timeout_ms exceeds maximum allowed value of {}",
-                settings.max_timeout_ms
+                settings.max_timeout_ms()
             ),
         ));
     }
@@ -73,7 +73,7 @@ pub async fn fetch_url(
         })
         .transpose()?;
     if let Some(len) = content_length {
-        check_size(len, &request.url, settings.max_response_size)?;
+        check_size(len, &request.url, settings.max_response_size())?;
     }
 
     // Stream response body with incremental size checks to avoid memory exhaustion
@@ -88,7 +88,7 @@ pub async fn fetch_url(
         total_len = total_len.checked_add(chunk.len()).ok_or_else(|| {
             ToolError::Http(format!("Response size overflow for {}", request.url))
         })?;
-        check_size(total_len, &request.url, settings.max_response_size)?;
+        check_size(total_len, &request.url, settings.max_response_size())?;
         bytes.extend_from_slice(&chunk);
     }
 
@@ -106,9 +106,15 @@ pub async fn fetch_url(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tools::webfetch::{WebFetchRequest, WebFetchSettings};
+    use crate::tools::webfetch::WebFetchSettings;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_settings() -> WebFetchSettings {
+        WebFetchSettings::new()
+            .with_timeouts(5_000, 10_000)
+            .unwrap()
+    }
 
     fn test_client() -> reqwest::Client {
         reqwest::Client::builder()
@@ -132,15 +138,11 @@ mod tests {
         let client = test_client();
         let result = fetch_url(
             &client,
-            WebFetchRequest {
+            super::super::WebFetchRequest {
                 url: format!("{}/text", server.uri()),
                 timeout_ms: None,
             },
-            WebFetchSettings {
-                default_timeout_ms: 5_000,
-                max_timeout_ms: 10_000,
-                max_response_size: 5 * 1024 * 1024,
-            },
+            test_settings(),
         )
         .await
         .unwrap();
@@ -165,15 +167,11 @@ mod tests {
         let client = test_client();
         let result = fetch_url(
             &client,
-            WebFetchRequest {
+            super::super::WebFetchRequest {
                 url: format!("{}/html", server.uri()),
                 timeout_ms: None,
             },
-            WebFetchSettings {
-                default_timeout_ms: 5_000,
-                max_timeout_ms: 10_000,
-                max_response_size: 5 * 1024 * 1024,
-            },
+            test_settings(),
         )
         .await
         .unwrap();
@@ -196,15 +194,11 @@ mod tests {
         let client = test_client();
         let result = fetch_url(
             &client,
-            WebFetchRequest {
+            super::super::WebFetchRequest {
                 url: format!("{}/json", server.uri()),
                 timeout_ms: None,
             },
-            WebFetchSettings {
-                default_timeout_ms: 5_000,
-                max_timeout_ms: 10_000,
-                max_response_size: 5 * 1024 * 1024,
-            },
+            test_settings(),
         )
         .await
         .unwrap();
@@ -224,15 +218,11 @@ mod tests {
         let client = test_client();
         let result = fetch_url(
             &client,
-            WebFetchRequest {
+            super::super::WebFetchRequest {
                 url: format!("{}/notfound", server.uri()),
                 timeout_ms: None,
             },
-            WebFetchSettings {
-                default_timeout_ms: 5_000,
-                max_timeout_ms: 10_000,
-                max_response_size: 5 * 1024 * 1024,
-            },
+            test_settings(),
         )
         .await;
 
@@ -244,15 +234,11 @@ mod tests {
         let client = test_client();
         let result = fetch_url(
             &client,
-            WebFetchRequest {
+            super::super::WebFetchRequest {
                 url: "http://localhost:1".to_string(),
                 timeout_ms: Some(0),
             },
-            WebFetchSettings {
-                default_timeout_ms: 5_000,
-                max_timeout_ms: 10_000,
-                max_response_size: 5 * 1024 * 1024,
-            },
+            test_settings(),
         )
         .await;
         assert!(matches!(result, Err(ToolError::Validation { .. })));
@@ -263,15 +249,11 @@ mod tests {
         let client = test_client();
         let result = fetch_url(
             &client,
-            WebFetchRequest {
+            super::super::WebFetchRequest {
                 url: "http://localhost:1".to_string(),
                 timeout_ms: Some(11_000),
             },
-            WebFetchSettings {
-                default_timeout_ms: 5_000,
-                max_timeout_ms: 10_000,
-                max_response_size: 5 * 1024 * 1024,
-            },
+            test_settings(),
         )
         .await;
         assert!(matches!(result, Err(ToolError::Validation { .. })));

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
@@ -16,9 +16,47 @@ use llm_coding_tools_agents::{
     AgentRuntime, AgentToolSettings, ModelResolutionError, TaskTargetSummary, ToolCatalogEntry,
     ToolCatalogKind, summarize_callable_targets,
 };
+use llm_coding_tools_core::tool_metadata::{
+    glob as glob_meta, grep as grep_meta, read as read_meta, webfetch as webfetch_meta,
+};
+use llm_coding_tools_core::tools::{
+    GlobSettings, GrepFormattingSettings, GrepSettings, ReadSettings, WebFetchSettings,
+};
 use llm_coding_tools_core::{CredentialLookup, models::ModelCatalog};
 use serdes_ai::AgentBuilder;
 use serdes_ai_models::BoxedModel;
+
+/// Error returned when a build cannot produce a SerdesAI agent.
+#[derive(Debug, thiserror::Error)]
+pub enum AgentBuildError {
+    /// The requested agent name was not found in the runtime catalog.
+    #[error("unknown agent `{name}`")]
+    UnknownAgent {
+        /// The missing agent name.
+        name: Box<str>,
+    },
+    /// The runtime contains a tool kind this adapter cannot materialise.
+    #[error("tool `{name}` is not supported")]
+    UnsupportedToolKind {
+        /// The unsupported tool name.
+        name: Box<str>,
+    },
+    /// Resolving or validating the model configuration failed.
+    #[error(transparent)]
+    ModelResolution(#[from] ModelResolutionError),
+    /// Initializing the SerdesAI model failed.
+    #[error("failed to initialise model: {0}")]
+    ModelInit(#[from] serdes_ai_models::ModelError),
+    /// Tool settings validation failed during agent build.
+    #[error("invalid settings for tool `{tool}`: {source}")]
+    ToolSettingsValidation {
+        /// The tool name that had invalid settings.
+        tool: &'static str,
+        /// The underlying Core tool error.
+        #[source]
+        source: llm_coding_tools_core::ToolError,
+    },
+}
 
 /// Resolved build parameters ready for agent construction.
 #[derive(Clone)]
@@ -121,13 +159,10 @@ where
     for entry in &prepared.tools {
         match entry.kind {
             ToolCatalogKind::Read => {
-                let settings = &prepared.tool_settings.read;
-                builder = builder.tool(prompt_builder.track(ReadTool::with_settings(
-                    AbsolutePathResolver,
-                    settings.limit,
-                    settings.max_line_length,
-                    settings.line_numbers,
-                )));
+                let settings = build_read_settings(&prepared.tool_settings.read)?;
+                builder = builder.tool(
+                    prompt_builder.track(ReadTool::with_settings(AbsolutePathResolver, settings)),
+                );
             }
             ToolCatalogKind::Write => {
                 builder = builder.tool(prompt_builder.track(WriteTool::new(AbsolutePathResolver)))
@@ -136,19 +171,18 @@ where
                 builder = builder.tool(prompt_builder.track(EditTool::new(AbsolutePathResolver)))
             }
             ToolCatalogKind::Glob => {
-                let settings = &prepared.tool_settings.glob;
-                builder = builder.tool(prompt_builder.track(GlobTool::with_settings(
-                    AbsolutePathResolver,
-                    settings.limit,
-                )));
+                let settings = build_glob_settings(&prepared.tool_settings.glob)?;
+                builder = builder.tool(
+                    prompt_builder.track(GlobTool::with_settings(AbsolutePathResolver, settings)),
+                );
             }
             ToolCatalogKind::Grep => {
-                let settings = &prepared.tool_settings.grep;
+                let (search_settings, formatting_settings) =
+                    build_grep_settings(&prepared.tool_settings.grep)?;
                 builder = builder.tool(prompt_builder.track(GrepTool::with_settings(
                     AbsolutePathResolver,
-                    settings.max_line_length,
-                    settings.limit,
-                    settings.line_numbers,
+                    search_settings,
+                    formatting_settings,
                 )));
             }
             ToolCatalogKind::Bash => {
@@ -162,12 +196,8 @@ where
                     ));
             }
             ToolCatalogKind::WebFetch => {
-                let settings = &prepared.tool_settings.webfetch;
-                builder = builder.tool(prompt_builder.track(WebFetchTool::with_settings(
-                    settings.timeout_ms,
-                    Some(settings.max_timeout_ms),
-                    settings.max_response_size_mib,
-                )));
+                let settings = build_webfetch_settings(&prepared.tool_settings.webfetch)?;
+                builder = builder.tool(prompt_builder.track(WebFetchTool::with_settings(settings)));
             }
             ToolCatalogKind::TodoRead => {
                 builder = builder.tool(prompt_builder.track(todo_read.clone()))
@@ -197,27 +227,61 @@ where
     Ok((builder, prompt_builder))
 }
 
-/// Error returned when a build cannot produce a SerdesAI agent.
-#[derive(Debug, thiserror::Error)]
-pub enum AgentBuildError {
-    /// The requested agent name was not found in the runtime catalog.
-    #[error("unknown agent `{name}`")]
-    UnknownAgent {
-        /// The missing agent name.
-        name: Box<str>,
-    },
-    /// The runtime contains a tool kind this adapter cannot materialise.
-    #[error("tool `{name}` is not supported")]
-    UnsupportedToolKind {
-        /// The unsupported tool name.
-        name: Box<str>,
-    },
-    /// Resolving or validating the model configuration failed.
-    #[error(transparent)]
-    ModelResolution(#[from] ModelResolutionError),
-    /// Initializing the SerdesAI model failed.
-    #[error("failed to initialise model: {0}")]
-    ModelInit(#[from] serdes_ai_models::ModelError),
+fn build_read_settings(
+    settings: &llm_coding_tools_agents::ReadToolSettings,
+) -> Result<ReadSettings, AgentBuildError> {
+    ReadSettings::new()
+        .with_limits(settings.limit, settings.limit)
+        .and_then(|value| value.with_max_line_length(settings.max_line_length))
+        .map(|value| value.with_line_numbers(settings.line_numbers))
+        .map_err(|source| AgentBuildError::ToolSettingsValidation {
+            tool: read_meta::NAME,
+            source,
+        })
+}
+
+fn build_grep_settings(
+    settings: &llm_coding_tools_agents::GrepToolSettings,
+) -> Result<(GrepSettings, GrepFormattingSettings), AgentBuildError> {
+    let search_settings = GrepSettings::new()
+        .with_max_limit(settings.limit)
+        .map_err(|source| AgentBuildError::ToolSettingsValidation {
+            tool: grep_meta::NAME,
+            source,
+        })?;
+
+    let formatting_settings = GrepFormattingSettings::new()
+        .with_max_line_length(settings.max_line_length)
+        .map(|value| value.with_line_numbers(settings.line_numbers))
+        .map_err(|source| AgentBuildError::ToolSettingsValidation {
+            tool: grep_meta::NAME,
+            source,
+        })?;
+
+    Ok((search_settings, formatting_settings))
+}
+
+fn build_glob_settings(
+    settings: &llm_coding_tools_agents::GlobToolSettings,
+) -> Result<GlobSettings, AgentBuildError> {
+    GlobSettings::new()
+        .with_limit(settings.limit)
+        .map_err(|source| AgentBuildError::ToolSettingsValidation {
+            tool: glob_meta::NAME,
+            source,
+        })
+}
+
+fn build_webfetch_settings(
+    settings: &llm_coding_tools_agents::WebFetchToolSettings,
+) -> Result<WebFetchSettings, AgentBuildError> {
+    WebFetchSettings::new()
+        .with_timeouts(settings.timeout_ms, settings.max_timeout_ms)
+        .and_then(|value| value.with_max_response_size(settings.max_response_size))
+        .map_err(|source| AgentBuildError::ToolSettingsValidation {
+            tool: webfetch_meta::NAME,
+            source,
+        })
 }
 
 #[cfg(test)]

--- a/src/llm-coding-tools-serdesai/src/tools/glob.rs
+++ b/src/llm-coding-tools-serdesai/src/tools/glob.rs
@@ -15,7 +15,6 @@ use llm_coding_tools_core::context::{PathMode, ToolPrompt};
 use llm_coding_tools_core::path::PathResolver;
 use llm_coding_tools_core::tool_metadata::glob as glob_meta;
 use llm_coding_tools_core::tools::{GlobOutput, GlobRequest, GlobSettings, glob_files};
-use llm_coding_tools_core::util::MIN_LIMIT;
 use serde_json::json;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolResult, ToolReturn};
 
@@ -29,7 +28,7 @@ pub struct GlobTool<R: PathResolver + Clone> {
     definition: ToolDefinition,
     resolver: R,
     path_mode: PathMode,
-    limit: usize,
+    settings: GlobSettings,
 }
 
 impl<R: PathResolver + Clone> GlobTool<R> {
@@ -41,7 +40,7 @@ impl<R: PathResolver + Clone> GlobTool<R> {
     ///
     /// * `R` - A path resolver implementing [`PathResolver`].
     pub fn new(resolver: R) -> Self {
-        Self::with_settings(resolver, glob_meta::MAX_RESULTS)
+        Self::with_settings(resolver, GlobSettings::new())
     }
 
     /// Creates a new glob tool with custom settings.
@@ -49,18 +48,14 @@ impl<R: PathResolver + Clone> GlobTool<R> {
     /// # Arguments
     ///
     /// * `resolver` - The path resolver for path validation.
-    /// * `limit` - Maximum number of files to return per glob call.
-    pub fn with_settings(resolver: R, limit: usize) -> Self {
-        if limit < MIN_LIMIT {
-            panic!("GlobTool::with_settings: limit must be >= {}", MIN_LIMIT);
-        }
-
+    /// * `settings` - Core glob settings for result limits.
+    pub fn with_settings(resolver: R, settings: GlobSettings) -> Self {
         let path_mode = R::PATH_MODE;
         Self {
             definition: build_definition(path_mode),
             resolver,
             path_mode,
-            limit,
+            settings,
         }
     }
 
@@ -81,7 +76,7 @@ impl<R: PathResolver + Clone + Send + Sync, Deps: Send + Sync> Tool<Deps> for Gl
         let args =
             GlobRequest::parse(args).map_err(|e| core_error_to_serdes(glob_meta::NAME, e))?;
 
-        let result = glob_files(&self.resolver, args, GlobSettings { limit: self.limit });
+        let result = glob_files(&self.resolver, args, self.settings);
 
         match result {
             Err(e) => to_serdes_result(glob_meta::NAME, Err(e)),

--- a/src/llm-coding-tools-serdesai/src/tools/grep.rs
+++ b/src/llm-coding-tools-serdesai/src/tools/grep.rs
@@ -16,9 +16,8 @@ use llm_coding_tools_core::context::{PathMode, ToolPrompt};
 use llm_coding_tools_core::path::PathResolver;
 use llm_coding_tools_core::tool_metadata::grep as grep_meta;
 use llm_coding_tools_core::tools::{
-    DEFAULT_MAX_LINE_LENGTH, GrepOutput, GrepRequest, GrepSettings, grep_search,
+    GrepFormattingSettings, GrepOutput, GrepRequest, GrepSettings, grep_search,
 };
-use llm_coding_tools_core::util::{MIN_LIMIT, MIN_LINE_LENGTH};
 use serde_json::json;
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolResult, ToolReturn};
 
@@ -32,9 +31,8 @@ pub struct GrepTool<R: PathResolver + Clone> {
     definition: ToolDefinition,
     resolver: R,
     path_mode: PathMode,
-    max_line_length: usize,
-    limit: usize,
-    line_numbers: bool,
+    search_settings: GrepSettings,
+    formatting_settings: GrepFormattingSettings,
 }
 
 impl<R: PathResolver + Clone> GrepTool<R> {
@@ -47,12 +45,7 @@ impl<R: PathResolver + Clone> GrepTool<R> {
     ///
     /// * `R` - A path resolver implementing [`PathResolver`].
     pub fn new(resolver: R) -> Self {
-        Self::with_settings(
-            resolver,
-            DEFAULT_MAX_LINE_LENGTH,
-            grep_meta::DEFAULT_LIMIT,
-            true,
-        )
+        Self::with_settings(resolver, GrepSettings::new(), GrepFormattingSettings::new())
     }
 
     /// Creates a new grep tool with custom settings.
@@ -60,33 +53,20 @@ impl<R: PathResolver + Clone> GrepTool<R> {
     /// # Arguments
     ///
     /// * `resolver` - The path resolver for path validation.
-    /// * `max_line_length` - Maximum characters per matching line before truncation.
-    /// * `limit` - Maximum number of matches to return when not specified in args.
-    /// * `line_numbers` - Whether to prefix lines with line numbers.
+    /// * `search_settings` - Core grep settings for search limits.
+    /// * `formatting_settings` - Core grep formatting settings for output.
     pub fn with_settings(
         resolver: R,
-        max_line_length: usize,
-        limit: usize,
-        line_numbers: bool,
+        search_settings: GrepSettings,
+        formatting_settings: GrepFormattingSettings,
     ) -> Self {
-        if limit < MIN_LIMIT {
-            panic!("GrepTool::with_settings: limit must be >= {}", MIN_LIMIT);
-        }
-        if max_line_length < MIN_LINE_LENGTH {
-            panic!(
-                "GrepTool::with_settings: max_line_length must be >= {}",
-                MIN_LINE_LENGTH
-            );
-        }
-
         let path_mode = R::PATH_MODE;
         Self {
-            definition: build_definition(path_mode, line_numbers),
+            definition: build_definition(path_mode, formatting_settings.line_numbers()),
             resolver,
             path_mode,
-            max_line_length,
-            limit,
-            line_numbers,
+            search_settings,
+            formatting_settings,
         }
     }
 
@@ -107,34 +87,20 @@ impl<R: PathResolver + Clone + Send + Sync, Deps: Send + Sync> Tool<Deps> for Gr
         let args =
             GrepRequest::parse(args).map_err(|e| core_error_to_serdes(grep_meta::NAME, e))?;
 
-        let result = grep_search(
-            &self.resolver,
-            args,
-            GrepSettings {
-                max_limit: self.limit,
-            },
-        );
+        let result = grep_search(&self.resolver, args, self.search_settings);
 
         match result {
             Err(e) => to_serdes_result(grep_meta::NAME, Err(e)),
-            Ok(grep_output) => Ok(grep_output_to_return(
-                grep_output,
-                self.line_numbers,
-                self.max_line_length,
-            )),
+            Ok(grep_output) => Ok(grep_output_to_return(grep_output, self.formatting_settings)),
         }
     }
 }
 
 const NO_MATCHES_FOUND: &str = "No matches found.";
 
-fn grep_output_to_return(
-    output: GrepOutput,
-    line_numbers: bool,
-    max_line_len: usize,
-) -> ToolReturn {
+fn grep_output_to_return(output: GrepOutput, formatting: GrepFormattingSettings) -> ToolReturn {
     if output.partial {
-        let content = output.format(line_numbers, max_line_len);
+        let content = output.format(formatting);
         return ToolReturn::json(json!({
             "content": content,
             "partial": true,
@@ -148,7 +114,7 @@ fn grep_output_to_return(
         return ToolReturn::text(NO_MATCHES_FOUND);
     }
 
-    ToolReturn::text(output.format(line_numbers, max_line_len))
+    ToolReturn::text(output.format(formatting))
 }
 
 impl<R: PathResolver + Clone> ToolContext for GrepTool<R> {
@@ -157,7 +123,7 @@ impl<R: PathResolver + Clone> ToolContext for GrepTool<R> {
     fn context(&self) -> ToolPrompt {
         ToolPrompt::Grep {
             path_mode: self.path_mode,
-            line_numbers: self.line_numbers,
+            line_numbers: self.formatting_settings.line_numbers(),
         }
     }
 }
@@ -384,7 +350,7 @@ mod tests {
                 // Line format is "  L1: content", so actual content is line.len() - prefix
                 let content_start = line.find("prefix_").unwrap();
                 let content = &line[content_start..];
-                assert!(content.len() <= DEFAULT_MAX_LINE_LENGTH);
+                assert!(content.len() <= llm_coding_tools_core::tools::DEFAULT_MAX_LINE_LENGTH);
             }
         }
     }
@@ -443,11 +409,12 @@ mod tests {
         std::fs::write(dir.path().join("test.txt"), "alpha\nbeta\ngamma\n").unwrap();
 
         // Tool configured with limit=1, but caller requests limit=3
+        let search_settings = GrepSettings::new().with_max_limit(1).unwrap();
+        let formatting_settings = GrepFormattingSettings::new();
         let tool = GrepTool::with_settings(
             AllowedPathResolver::new([dir.path()]).unwrap(),
-            DEFAULT_MAX_LINE_LENGTH,
-            1,
-            true,
+            search_settings,
+            formatting_settings,
         );
 
         let result = tool
@@ -467,6 +434,16 @@ mod tests {
         assert!(text.contains("L1: alpha"));
         assert!(!text.contains("L2: beta"));
         assert!(!text.contains("L3: gamma"));
+    }
+
+    #[test]
+    fn grep_tool_should_use_core_formatting_settings() {
+        let resolver = AbsolutePathResolver;
+        let search_settings = GrepSettings::new().with_max_limit(1).unwrap();
+        let formatting_settings = GrepFormattingSettings::new().with_line_numbers(false);
+        let tool = GrepTool::with_settings(resolver, search_settings, formatting_settings);
+        assert_eq!(tool.search_settings, search_settings);
+        assert_eq!(tool.formatting_settings, formatting_settings);
     }
 
     #[test]

--- a/src/llm-coding-tools-serdesai/src/tools/read.rs
+++ b/src/llm-coding-tools-serdesai/src/tools/read.rs
@@ -29,7 +29,6 @@ use llm_coding_tools_core::context::{PathMode, ToolPrompt};
 use llm_coding_tools_core::path::PathResolver;
 use llm_coding_tools_core::tool_metadata::read as read_meta;
 use llm_coding_tools_core::tools::{ReadRequest, ReadSettings, read_file};
-use llm_coding_tools_core::util::{MIN_LIMIT, MIN_LINE_LENGTH};
 use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolResult};
 
 use crate::convert::{core_error_to_serdes, to_serdes_result};
@@ -43,9 +42,7 @@ pub struct ReadTool<R: PathResolver + Clone> {
     definition: ToolDefinition,
     resolver: R,
     path_mode: PathMode,
-    limit: usize,
-    max_line_length: usize,
-    line_numbers: bool,
+    settings: ReadSettings,
 }
 
 impl<R: PathResolver + Clone> ReadTool<R> {
@@ -58,12 +55,7 @@ impl<R: PathResolver + Clone> ReadTool<R> {
     ///
     /// * `R` - A path resolver implementing [`PathResolver`].
     pub fn new(resolver: R) -> Self {
-        Self::with_settings(
-            resolver,
-            read_meta::DEFAULT_LIMIT,
-            read_meta::MAX_LINE_LENGTH,
-            true,
-        )
+        Self::with_settings(resolver, ReadSettings::new())
     }
 
     /// Creates a new read tool with custom settings.
@@ -71,33 +63,14 @@ impl<R: PathResolver + Clone> ReadTool<R> {
     /// # Arguments
     ///
     /// * `resolver` - The path resolver for path validation and resolution.
-    /// * `limit` - Maximum number of lines to return per read call.
-    /// * `max_line_length` - Maximum characters per line before truncation.
-    /// * `line_numbers` - Whether to prefix lines with line numbers.
-    pub fn with_settings(
-        resolver: R,
-        limit: usize,
-        max_line_length: usize,
-        line_numbers: bool,
-    ) -> Self {
-        if limit < MIN_LIMIT {
-            panic!("ReadTool::with_settings: limit must be >= {}", MIN_LIMIT);
-        }
-        if max_line_length < MIN_LINE_LENGTH {
-            panic!(
-                "ReadTool::with_settings: max_line_length must be >= {}",
-                MIN_LINE_LENGTH
-            );
-        }
-
+    /// * `settings` - Core read settings for limits and formatting.
+    pub fn with_settings(resolver: R, settings: ReadSettings) -> Self {
         let path_mode = R::PATH_MODE;
         Self {
-            definition: build_definition(path_mode, line_numbers),
+            definition: build_definition(path_mode, settings.line_numbers()),
             resolver,
             path_mode,
-            limit,
-            max_line_length,
-            line_numbers,
+            settings,
         }
     }
 
@@ -120,17 +93,7 @@ impl<R: PathResolver + Clone + Send + Sync, Deps: Send + Sync> Tool<Deps> for Re
         let args =
             ReadRequest::parse(args).map_err(|e| core_error_to_serdes(read_meta::NAME, e))?;
 
-        let result = read_file(
-            &self.resolver,
-            args,
-            ReadSettings {
-                default_limit: self.limit,
-                max_limit: self.limit,
-                max_line_length: self.max_line_length,
-                line_numbers: self.line_numbers,
-            },
-        )
-        .await;
+        let result = read_file(&self.resolver, args, self.settings).await;
         to_serdes_result(read_meta::NAME, result)
     }
 }
@@ -141,7 +104,7 @@ impl<R: PathResolver + Clone> ToolContext for ReadTool<R> {
     fn context(&self) -> ToolPrompt {
         ToolPrompt::Read {
             path_mode: self.path_mode,
-            line_numbers: self.line_numbers,
+            line_numbers: self.settings.line_numbers(),
         }
     }
 }
@@ -202,6 +165,18 @@ mod tests {
 
     fn mock_ctx() -> RunContext<()> {
         RunContext::new((), "test-model")
+    }
+
+    #[test]
+    fn read_tool_should_use_custom_core_settings() {
+        let settings = ReadSettings::new()
+            .with_limits(1, 1)
+            .unwrap()
+            .with_max_line_length(100)
+            .unwrap()
+            .with_line_numbers(false);
+        let tool = ReadTool::with_settings(AbsolutePathResolver, settings);
+        assert_eq!(tool.settings, settings);
     }
 
     #[tokio::test]
@@ -274,7 +249,13 @@ mod tests {
     async fn respects_custom_settings() {
         let mut temp = NamedTempFile::new().unwrap();
         temp.write_all(b"line1\nline2\n").unwrap();
-        let tool = ReadTool::with_settings(AbsolutePathResolver, 1, 100, false);
+        let settings = ReadSettings::new()
+            .with_limits(1, 1)
+            .unwrap()
+            .with_max_line_length(100)
+            .unwrap()
+            .with_line_numbers(false);
+        let tool = ReadTool::with_settings(AbsolutePathResolver, settings);
 
         let result = tool
             .call(
@@ -295,7 +276,11 @@ mod tests {
     async fn caps_requested_limit_at_tool_limit() {
         let mut temp = NamedTempFile::new().unwrap();
         temp.write_all(b"line1\nline2\nline3\n").unwrap();
-        let tool = ReadTool::with_settings(AbsolutePathResolver, 1, 100, true);
+        let settings = ReadSettings::new()
+            .with_limits(1, 1)
+            .unwrap()
+            .with_line_numbers(true);
+        let tool = ReadTool::with_settings(AbsolutePathResolver, settings);
 
         let result = tool
             .call(

--- a/src/llm-coding-tools-serdesai/src/tools/webfetch.rs
+++ b/src/llm-coding-tools-serdesai/src/tools/webfetch.rs
@@ -24,9 +24,7 @@ use serdes_ai::tools::{RunContext, SchemaBuilder, Tool, ToolDefinition, ToolResu
 pub struct WebFetchTool {
     client: reqwest::Client,
     definition: ToolDefinition,
-    default_timeout_ms: u32,
-    max_timeout_ms: u32,
-    max_response_size: usize,
+    settings: WebFetchSettings,
 }
 
 impl Default for WebFetchTool {
@@ -38,22 +36,16 @@ impl Default for WebFetchTool {
 impl WebFetchTool {
     /// Creates a new webfetch tool with default client and settings.
     pub fn new() -> Self {
-        Self::with_settings(
-            webfetch_meta::DEFAULT_TIMEOUT_MS,
-            None,
-            webfetch_meta::MAX_RESPONSE_SIZE_MIB,
-        )
+        Self::with_settings(WebFetchSettings::new())
     }
 
     /// Creates a webfetch tool with a custom client and default settings.
     pub fn with_client(client: reqwest::Client) -> Self {
-        let max_timeout_ms = webfetch_meta::MAX_TIMEOUT_MS;
+        let settings = WebFetchSettings::new();
         Self {
             client,
-            definition: build_definition(max_timeout_ms),
-            default_timeout_ms: webfetch_meta::DEFAULT_TIMEOUT_MS,
-            max_timeout_ms,
-            max_response_size: webfetch_meta::MAX_RESPONSE_SIZE_MIB * 1024 * 1024,
+            definition: build_definition(settings.max_timeout_ms()),
+            settings,
         }
     }
 
@@ -61,41 +53,12 @@ impl WebFetchTool {
     ///
     /// # Arguments
     ///
-    /// * `default_timeout_ms` - Default timeout for web requests (must be >= 1)
-    /// * `max_timeout_ms` - Maximum timeout allowed for LLM requests (defaults to MAX_TIMEOUT_MS)
-    /// * `max_response_size_mib` - Maximum response size in mebibytes
-    ///
-    /// # Panics
-    ///
-    /// Panics if `default_timeout_ms` is 0 or exceeds `max_timeout_ms`.
-    pub fn with_settings(
-        default_timeout_ms: u32,
-        max_timeout_ms: Option<u32>,
-        max_response_size_mib: usize,
-    ) -> Self {
-        let max_timeout_ms = max_timeout_ms.unwrap_or(webfetch_meta::MAX_TIMEOUT_MS);
-
-        if max_timeout_ms == 0 {
-            panic!("max_timeout_ms must be at least 1");
-        }
-
-        if default_timeout_ms == 0 {
-            panic!("default_timeout_ms must be at least 1");
-        }
-        if default_timeout_ms > max_timeout_ms {
-            panic!(
-                "default_timeout_ms ({}) cannot exceed max_timeout_ms ({})",
-                default_timeout_ms, max_timeout_ms
-            );
-        }
-
-        let max_response_size = max_response_size_mib.saturating_mul(1024 * 1024);
+    /// * `settings` - Core webfetch settings for timeouts and size limits.
+    pub fn with_settings(settings: WebFetchSettings) -> Self {
         Self {
             client: reqwest::Client::new(),
-            definition: build_definition(max_timeout_ms),
-            default_timeout_ms,
-            max_timeout_ms,
-            max_response_size,
+            definition: build_definition(settings.max_timeout_ms()),
+            settings,
         }
     }
 }
@@ -110,16 +73,7 @@ impl<Deps: Send + Sync> Tool<Deps> for WebFetchTool {
         let args = WebFetchRequest::parse(args)
             .map_err(|e| core_error_to_serdes(webfetch_meta::NAME, e))?;
 
-        let result = fetch_url(
-            &self.client,
-            args,
-            WebFetchSettings {
-                default_timeout_ms: self.default_timeout_ms,
-                max_timeout_ms: self.max_timeout_ms,
-                max_response_size: self.max_response_size,
-            },
-        )
-        .await;
+        let result = fetch_url(&self.client, args, self.settings).await;
 
         to_serdes_result(webfetch_meta::NAME, result.map(ToolOutput::from))
     }


### PR DESCRIPTION
## Summary

This PR refactors the Core settings types (`ReadSettings`, `GlobSettings`, `GrepSettings`, `GrepFormattingSettings`, and `WebFetchSettings`) to use explicit constructors with private fields and grouped, validating setters. It also converts the `serdesai` adapter tools to serve as pure wiring/storage helpers that delegate to Core settings directly.

## Changes

- **Core Settings API**: Add `new()` constructors and `#[must_use]` getters, replacing public fields with private ones
- **Grouped Setters**: Replace individual field setters with validating grouped setters (e.g., `with_limits()` that ensures `default_limit <= max_limit`)
- **Serdesai Adapters**: Convert `ReadTool`, `GlobTool`, `GrepTool`, and `WebFetchTool` to store Core settings directly instead of duplicating fields
- **Validation**: Move Read/Glob/Grep/WebFetch validation from serdesai adapters to Core builder calls at agent build time
- **Error Handling**: Add `AgentBuildError::ToolSettingsValidation` variant for build-time validation failures
- **Documentation**: Add `Errors` sections to all `with_*` methods returning `Result` with reference-style intra-doc links
- **Config Format**: Rename `max_response_size_mib` to `max_response_size` (bytes) in WebFetch config; update README.md and tool prompt documentation

## Breaking Changes

⚠️ **Settings structs no longer have public fields** - users must use the new `new()` constructors and `with_*()` setters.

⚠️ **WebFetch config renamed** - `max_response_size_mib` is now `max_response_size` (in bytes).

## Migration Guide

```rust
// Before
let settings = ReadSettings {
    default_limit: 50,
    max_limit: 200,
    max_total_chars: 100000,
    include_line_numbers: true,
};

// After
let settings = ReadSettings::new()
    .with_limits(50, 200)?  // validates default <= max
    .with_max_total_chars(100000);
```