### PR TITLE
Optimize path resolver performance with early rejection and fast path

### DIFF
--- a/src/llm-coding-tools-core/Cargo.toml
+++ b/src/llm-coding-tools-core/Cargo.toml
@@ -120,3 +120,7 @@ rstest = "0.26"
 [[bench]]
 name = "model_catalog_builder"
 harness = false
+
+[[bench]]
+name = "path_resolvers"
+harness = false

--- a/src/llm-coding-tools-core/benches/path_resolvers.rs
+++ b/src/llm-coding-tools-core/benches/path_resolvers.rs
@@ -6,36 +6,45 @@
 //!
 //! - `resolvers`: Compares [`AllowedPathResolver`] and [`AllowedGlobResolver`] on the same paths
 //! - `multiple_bases`: Tests [`AllowedPathResolver`] with multiple base directories
+//! - `canonicalize`: Isolates `canonicalize` vs `soft_canonicalize` performance
 //!
 //! # Test Cases
 //!
 //! ```text
-//! | Case              | Path                                               | What it tests                                  |
-//! |-------------------|----------------------------------------------------|------------------------------------------------|
-//! | existing_file     | src/lib.rs                                         | Fast path: file exists, canonicalize succeeds  |
-//! | new_file          | benchmarks/new_file_test.rs                        | Slow path: soft-canonicalize for non-existent  |
-//! | deep_nested       | src/llm-coding-tools-core/src/path/.../policy.rs   | Longer path, more components to process        |
-//! | traversal_reject  | ../../../outside.txt                               | Early rejection via lexical escape check       |
+//! | Case                   | Path                                               | What it tests                                  |
+//! |------------------------|----------------------------------------------------|------------------------------------------------|
+//! | existing_file          | src/lib.rs                                         | Fast path: file exists, canonicalize succeeds  |
+//! | new_file_existing_dir  | src/new_file_test.rs                               | Fast path: parent exists, canonicalize parent   |
+//! | new_file_missing_dir   | benchmarks/new_file_test.rs                        | Slow path: soft-canonicalize for non-existent  |
+//! | deep_nested            | src/llm-coding-tools-core/src/path/.../policy.rs   | Longer path, more components to process        |
+//! | traversal_reject       | ../../../outside.txt                               | Early rejection via lexical escape check       |
 //! ```
 //!
 //! # Reference Results (Linux, optimized build)
 //!
 //! ```text
-//! resolvers/AllowedPathResolver/existing_file       ~1.7-1.8 µs
-//! resolvers/AllowedPathResolver/new_file            ~7.8-8.0 µs
-//! resolvers/AllowedPathResolver/deep_nested         ~10.2-10.5 µs
-//! resolvers/AllowedPathResolver/traversal_reject    ~20 ns
+//! resolvers/AllowedPathResolver/existing_file          ~1.8 µs
+//! resolvers/AllowedPathResolver/new_file_existing_dir ~3.5 µs  (optimized: parent canonicalize)
+//! resolvers/AllowedPathResolver/new_file_missing_dir  ~8.1 µs  (fallback: soft_canonicalize)
+//! resolvers/AllowedPathResolver/deep_nested           ~10.5 µs
+//! resolvers/AllowedPathResolver/traversal_reject      ~20 ns
 //!
-//! resolvers/AllowedGlobResolver_simple_policy/existing_file     ~2.0-2.1 µs
-//! resolvers/AllowedGlobResolver_simple_policy/new_file          ~8.0-8.1 µs
-//! resolvers/AllowedGlobResolver_simple_policy/deep_nested       ~10.5-10.8 µs
-//! resolvers/AllowedGlobResolver_simple_policy/traversal_reject  ~20 ns
+//! resolvers/AllowedGlobResolver_simple_policy/existing_file          ~2.0 µs
+//! resolvers/AllowedGlobResolver_simple_policy/new_file_existing_dir  ~3.8 µs
+//! resolvers/AllowedGlobResolver_simple_policy/new_file_missing_dir   ~8.4 µs
+//! resolvers/AllowedGlobResolver_simple_policy/deep_nested            ~10.8 µs
+//! resolvers/AllowedGlobResolver_simple_policy/traversal_reject       ~20 ns
 //!
-//! resolvers/AllowedGlobResolver_complex_policy/existing_file     ~2.1-2.2 µs
-//! resolvers/AllowedGlobResolver_complex_policy/new_file          ~7.9-8.1 µs
-//! resolvers/AllowedGlobResolver_complex_policy/deep_nested       ~10.8-11.0 µs
-//! resolvers/AllowedGlobResolver_complex_policy/traversal_reject  ~20 ns
+//! canonicalize/existing_file_canonicalize         ~1.6 µs
+//! canonicalize/existing_file_soft_canonicalize    ~4.4 µs  (2.7x slower than canonicalize)
+//! canonicalize/new_file_shallow_soft_canonicalize ~6.0 µs
+//! canonicalize/new_file_deep_soft_canonicalize    ~7.0 µs
 //! ```
+//!
+//! # Platform Differences
+//!
+//! On Unix, new files in existing directories use the fast path (canonicalize parent + join filename).
+//! On Windows, the fast path uses `soft_canonicalize` due to complex path semantics.
 //!
 //! # Running Benchmarks
 //!
@@ -56,11 +65,13 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 use llm_coding_tools_core::path::{
     AllowedGlobResolver, AllowedPathResolver, GlobPolicy, GlobPolicyBuilder, PathResolver,
 };
+use soft_canonicalize::soft_canonicalize;
 use std::fs;
 use tempfile::TempDir;
 
 const EXISTING_FILE: &str = "src/lib.rs";
-const NEW_FILE: &str = "benchmarks/new_file_test.rs";
+const NEW_FILE_EXISTING_DIR: &str = "src/new_file_test.rs";
+const NEW_FILE_MISSING_DIR: &str = "benchmarks/new_file_test.rs";
 const DEEP_NESTED: &str = "src/llm-coding-tools-core/src/path/allowed_glob/policy.rs";
 const TRAVERSAL: &str = "../../../outside.txt";
 
@@ -85,15 +96,16 @@ where
 /// | AllowedGlobResolver_complex     | 10 rules: realistic project config       |
 /// ```
 ///
-/// # Expected Performance
+/// # Expected Performance (Unix)
 ///
 /// ```text
-/// | Case              | Expected Time | Why                                    |
-/// |-------------------|---------------|----------------------------------------|
-/// | existing_file     | 1-2 µs        | canonicalize is fast for existing      |
-/// | new_file          | 7-8 µs        | soft-canonicalize walks filesystem     |
-/// | deep_nested       | 10-11 µs      | more path components to process        |
-/// | traversal_reject  | ~20 ns        | lexical check only, no filesystem I/O  |
+/// | Case                   | Expected Time | Why                                    |
+/// |------------------------|---------------|----------------------------------------|
+/// | existing_file          | 1-2 µs        | canonicalize is fast for existing      |
+/// | new_file_existing_dir  | 3-4 µs        | canonicalize parent, join filename     |
+/// | new_file_missing_dir   | 7-8 µs        | soft-canonicalize walks filesystem     |
+/// | deep_nested            | 10-11 µs      | more path components to process        |
+/// | traversal_reject       | ~20 ns        | lexical check only, no filesystem I/O  |
 /// ```
 fn bench_resolvers_same_paths(c: &mut Criterion) {
     let mut group = c.benchmark_group("resolvers");
@@ -133,7 +145,8 @@ fn bench_resolvers_same_paths(c: &mut Criterion) {
 
     for (case_name, path_input) in [
         ("existing_file", EXISTING_FILE),
-        ("new_file", NEW_FILE),
+        ("new_file_existing_dir", NEW_FILE_EXISTING_DIR),
+        ("new_file_missing_dir", NEW_FILE_MISSING_DIR),
         ("deep_nested", DEEP_NESTED),
         ("traversal_reject", TRAVERSAL),
     ] {
@@ -182,7 +195,7 @@ fn bench_resolvers_same_paths(c: &mut Criterion) {
 /// | first_base  | Path found in first base (fastest)          |
 /// | second_base | Path found in second base (one miss, hit)   |
 /// | third_base  | Path found in third base (two misses, hit)  |
-/// | not_found   | Path not in any base (all bases tried)      |
+/// | not_found   | Path not in any base (all bases tried)     |
 /// ```
 fn bench_multiple_bases(c: &mut Criterion) {
     let mut group = c.benchmark_group("multiple_bases");
@@ -217,6 +230,53 @@ fn bench_multiple_bases(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_resolvers_same_paths, bench_multiple_bases);
+/// Benchmarks `std::fs::canonicalize` vs `soft_canonicalize` directly.
+///
+/// Isolates the core filesystem operation to understand where time is spent.
+///
+/// # Test Cases
+///
+/// ```text
+/// | Case              | Path                          | canonicalize | soft_canonicalize |
+/// |-------------------|-------------------------------|--------------|-------------------|
+/// | existing_file     | src/lib.rs (exists)           | O(1) FS call | O(1) FS call      |
+/// | new_file_shallow  | new_file.rs (in root)         | N/A          | O(1) FS call      |
+/// | new_file_deep     | a/b/c/new_file.rs (3 levels)  | N/A          | O(4) FS calls     |
+/// ```
+fn bench_canonicalize_vs_soft(c: &mut Criterion) {
+    let mut group = c.benchmark_group("canonicalize");
+
+    let current_dir = std::env::current_dir().unwrap();
+    let existing = current_dir.join("src/lib.rs");
+    let new_shallow = current_dir.join("new_file.rs");
+    let new_deep = current_dir.join("a/b/c/new_file.rs");
+
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("existing_file_canonicalize", |b| {
+        b.iter(|| existing.canonicalize().unwrap())
+    });
+
+    group.bench_function("existing_file_soft_canonicalize", |b| {
+        b.iter(|| soft_canonicalize(&existing).unwrap())
+    });
+
+    group.bench_function("new_file_shallow_soft_canonicalize", |b| {
+        b.iter(|| soft_canonicalize(&new_shallow).unwrap())
+    });
+
+    group.bench_function("new_file_deep_soft_canonicalize", |b| {
+        b.iter(|| soft_canonicalize(&new_deep).unwrap())
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_resolvers_same_paths,
+    bench_multiple_bases,
+    bench_canonicalize_vs_soft
+);
 
 criterion_main!(benches);

--- a/src/llm-coding-tools-core/benches/path_resolvers.rs
+++ b/src/llm-coding-tools-core/benches/path_resolvers.rs
@@ -1,0 +1,228 @@
+//! Benchmarks for path resolver implementations.
+//!
+//! Tests performance on real filesystem paths using the current workspace.
+//!
+//! # Benchmark Groups
+//!
+//! - `resolvers`: Compares [`AllowedPathResolver`] and [`AllowedGlobResolver`] on the same paths
+//! - `multiple_bases`: Tests [`AllowedPathResolver`] with multiple base directories
+//!
+//! # Test Cases
+//!
+//! ```text
+//! | Case              | Path                                               | What it tests                                  |
+//! |-------------------|----------------------------------------------------|------------------------------------------------|
+//! | existing_file     | src/lib.rs                                         | Fast path: file exists, canonicalize succeeds  |
+//! | new_file          | benchmarks/new_file_test.rs                        | Slow path: soft-canonicalize for non-existent  |
+//! | deep_nested       | src/llm-coding-tools-core/src/path/.../policy.rs   | Longer path, more components to process        |
+//! | traversal_reject  | ../../../outside.txt                               | Early rejection via lexical escape check       |
+//! ```
+//!
+//! # Reference Results (Linux, optimized build)
+//!
+//! ```text
+//! resolvers/AllowedPathResolver/existing_file       ~1.7-1.8 µs
+//! resolvers/AllowedPathResolver/new_file            ~7.8-8.0 µs
+//! resolvers/AllowedPathResolver/deep_nested         ~10.2-10.5 µs
+//! resolvers/AllowedPathResolver/traversal_reject    ~20 ns
+//!
+//! resolvers/AllowedGlobResolver_simple_policy/existing_file     ~2.0-2.1 µs
+//! resolvers/AllowedGlobResolver_simple_policy/new_file          ~8.0-8.1 µs
+//! resolvers/AllowedGlobResolver_simple_policy/deep_nested       ~10.5-10.8 µs
+//! resolvers/AllowedGlobResolver_simple_policy/traversal_reject  ~20 ns
+//!
+//! resolvers/AllowedGlobResolver_complex_policy/existing_file     ~2.1-2.2 µs
+//! resolvers/AllowedGlobResolver_complex_policy/new_file          ~7.9-8.1 µs
+//! resolvers/AllowedGlobResolver_complex_policy/deep_nested       ~10.8-11.0 µs
+//! resolvers/AllowedGlobResolver_complex_policy/traversal_reject  ~20 ns
+//! ```
+//!
+//! # Running Benchmarks
+//!
+//! Quick run (1s per benchmark):
+//! ```sh
+//! cargo bench -p llm-coding-tools-core --bench path_resolvers -- --sample-size 10 --measurement-time 1 --warm-up-time 1
+//! ```
+//!
+//! Full run with baseline comparison:
+//! ```sh
+//! cargo bench -p llm-coding-tools-core --bench path_resolvers -- --save-baseline main
+//! # make changes, then:
+//! cargo bench -p llm-coding-tools-core --bench path_resolvers -- --baseline main
+//! ```
+
+use core::hint::black_box;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use llm_coding_tools_core::path::{
+    AllowedGlobResolver, AllowedPathResolver, GlobPolicy, PathResolver,
+};
+use std::fs;
+use tempfile::TempDir;
+
+const EXISTING_FILE: &str = "src/lib.rs";
+const NEW_FILE: &str = "benchmarks/new_file_test.rs";
+const DEEP_NESTED: &str = "src/llm-coding-tools-core/src/path/allowed_glob/policy.rs";
+const TRAVERSAL: &str = "../../../outside.txt";
+
+/// Benchmarks [`AllowedPathResolver`] and [`AllowedGlobResolver`] on the same paths.
+///
+/// This group measures the core resolve operation under different conditions.
+///
+/// # Resolvers Compared
+///
+/// ```text
+/// | Resolver                        | Description                              |
+/// |---------------------------------|------------------------------------------|
+/// | AllowedPathResolver             | Baseline: no glob policy                 |
+/// | AllowedGlobResolver_simple      | Single rule: src/**/*.rs                 |
+/// | AllowedGlobResolver_complex     | 10 rules: realistic project config       |
+/// ```
+///
+/// # Expected Performance
+///
+/// ```text
+/// | Case              | Expected Time | Why                                    |
+/// |-------------------|---------------|----------------------------------------|
+/// | existing_file     | 1-2 µs        | canonicalize is fast for existing      |
+/// | new_file          | 7-8 µs        | soft-canonicalize walks filesystem     |
+/// | deep_nested       | 10-11 µs      | more path components to process        |
+/// | traversal_reject  | ~20 ns        | lexical check only, no filesystem I/O  |
+/// ```
+fn bench_resolvers_same_paths(c: &mut Criterion) {
+    let mut group = c.benchmark_group("resolvers");
+
+    let current_dir = std::env::current_dir().unwrap();
+
+    // Baseline: AllowedPathResolver (no glob policy)
+    let allowed = AllowedPathResolver::new(vec![current_dir.clone()]).unwrap();
+
+    // Simple policy: single glob pattern (src/**/*.rs)
+    // This tests minimal glob matching overhead.
+    let simple_policy = GlobPolicy::builder()
+        .allow("src/**/*.rs")
+        .unwrap()
+        .build()
+        .unwrap();
+
+    // Complex policy: 10 rules simulating a realistic project configuration.
+    // Tests last-match-wins semantics and rule iteration overhead.
+    let complex_policy = GlobPolicy::builder()
+        .allow("src/**/*.rs")
+        .unwrap()
+        .deny("target/**")
+        .unwrap()
+        .allow("*.toml")
+        .unwrap()
+        .deny("*.log")
+        .unwrap()
+        .allow("benches/**")
+        .unwrap()
+        .deny("**/test_data/**")
+        .unwrap()
+        .allow("tests/**/*.rs")
+        .unwrap()
+        .deny("node_modules/**")
+        .unwrap()
+        .allow("examples/**")
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let glob_simple = AllowedGlobResolver::new(vec![current_dir.clone()])
+        .unwrap()
+        .with_policy(simple_policy);
+    let glob_complex = AllowedGlobResolver::new(vec![current_dir.clone()])
+        .unwrap()
+        .with_policy(complex_policy);
+
+    group.throughput(Throughput::Elements(1));
+
+    for (case_name, path_input) in [
+        ("existing_file", EXISTING_FILE),
+        ("new_file", NEW_FILE),
+        ("deep_nested", DEEP_NESTED),
+        ("traversal_reject", TRAVERSAL),
+    ] {
+        group.bench_with_input(
+            BenchmarkId::new("AllowedPathResolver", case_name),
+            &allowed,
+            |b, resolver| b.iter(|| resolver.resolve(black_box(path_input))),
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("AllowedGlobResolver_simple_policy", case_name),
+            &glob_simple,
+            |b, resolver| b.iter(|| resolver.resolve(black_box(path_input))),
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("AllowedGlobResolver_complex_policy", case_name),
+            &glob_complex,
+            |b, resolver| b.iter(|| resolver.resolve(black_box(path_input))),
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmarks [`AllowedPathResolver`] with multiple base directories.
+///
+/// Tests how the resolver performs when it must search through multiple
+/// allowed directories to find a match.
+///
+/// # Setup
+///
+/// ```text
+/// | Base    | Directory         | Contains     |
+/// |---------|-------------------|--------------|
+/// | Base 1  | Current workspace | src/lib.rs   |
+/// | Base 2  | Temp directory 1  | file1.txt    |
+/// | Base 3  | Temp directory 2  | file2.txt    |
+/// ```
+///
+/// # Test Cases
+///
+/// ```text
+/// | Case        | What it tests                              |
+/// |-------------|--------------------------------------------|
+/// | first_base  | Path found in first base (fastest)          |
+/// | second_base | Path found in second base (one miss, hit)   |
+/// | third_base  | Path found in third base (two misses, hit)  |
+/// | not_found   | Path not in any base (all bases tried)      |
+/// ```
+fn bench_multiple_bases(c: &mut Criterion) {
+    let mut group = c.benchmark_group("multiple_bases");
+
+    let current_dir = std::env::current_dir().unwrap();
+    let temp1 = TempDir::new().unwrap();
+    let temp2 = TempDir::new().unwrap();
+
+    fs::write(temp1.path().join("file1.txt"), "content").unwrap();
+    fs::write(temp2.path().join("file2.txt"), "content").unwrap();
+
+    let resolver = AllowedPathResolver::new(vec![
+        current_dir.clone(),
+        temp1.path().to_path_buf(),
+        temp2.path().to_path_buf(),
+    ])
+    .unwrap();
+
+    group.throughput(Throughput::Elements(1));
+
+    for (case_name, path_input) in [
+        ("first_base", "src/lib.rs"),
+        ("second_base", "file1.txt"),
+        ("third_base", "file2.txt"),
+        ("not_found", "nonexistent.xyz"),
+    ] {
+        group.bench_function(case_name, |b| {
+            b.iter(|| resolver.resolve(black_box(path_input)))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_resolvers_same_paths, bench_multiple_bases);
+
+criterion_main!(benches);

--- a/src/llm-coding-tools-core/benches/path_resolvers.rs
+++ b/src/llm-coding-tools-core/benches/path_resolvers.rs
@@ -54,7 +54,7 @@
 use core::hint::black_box;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use llm_coding_tools_core::path::{
-    AllowedGlobResolver, AllowedPathResolver, GlobPolicy, PathResolver,
+    AllowedGlobResolver, AllowedPathResolver, GlobPolicy, GlobPolicyBuilder, PathResolver,
 };
 use std::fs;
 use tempfile::TempDir;
@@ -63,6 +63,13 @@ const EXISTING_FILE: &str = "src/lib.rs";
 const NEW_FILE: &str = "benchmarks/new_file_test.rs";
 const DEEP_NESTED: &str = "src/llm-coding-tools-core/src/path/allowed_glob/policy.rs";
 const TRAVERSAL: &str = "../../../outside.txt";
+
+fn build_policy<F>(f: F) -> llm_coding_tools_core::error::ToolResult<GlobPolicy>
+where
+    F: FnOnce(GlobPolicyBuilder) -> llm_coding_tools_core::error::ToolResult<GlobPolicyBuilder>,
+{
+    f(GlobPolicy::builder()).and_then(|b| b.build())
+}
 
 /// Benchmarks [`AllowedPathResolver`] and [`AllowedGlobResolver`] on the same paths.
 ///
@@ -98,35 +105,22 @@ fn bench_resolvers_same_paths(c: &mut Criterion) {
 
     // Simple policy: single glob pattern (src/**/*.rs)
     // This tests minimal glob matching overhead.
-    let simple_policy = GlobPolicy::builder()
-        .allow("src/**/*.rs")
-        .unwrap()
-        .build()
-        .unwrap();
+    let simple_policy = build_policy(|b| b.allow("src/**/*.rs")).unwrap();
 
     // Complex policy: 10 rules simulating a realistic project configuration.
     // Tests last-match-wins semantics and rule iteration overhead.
-    let complex_policy = GlobPolicy::builder()
-        .allow("src/**/*.rs")
-        .unwrap()
-        .deny("target/**")
-        .unwrap()
-        .allow("*.toml")
-        .unwrap()
-        .deny("*.log")
-        .unwrap()
-        .allow("benches/**")
-        .unwrap()
-        .deny("**/test_data/**")
-        .unwrap()
-        .allow("tests/**/*.rs")
-        .unwrap()
-        .deny("node_modules/**")
-        .unwrap()
-        .allow("examples/**")
-        .unwrap()
-        .build()
-        .unwrap();
+    let complex_policy = build_policy(|b| {
+        b.allow("src/**/*.rs")?
+            .deny("target/**")?
+            .allow("*.toml")?
+            .deny("*.log")?
+            .allow("benches/**")?
+            .deny("**/test_data/**")?
+            .allow("tests/**/*.rs")?
+            .deny("node_modules/**")?
+            .allow("examples/**")
+    })
+    .unwrap();
 
     let glob_simple = AllowedGlobResolver::new(vec![current_dir.clone()])
         .unwrap()

--- a/src/llm-coding-tools-core/benches/path_resolvers.rs
+++ b/src/llm-coding-tools-core/benches/path_resolvers.rs
@@ -15,7 +15,8 @@
 //! |------------------------|----------------------------------------------------|------------------------------------------------|
 //! | existing_file          | src/lib.rs                                         | Fast path: file exists, canonicalize succeeds  |
 //! | new_file_existing_dir  | src/new_file_test.rs                               | Fast path: parent exists, canonicalize parent   |
-//! | new_file_missing_dir   | benchmarks/new_file_test.rs                        | Slow path: soft-canonicalize for non-existent  |
+//! | new_file_missing_dir   | src/new_dir/nested/new_file_test.rs                | Slow path: soft-canonicalize for non-existent  |
+//! | policy_reject          | benchmarks/new_file_test.rs                        | Early rejection via fast policy check          |
 //! | deep_nested            | src/llm-coding-tools-core/src/path/.../policy.rs   | Longer path, more components to process        |
 //! | traversal_reject       | ../../../outside.txt                               | Early rejection via lexical escape check       |
 //! ```
@@ -23,22 +24,24 @@
 //! # Reference Results (Linux, optimized build)
 //!
 //! ```text
-//! resolvers/AllowedPathResolver/existing_file          ~1.8 µs
+//! resolvers/AllowedPathResolver/existing_file          ~1.7 µs
 //! resolvers/AllowedPathResolver/new_file_existing_dir ~3.5 µs  (optimized: parent canonicalize)
-//! resolvers/AllowedPathResolver/new_file_missing_dir  ~8.1 µs  (fallback: soft_canonicalize)
-//! resolvers/AllowedPathResolver/deep_nested           ~10.5 µs
+//! resolvers/AllowedPathResolver/new_file_missing_dir  ~9.7 µs  (fallback: soft_canonicalize)
+//! resolvers/AllowedPathResolver/policy_reject         ~8.0 µs  (no policy, resolves normally)
+//! resolvers/AllowedPathResolver/deep_nested           ~10.9 µs
 //! resolvers/AllowedPathResolver/traversal_reject      ~20 ns
 //!
-//! resolvers/AllowedGlobResolver_simple_policy/existing_file          ~2.0 µs
-//! resolvers/AllowedGlobResolver_simple_policy/new_file_existing_dir  ~3.8 µs
-//! resolvers/AllowedGlobResolver_simple_policy/new_file_missing_dir   ~8.4 µs
+//! resolvers/AllowedGlobResolver_simple_policy/existing_file          ~1.8 µs  (overhead: ~100 ns)
+//! resolvers/AllowedGlobResolver_simple_policy/new_file_existing_dir  ~3.5 µs  (overhead: ~40 ns)
+//! resolvers/AllowedGlobResolver_simple_policy/new_file_missing_dir   ~9.8 µs  (overhead: ~90 ns)
+//! resolvers/AllowedGlobResolver_simple_policy/policy_reject          ~54 ns   (150x faster!)
 //! resolvers/AllowedGlobResolver_simple_policy/deep_nested            ~10.8 µs
-//! resolvers/AllowedGlobResolver_simple_policy/traversal_reject       ~20 ns
+//! resolvers/AllowedGlobResolver_simple_policy/traversal_reject       ~28 ns
 //!
 //! canonicalize/existing_file_canonicalize         ~1.6 µs
 //! canonicalize/existing_file_soft_canonicalize    ~4.4 µs  (2.7x slower than canonicalize)
-//! canonicalize/new_file_shallow_soft_canonicalize ~6.0 µs
-//! canonicalize/new_file_deep_soft_canonicalize    ~7.0 µs
+//! canonicalize/new_file_shallow_soft_canonicalize ~5.9 µs
+//! canonicalize/new_file_deep_soft_canonicalize    ~6.9 µs
 //! ```
 //!
 //! # Platform Differences
@@ -71,7 +74,10 @@ use tempfile::TempDir;
 
 const EXISTING_FILE: &str = "src/lib.rs";
 const NEW_FILE_EXISTING_DIR: &str = "src/new_file_test.rs";
-const NEW_FILE_MISSING_DIR: &str = "benchmarks/new_file_test.rs";
+// Path that matches simple policy (src/**/*.rs) but has missing directories
+const NEW_FILE_MISSING_DIR: &str = "src/new_dir/nested/new_file_test.rs";
+// Path that does NOT match simple policy - tests early rejection
+const POLICY_REJECT: &str = "benchmarks/new_file_test.rs";
 const DEEP_NESTED: &str = "src/llm-coding-tools-core/src/path/allowed_glob/policy.rs";
 const TRAVERSAL: &str = "../../../outside.txt";
 
@@ -147,6 +153,7 @@ fn bench_resolvers_same_paths(c: &mut Criterion) {
         ("existing_file", EXISTING_FILE),
         ("new_file_existing_dir", NEW_FILE_EXISTING_DIR),
         ("new_file_missing_dir", NEW_FILE_MISSING_DIR),
+        ("policy_reject", POLICY_REJECT),
         ("deep_nested", DEEP_NESTED),
         ("traversal_reject", TRAVERSAL),
     ] {

--- a/src/llm-coding-tools-core/src/path/allowed.rs
+++ b/src/llm-coding-tools-core/src/path/allowed.rs
@@ -1,6 +1,6 @@
 //! Allowed directory path resolver implementation.
 
-use super::{relative_path_escapes_base, PathResolver};
+use super::{relative_path_escapes_base, resolve_new_file_fast, PathResolver};
 use crate::context::PathMode;
 use crate::error::{ToolError, ToolResult};
 use soft_canonicalize::soft_canonicalize;
@@ -124,8 +124,17 @@ impl PathResolver for AllowedPathResolver {
                 continue;
             }
 
-            // Non-existent paths still need a resolved absolute target so we can
-            // validate containment consistently across platforms.
+            // Fast path for new files in existing directories.
+            // Canonicalizes parent directory, then joins filename.
+            // This avoids soft_canonicalize's expensive walk-up logic.
+            if let Some(resolved) = resolve_new_file_fast(&candidate) {
+                if resolved.starts_with(base) {
+                    return Ok(resolved);
+                }
+                continue;
+            }
+
+            // Fallback for paths where parent doesn't exist.
             if let Ok(resolved) = soft_canonicalize(&candidate) {
                 if resolved.starts_with(base) {
                     return Ok(resolved);

--- a/src/llm-coding-tools-core/src/path/allowed.rs
+++ b/src/llm-coding-tools-core/src/path/allowed.rs
@@ -1,6 +1,6 @@
 //! Allowed directory path resolver implementation.
 
-use super::PathResolver;
+use super::{relative_path_escapes_base, PathResolver};
 use crate::context::PathMode;
 use crate::error::{ToolError, ToolResult};
 use soft_canonicalize::soft_canonicalize;
@@ -101,11 +101,18 @@ impl PathResolver for AllowedPathResolver {
     const PATH_MODE: PathMode = PathMode::Allowed;
 
     fn resolve(&self, path: &str) -> ToolResult<PathBuf> {
-        let input_path = PathBuf::from(path);
+        let input_path = Path::new(path);
+
+        if relative_path_escapes_base(input_path) {
+            return Err(ToolError::InvalidPath(format!(
+                "path '{}' is not within allowed directories",
+                path
+            )));
+        }
 
         // Try each allowed base directory in order
         for base in self.allowed_paths.iter() {
-            let candidate = base.join(&input_path);
+            let candidate = base.join(input_path);
 
             // Try to canonicalize for existing paths
             if let Ok(canonical) = candidate.canonicalize() {

--- a/src/llm-coding-tools-core/src/path/allowed_glob/mod.rs
+++ b/src/llm-coding-tools-core/src/path/allowed_glob/mod.rs
@@ -6,7 +6,7 @@
 mod normalize;
 mod policy;
 
-use super::{relative_path_escapes_base, PathResolver};
+use super::{relative_path_escapes_base, resolve_new_file_fast, PathResolver};
 use crate::context::PathMode;
 use crate::error::{ToolError, ToolResult};
 use normalize::expand_shell;
@@ -174,8 +174,27 @@ impl PathResolver for AllowedGlobResolver {
                 return Ok(resolved);
             }
 
-            // Non-existent paths still need a resolved absolute target so we can
-            // validate containment and glob policy consistently across platforms.
+            // Fast path for new files in existing directories.
+            // Canonicalizes parent directory, then joins filename.
+            // This avoids soft_canonicalize's expensive walk-up logic.
+            if let Some(resolved) = resolve_new_file_fast(&candidate) {
+                if !resolved.starts_with(base_dir) {
+                    continue;
+                }
+
+                // Apply glob policy to the resolved relative path.
+                if let Some(policy) = policy {
+                    let relative_path = resolved.strip_prefix(base_dir).unwrap_or(Path::new(""));
+                    let normalized_relative = normalize::normalize_path(relative_path);
+                    if !policy.is_allowed(&normalized_relative) {
+                        continue;
+                    }
+                }
+
+                return Ok(resolved);
+            }
+
+            // Fallback for paths where parent doesn't exist.
             if let Ok(target_path) = soft_canonicalize(&candidate) {
                 if !target_path.starts_with(base_dir) {
                     continue;

--- a/src/llm-coding-tools-core/src/path/allowed_glob/mod.rs
+++ b/src/llm-coding-tools-core/src/path/allowed_glob/mod.rs
@@ -6,7 +6,7 @@
 mod normalize;
 mod policy;
 
-use super::PathResolver;
+use super::{relative_path_escapes_base, PathResolver};
 use crate::context::PathMode;
 use crate::error::{ToolError, ToolResult};
 use normalize::expand_shell;
@@ -141,11 +141,19 @@ impl PathResolver for AllowedGlobResolver {
     const PATH_MODE: PathMode = PathMode::Allowed;
 
     fn resolve(&self, path: &str) -> ToolResult<PathBuf> {
-        let input_path = PathBuf::from(path);
+        let input_path = Path::new(path);
+        let policy = self.policy.as_deref();
+
+        if relative_path_escapes_base(input_path) {
+            return Err(ToolError::InvalidPath(format!(
+                "path '{}' is not within allowed directories",
+                path
+            )));
+        }
 
         for base_dir in self.base_directories.iter() {
             // Relative input joins base_dir; absolute input overrides it.
-            let candidate = base_dir.join(&input_path);
+            let candidate = base_dir.join(input_path);
 
             // Existing file/dir: canonicalize resolves symlinks and normalizes.
             if let Ok(resolved) = candidate.canonicalize() {
@@ -155,10 +163,9 @@ impl PathResolver for AllowedGlobResolver {
                 }
 
                 // Apply glob policy to the relative path.
-                let relative_path = resolved.strip_prefix(base_dir).unwrap_or(Path::new(""));
-                let normalized_relative = normalize::normalize_path(relative_path);
-
-                if let Some(policy) = &self.policy {
+                if let Some(policy) = policy {
+                    let relative_path = resolved.strip_prefix(base_dir).unwrap_or(Path::new(""));
+                    let normalized_relative = normalize::normalize_path(relative_path);
                     if !policy.is_allowed(&normalized_relative) {
                         continue;
                     }
@@ -175,10 +182,9 @@ impl PathResolver for AllowedGlobResolver {
                 }
 
                 // Apply glob policy to the target relative path.
-                let relative_path = target_path.strip_prefix(base_dir).unwrap_or(Path::new(""));
-                let normalized_relative = normalize::normalize_path(relative_path);
-
-                if let Some(policy) = &self.policy {
+                if let Some(policy) = policy {
+                    let relative_path = target_path.strip_prefix(base_dir).unwrap_or(Path::new(""));
+                    let normalized_relative = normalize::normalize_path(relative_path);
                     if !policy.is_allowed(&normalized_relative) {
                         continue;
                     }

--- a/src/llm-coding-tools-core/src/path/allowed_glob/mod.rs
+++ b/src/llm-coding-tools-core/src/path/allowed_glob/mod.rs
@@ -153,8 +153,8 @@ impl PathResolver for AllowedGlobResolver {
         }
 
         // Optimization: if path has no `.` or `..` components, we can check the glob
-        // policy on the input path directly, avoiding strip_prefix overhead.
-        // For paths with dots (e.g., "src/../lib.rs"), we must use the canonical path.
+        // policy on the input path directly and only fall back to the resolved path
+        // check when canonicalization changes what the policy should see.
         let fast_policy_input = if !analysis.has_dots { Some(path) } else { None };
 
         for base_dir in self.base_directories.iter() {
@@ -175,11 +175,14 @@ impl PathResolver for AllowedGlobResolver {
                     continue;
                 }
 
-                // Policy check on resolved path (handles symlink policy bypass).
+                // Re-check policy after resolution if normalization or symlinks changed
+                // the path seen by glob matching.
                 if let Some(policy) = policy {
                     let relative_path = resolved.strip_prefix(base_dir).unwrap_or(Path::new(""));
                     let normalized_relative = normalize::normalize_path(relative_path);
-                    if !policy.is_allowed(&normalized_relative) {
+                    if fast_policy_input != Some(normalized_relative.as_ref())
+                        && !policy.is_allowed(&normalized_relative)
+                    {
                         continue;
                     }
                 }
@@ -195,11 +198,14 @@ impl PathResolver for AllowedGlobResolver {
                     continue;
                 }
 
-                // Policy check on resolved path (handles symlink policy bypass).
+                // Re-check policy after resolution if normalization or symlinks changed
+                // the path seen by glob matching.
                 if let Some(policy) = policy {
                     let relative_path = resolved.strip_prefix(base_dir).unwrap_or(Path::new(""));
                     let normalized_relative = normalize::normalize_path(relative_path);
-                    if !policy.is_allowed(&normalized_relative) {
+                    if fast_policy_input != Some(normalized_relative.as_ref())
+                        && !policy.is_allowed(&normalized_relative)
+                    {
                         continue;
                     }
                 }
@@ -213,11 +219,14 @@ impl PathResolver for AllowedGlobResolver {
                     continue;
                 }
 
-                // Policy check on resolved path (handles symlink policy bypass).
+                // Re-check policy after resolution if normalization or symlinks changed
+                // the path seen by glob matching.
                 if let Some(policy) = policy {
                     let relative_path = target_path.strip_prefix(base_dir).unwrap_or(Path::new(""));
                     let normalized_relative = normalize::normalize_path(relative_path);
-                    if !policy.is_allowed(&normalized_relative) {
+                    if fast_policy_input != Some(normalized_relative.as_ref())
+                        && !policy.is_allowed(&normalized_relative)
+                    {
                         continue;
                     }
                 }

--- a/src/llm-coding-tools-core/src/path/allowed_glob/mod.rs
+++ b/src/llm-coding-tools-core/src/path/allowed_glob/mod.rs
@@ -6,7 +6,7 @@
 mod normalize;
 mod policy;
 
-use super::{relative_path_escapes_base, resolve_new_file_fast, PathResolver};
+use super::{path_analysis, resolve_new_file_fast, PathResolver};
 use crate::context::PathMode;
 use crate::error::{ToolError, ToolResult};
 use normalize::expand_shell;
@@ -144,14 +144,27 @@ impl PathResolver for AllowedGlobResolver {
         let input_path = Path::new(path);
         let policy = self.policy.as_deref();
 
-        if relative_path_escapes_base(input_path) {
+        let analysis = path_analysis(input_path);
+        if analysis.escapes {
             return Err(ToolError::InvalidPath(format!(
                 "path '{}' is not within allowed directories",
                 path
             )));
         }
 
+        // Optimization: if path has no `.` or `..` components, we can check the glob
+        // policy on the input path directly, avoiding strip_prefix overhead.
+        // For paths with dots (e.g., "src/../lib.rs"), we must use the canonical path.
+        let fast_policy_input = if !analysis.has_dots { Some(path) } else { None };
+
         for base_dir in self.base_directories.iter() {
+            // Fast policy check before filesystem operations.
+            if let (Some(policy), Some(input)) = (policy, fast_policy_input) {
+                if !policy.is_allowed(input) {
+                    continue;
+                }
+            }
+
             // Relative input joins base_dir; absolute input overrides it.
             let candidate = base_dir.join(input_path);
 
@@ -162,8 +175,8 @@ impl PathResolver for AllowedGlobResolver {
                     continue;
                 }
 
-                // Apply glob policy to the relative path.
-                if let Some(policy) = policy {
+                // Slow policy check for paths with dots.
+                if let (Some(policy), None) = (policy, fast_policy_input) {
                     let relative_path = resolved.strip_prefix(base_dir).unwrap_or(Path::new(""));
                     let normalized_relative = normalize::normalize_path(relative_path);
                     if !policy.is_allowed(&normalized_relative) {
@@ -182,8 +195,8 @@ impl PathResolver for AllowedGlobResolver {
                     continue;
                 }
 
-                // Apply glob policy to the resolved relative path.
-                if let Some(policy) = policy {
+                // Slow policy check for paths with dots.
+                if let (Some(policy), None) = (policy, fast_policy_input) {
                     let relative_path = resolved.strip_prefix(base_dir).unwrap_or(Path::new(""));
                     let normalized_relative = normalize::normalize_path(relative_path);
                     if !policy.is_allowed(&normalized_relative) {
@@ -200,8 +213,8 @@ impl PathResolver for AllowedGlobResolver {
                     continue;
                 }
 
-                // Apply glob policy to the target relative path.
-                if let Some(policy) = policy {
+                // Slow policy check for paths with dots.
+                if let (Some(policy), None) = (policy, fast_policy_input) {
                     let relative_path = target_path.strip_prefix(base_dir).unwrap_or(Path::new(""));
                     let normalized_relative = normalize::normalize_path(relative_path);
                     if !policy.is_allowed(&normalized_relative) {

--- a/src/llm-coding-tools-core/src/path/allowed_glob/mod.rs
+++ b/src/llm-coding-tools-core/src/path/allowed_glob/mod.rs
@@ -175,8 +175,8 @@ impl PathResolver for AllowedGlobResolver {
                     continue;
                 }
 
-                // Slow policy check for paths with dots.
-                if let (Some(policy), None) = (policy, fast_policy_input) {
+                // Policy check on resolved path (handles symlink policy bypass).
+                if let Some(policy) = policy {
                     let relative_path = resolved.strip_prefix(base_dir).unwrap_or(Path::new(""));
                     let normalized_relative = normalize::normalize_path(relative_path);
                     if !policy.is_allowed(&normalized_relative) {
@@ -195,8 +195,8 @@ impl PathResolver for AllowedGlobResolver {
                     continue;
                 }
 
-                // Slow policy check for paths with dots.
-                if let (Some(policy), None) = (policy, fast_policy_input) {
+                // Policy check on resolved path (handles symlink policy bypass).
+                if let Some(policy) = policy {
                     let relative_path = resolved.strip_prefix(base_dir).unwrap_or(Path::new(""));
                     let normalized_relative = normalize::normalize_path(relative_path);
                     if !policy.is_allowed(&normalized_relative) {
@@ -213,8 +213,8 @@ impl PathResolver for AllowedGlobResolver {
                     continue;
                 }
 
-                // Slow policy check for paths with dots.
-                if let (Some(policy), None) = (policy, fast_policy_input) {
+                // Policy check on resolved path (handles symlink policy bypass).
+                if let Some(policy) = policy {
                     let relative_path = target_path.strip_prefix(base_dir).unwrap_or(Path::new(""));
                     let normalized_relative = normalize::normalize_path(relative_path);
                     if !policy.is_allowed(&normalized_relative) {
@@ -409,6 +409,42 @@ mod tests {
 
         let result = resolver.resolve("escape_link/secret.txt");
         assert!(result.is_err(), "symlink escape should be blocked");
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("not within allowed"));
+    }
+
+    /// Regression test: symlink under allowed dir pointing to denied dir
+    /// must be blocked after canonicalization re-checks policy.
+    #[test]
+    #[cfg(unix)]
+    fn rejects_symlink_policy_bypass_attempt() {
+        use std::os::unix::fs::symlink;
+
+        let dir = setup_test_dir();
+        fs::create_dir_all(dir.path().join("src")).unwrap();
+        fs::create_dir_all(dir.path().join("target")).unwrap();
+        fs::write(dir.path().join("target/app"), "binary").unwrap();
+
+        let symlink_path = dir.path().join("src/link");
+        symlink(dir.path().join("target"), &symlink_path).unwrap();
+
+        let policy = GlobPolicy::builder()
+            .allow("src/**")
+            .unwrap()
+            .deny("target/**")
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let resolver = AllowedGlobResolver::new(vec![dir.path().to_path_buf()])
+            .unwrap()
+            .with_policy(policy);
+
+        let result = resolver.resolve("src/link/app");
+        assert!(
+            result.is_err(),
+            "symlink policy bypass should be blocked: 'src/link/app' resolves to 'target/app' which should be denied"
+        );
         let err = result.unwrap_err();
         assert!(err.to_string().contains("not within allowed"));
     }

--- a/src/llm-coding-tools-core/src/path/allowed_glob/normalize.rs
+++ b/src/llm-coding-tools-core/src/path/allowed_glob/normalize.rs
@@ -1,5 +1,6 @@
 //! Path normalization utilities for glob matching.
 
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 use crate::error::{ToolError, ToolResult};
@@ -8,15 +9,20 @@ use crate::error::{ToolError, ToolResult};
 ///
 /// On Windows, converts backslashes to forward slashes.
 /// On Unix, this returns the path string unchanged.
-pub(crate) fn normalize_path(path: &Path) -> String {
+#[inline]
+pub(crate) fn normalize_path(path: &Path) -> Cow<'_, str> {
     let path_str = path.to_string_lossy();
     #[cfg(windows)]
     {
-        path_str.replace('\\', "/")
+        if path_str.contains('\\') {
+            Cow::Owned(path_str.replace('\\', "/"))
+        } else {
+            path_str
+        }
     }
     #[cfg(not(windows))]
     {
-        path_str.into_owned()
+        path_str
     }
 }
 

--- a/src/llm-coding-tools-core/src/path/mod.rs
+++ b/src/llm-coding-tools-core/src/path/mod.rs
@@ -70,3 +70,42 @@ pub(crate) fn relative_path_escapes_base(path: &Path) -> bool {
 
     false
 }
+
+/// Resolves a path for a new file when the parent directory exists.
+///
+/// This is a fast path optimization that avoids the expensive `soft_canonicalize`
+/// for the common case where a new file is being created in an existing directory.
+///
+/// # Platform Differences
+///
+/// - **Unix**: Canonicalizes the parent directory and joins the filename.
+///   This is safe because Unix path resolution is straightforward.
+/// - **Windows/others**: Uses `soft_canonicalize` because Windows has complex path
+///   semantics (drive letters, UNC paths, verbatim paths) that require the
+///   full resolution logic for correct `..` handling.
+///
+/// # Returns
+///
+/// - `Some(resolved_path)` if the parent directory exists and was successfully canonicalized
+/// - `None` if the parent directory doesn't exist or canonicalization failed
+#[inline]
+pub(crate) fn resolve_new_file_fast(candidate: &Path) -> Option<PathBuf> {
+    let parent = candidate.parent()?;
+
+    #[cfg(unix)]
+    {
+        let filename = candidate.file_name()?;
+        if parent.is_dir() {
+            return parent.canonicalize().ok().map(|p| p.join(filename));
+        }
+        None
+    }
+
+    #[cfg(not(unix))]
+    {
+        if parent.is_dir() {
+            return soft_canonicalize::soft_canonicalize(candidate).ok();
+        }
+        None
+    }
+}

--- a/src/llm-coding-tools-core/src/path/mod.rs
+++ b/src/llm-coding-tools-core/src/path/mod.rs
@@ -15,7 +15,7 @@ pub use allowed_glob::{AllowedGlobResolver, GlobPolicy, GlobPolicyBuilder, RuleA
 
 use crate::context::PathMode;
 use crate::error::ToolResult;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 
 /// Strategy for resolving and validating file paths.
 ///
@@ -33,4 +33,40 @@ pub trait PathResolver: Send + Sync {
     /// Returns an absolute path (may or may not be canonical) if valid,
     /// or an error describing the issue.
     fn resolve(&self, path: &str) -> ToolResult<PathBuf>;
+}
+
+/// Fast lexical check for whether a relative path would escape its base directory.
+///
+/// This is a cheap pre-filter that avoids filesystem operations for obvious traversal
+/// attacks. It tracks the effective depth while walking path components:
+/// - `.` (current directory) has no effect
+/// - normal components increase depth
+/// - `..` (parent directory) decreases depth, and if depth is already 0, the path escapes
+///
+/// # Returns
+///
+/// - `true` if the path would escape (e.g., `../../../etc/passwd`, `../secrets.txt`)
+/// - `false` if the path stays within bounds or is absolute
+#[inline]
+pub(crate) fn relative_path_escapes_base(path: &Path) -> bool {
+    if path.is_absolute() {
+        return false;
+    }
+
+    let mut depth = 0usize;
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => depth += 1,
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if depth == 0 {
+                    return true;
+                }
+                depth -= 1;
+            }
+            Component::RootDir | Component::Prefix(_) => return false,
+        }
+    }
+
+    false
 }

--- a/src/llm-coding-tools-core/src/path/mod.rs
+++ b/src/llm-coding-tools-core/src/path/mod.rs
@@ -49,26 +49,65 @@ pub trait PathResolver: Send + Sync {
 /// - `false` if the path stays within bounds or is absolute
 #[inline]
 pub(crate) fn relative_path_escapes_base(path: &Path) -> bool {
+    path_analysis(path).escapes
+}
+
+/// Result of analyzing a path for traversal and dot components.
+pub(crate) struct PathAnalysis {
+    /// Whether the path would escape its base directory.
+    pub(crate) escapes: bool,
+    /// Whether the path contains `.` or `..` components.
+    pub(crate) has_dots: bool,
+}
+
+/// Analyzes a path for traversal attacks and dot components.
+///
+/// This is a single-pass analysis that checks both:
+/// 1. Whether the path escapes its base (for security)
+/// 2. Whether the path has `.` or `..` components (for optimization)
+///
+/// The `has_dots` flag is used by `AllowedGlobResolver` to decide whether
+/// to check the glob policy on the input path (fast) or the canonical path
+/// (correct for paths like `src/../lib.rs`).
+#[inline]
+pub(crate) fn path_analysis(path: &Path) -> PathAnalysis {
     if path.is_absolute() {
-        return false;
+        return PathAnalysis {
+            escapes: false,
+            has_dots: false,
+        };
     }
 
     let mut depth = 0usize;
+    let mut has_dots = false;
+
     for component in path.components() {
         match component {
             Component::Normal(_) => depth += 1,
-            Component::CurDir => {}
+            Component::CurDir => has_dots = true,
             Component::ParentDir => {
+                has_dots = true;
                 if depth == 0 {
-                    return true;
+                    return PathAnalysis {
+                        escapes: true,
+                        has_dots: true,
+                    };
                 }
                 depth -= 1;
             }
-            Component::RootDir | Component::Prefix(_) => return false,
+            Component::RootDir | Component::Prefix(_) => {
+                return PathAnalysis {
+                    escapes: false,
+                    has_dots: false,
+                };
+            }
         }
     }
 
-    false
+    PathAnalysis {
+        escapes: false,
+        has_dots,
+    }
 }
 
 /// Resolves a path for a new file when the parent directory exists.


### PR DESCRIPTION
## Summary

Two performance optimizations for path resolvers:

1. **Early traversal rejection** - Lexical detection bypasses filesystem ops (~400x faster)
2. **Fast path for new files** - Canonicalize parent instead of full walk-up (~2.2x faster)

## Benchmark Results (Linux, optimized)

Run on 2026-04-07:

```
resolvers/AllowedPathResolver/existing_file          ~1.73 µs
resolvers/AllowedPathResolver/new_file_existing_dir  ~3.46 µs  (optimized: parent canonicalize)
resolvers/AllowedPathResolver/new_file_missing_dir   ~9.60 µs  (fallback: soft_canonicalize)
resolvers/AllowedPathResolver/policy_reject          ~7.99 µs  (no policy, resolves normally)
resolvers/AllowedPathResolver/deep_nested            ~10.5 µs
resolvers/AllowedPathResolver/traversal_reject       ~20.3 ns  (lexical check only)

resolvers/AllowedGlobResolver_simple_policy/existing_file          ~1.85 µs
resolvers/AllowedGlobResolver_simple_policy/new_file_existing_dir  ~3.56 µs
resolvers/AllowedGlobResolver_simple_policy/new_file_missing_dir   ~9.75 µs
resolvers/AllowedGlobResolver_simple_policy/policy_reject          ~53.9 ns   (150x faster!)
resolvers/AllowedGlobResolver_simple_policy/deep_nested            ~10.6 µs
resolvers/AllowedGlobResolver_simple_policy/traversal_reject       ~20.3 ns

resolvers/AllowedGlobResolver_complex_policy/existing_file          ~2.02 µs
resolvers/AllowedGlobResolver_complex_policy/new_file_existing_dir  ~3.68 µs
resolvers/AllowedGlobResolver_complex_policy/new_file_missing_dir   ~9.99 µs
resolvers/AllowedGlobResolver_complex_policy/policy_reject          ~105 ns   (76x faster!)
resolvers/AllowedGlobResolver_complex_policy/deep_nested            ~10.8 µs
resolvers/AllowedGlobResolver_complex_policy/traversal_reject       ~20.2 ns

canonicalize/existing_file_canonicalize         ~1.59 µs
canonicalize/existing_file_soft_canonicalize    ~4.39 µs  (2.8x slower than canonicalize)
canonicalize/new_file_shallow_soft_canonicalize ~5.95 µs
canonicalize/new_file_deep_soft_canonicalize    ~6.96 µs
```

## Performance Comparison (Baseline vs Optimized)

| Case | Baseline | Optimized | Speedup |
|------|----------|-----------|---------|
| AllowedPathResolver/traversal_reject | ~8 µs | ~20 ns | **400x** |
| AllowedPathResolver/new_file_existing_dir | ~7.8 µs | ~3.5 µs | **2.2x** |
| AllowedGlobResolver_simple/existing_file | ~1.96 µs | ~1.85 µs | **1.06x** |
| AllowedGlobResolver_complex/existing_file | ~2.15 µs | ~2.02 µs | **1.06x** |
| AllowedPathResolver/existing_file | ~1.74 µs | ~1.73 µs | - |
| AllowedPathResolver/new_file_missing_dir | ~7.8 µs | ~9.6 µs | - |
| AllowedPathResolver/deep_nested | ~10.2 µs | ~10.5 µs | - |

## Changes

| File | Change |
|------|--------|
| `src/path/mod.rs` | Add `relative_path_escapes_base()` and `resolve_new_file_fast()` |
| `src/path/allowed.rs` | Early-reject traversal; fast path for new files |
| `src/path/allowed_glob/mod.rs` | Early-reject traversal; fast path with glob policy |
| `src/path/allowed_glob/normalize.rs` | Return `Cow<str>` to avoid allocation on Unix |
| `benches/path_resolvers.rs` | Benchmark suite with canonicalize vs soft_canonicalize comparison |

## Platform Differences

The new file fast path is platform-specific:
- **Unix**: Canonicalizes parent directory, joins filename (~1.6 µs)
- **Windows/others**: Uses `soft_canonicalize` for correct `..` handling (~4.4 µs)

Windows has complex path semantics (drive letters, UNC paths, verbatim paths) that require full resolution logic.