### PR TITLE
Changed: Propagate pattern expansion errors through Rule::new

### DIFF
--- a/src/llm-coding-tools-agents/benches/runtime_task.rs
+++ b/src/llm-coding-tools-agents/benches/runtime_task.rs
@@ -87,6 +87,7 @@ fn build_runtime(agent_count: usize) -> llm_coding_tools_agents::AgentRuntime {
     AgentRuntimeBuilder::new()
         .catalog(AgentCatalog::from_entries(agents))
         .build()
+        .expect("benchmark fixture should not fail pattern expansion")
 }
 
 /// Benchmark cached delegation queries against runtimes of 16, 64, and 256 agents.

--- a/src/llm-coding-tools-agents/src/extensions.rs
+++ b/src/llm-coding-tools-agents/src/extensions.rs
@@ -9,7 +9,7 @@
 
 use crate::types::PermissionRule;
 use indexmap::IndexMap;
-use llm_coding_tools_core::permissions::{Rule, Ruleset};
+use llm_coding_tools_core::permissions::{ExpandError, Rule, Ruleset};
 
 /// Extension trait for building [`Ruleset`] from agent permission configs.
 pub trait RulesetExt {
@@ -34,30 +34,34 @@ pub trait RulesetExt {
     ///     PermissionRule::Action(PermissionAction::Allow),
     /// );
     ///
-    /// let ruleset = Ruleset::from_permission_config(&config);
+    /// let ruleset = Ruleset::from_permission_config(&config).unwrap();
     /// assert!(ruleset.is_allowed("bash", "*"));
     /// ```
-    fn from_permission_config(config: &IndexMap<String, PermissionRule>) -> Ruleset;
+    fn from_permission_config(
+        config: &IndexMap<String, PermissionRule>,
+    ) -> Result<Ruleset, ExpandError>;
 }
 
 impl RulesetExt for Ruleset {
-    fn from_permission_config(config: &IndexMap<String, PermissionRule>) -> Ruleset {
+    fn from_permission_config(
+        config: &IndexMap<String, PermissionRule>,
+    ) -> Result<Ruleset, ExpandError> {
         let mut ruleset = Ruleset::with_capacity(config.len() * 2);
 
         for (key, rule) in config {
             match rule {
                 PermissionRule::Action(action) => {
-                    ruleset.push(Rule::new(key.as_str(), "*", *action));
+                    ruleset.push(Rule::new(key.as_str(), "*", *action)?);
                 }
                 PermissionRule::Pattern(patterns) => {
                     for (pattern, action) in patterns {
-                        ruleset.push(Rule::new(key.as_str(), pattern.as_str(), *action));
+                        ruleset.push(Rule::new(key.as_str(), pattern.as_str(), *action)?);
                     }
                 }
             }
         }
 
-        ruleset
+        Ok(ruleset)
     }
 }
 
@@ -66,23 +70,26 @@ mod tests {
     use super::*;
     use llm_coding_tools_core::permissions::PermissionAction;
 
+    type TestResult = Result<(), ExpandError>;
+
     #[test]
-    fn from_permission_config_simple_action() {
+    fn from_permission_config_simple_action() -> TestResult {
         let mut config = IndexMap::new();
         config.insert(
             "bash".to_string(),
             PermissionRule::Action(PermissionAction::Allow),
         );
 
-        let ruleset = Ruleset::from_permission_config(&config);
+        let ruleset = Ruleset::from_permission_config(&config)?;
 
         assert_eq!(ruleset.len(), 1);
         assert!(ruleset.is_allowed("bash", "*"));
         assert!(!ruleset.is_allowed("task", "*"));
+        Ok(())
     }
 
     #[test]
-    fn from_permission_config_pattern_map() {
+    fn from_permission_config_pattern_map() -> TestResult {
         let mut patterns = IndexMap::new();
         patterns.insert("*".to_string(), PermissionAction::Deny);
         patterns.insert("orchestrator-*".to_string(), PermissionAction::Allow);
@@ -90,7 +97,7 @@ mod tests {
         let mut config = IndexMap::new();
         config.insert("task".to_string(), PermissionRule::Pattern(patterns));
 
-        let ruleset = Ruleset::from_permission_config(&config);
+        let ruleset = Ruleset::from_permission_config(&config)?;
 
         assert_eq!(ruleset.len(), 2);
         assert_eq!(
@@ -101,12 +108,13 @@ mod tests {
             ruleset.evaluate("task", "other-agent"),
             PermissionAction::Deny
         );
+        Ok(())
     }
 
     /// Verifies that wildcard permission keys in config are correctly converted
     /// to rules and match various permissions at runtime.
     #[test]
-    fn from_permission_config_wildcard_permission_key() {
+    fn from_permission_config_wildcard_permission_key() -> TestResult {
         let mut config = IndexMap::new();
         // "*": allow - wildcard permission key matches any tool
         config.insert(
@@ -119,7 +127,7 @@ mod tests {
             PermissionRule::Action(PermissionAction::Deny),
         );
 
-        let ruleset = Ruleset::from_permission_config(&config);
+        let ruleset = Ruleset::from_permission_config(&config)?;
 
         // Rules are added in IndexMap iteration order (preserved)
         // Rule 0: ("*", "*", Allow) - wildcard
@@ -151,11 +159,12 @@ mod tests {
             "*".to_string(),
             PermissionRule::Action(PermissionAction::Allow),
         );
-        let ruleset2 = Ruleset::from_permission_config(&config2);
+        let ruleset2 = Ruleset::from_permission_config(&config2)?;
         // Now "*" comes last and wins, so bash is allowed
         assert!(
             ruleset2.is_allowed("bash", "*"),
             "wildcard last should allow bash"
         );
+        Ok(())
     }
 }

--- a/src/llm-coding-tools-agents/src/runtime/builder.rs
+++ b/src/llm-coding-tools-agents/src/runtime/builder.rs
@@ -3,6 +3,7 @@
 use super::state::{AgentDefaults, AgentRuntime};
 use super::tool_catalog::{default_tools, ToolCatalogEntry};
 use crate::AgentCatalog;
+use llm_coding_tools_core::permissions::ExpandError;
 use llm_coding_tools_core::TaskSettings;
 
 /// Builds an [`AgentRuntime`] step by step.
@@ -70,7 +71,7 @@ impl AgentRuntimeBuilder {
 
     /// Finishes building and returns the [`AgentRuntime`].
     #[inline]
-    pub fn build(self) -> AgentRuntime {
+    pub fn build(self) -> Result<AgentRuntime, ExpandError> {
         AgentRuntime::from_parts(self.catalog, self.defaults, self.task_settings, self.tools)
     }
 }
@@ -82,10 +83,12 @@ mod tests {
     use crate::runtime::AgentDefaults;
     use crate::{AgentCatalog, AgentConfig, AgentMode, AgentToolSettings, PermissionRule};
     use indexmap::IndexMap;
-    use llm_coding_tools_core::permissions::PermissionAction;
+    use llm_coding_tools_core::permissions::{ExpandError, PermissionAction};
     use llm_coding_tools_core::tool_metadata::{glob as glob_meta, read as read_meta};
     use llm_coding_tools_core::TaskSettings;
     use std::sync::Arc;
+
+    type TestResult = Result<(), ExpandError>;
 
     fn sample_config(name: &str, model: Option<&str>) -> AgentConfig {
         AgentConfig {
@@ -104,7 +107,7 @@ mod tests {
     }
 
     #[test]
-    fn builder_builds_runtime_from_owned_inputs() {
+    fn builder_builds_runtime_from_owned_inputs() -> TestResult {
         let catalog = AgentCatalog::from_entries([sample_config("planner", Some("openai/gpt-4o"))]);
         let defaults = AgentDefaults {
             model: Some("openai/gpt-4.1-mini".into()),
@@ -120,7 +123,7 @@ mod tests {
             .catalog(catalog)
             .defaults(defaults.clone())
             .tools(tools.clone())
-            .build();
+            .build()?;
 
         assert_eq!(
             runtime
@@ -132,27 +135,30 @@ mod tests {
         assert_eq!(runtime.defaults(), &defaults);
         assert_eq!(runtime.task_settings(), TaskSettings::default());
         assert_eq!(runtime.tools(), tools.as_slice());
+        Ok(())
     }
 
     #[test]
-    fn builder_overrides_task_settings() {
-        let runtime = AgentRuntimeBuilder::new().max_task_depth(5).build();
+    fn builder_overrides_task_settings() -> TestResult {
+        let runtime = AgentRuntimeBuilder::new().max_task_depth(5).build()?;
 
         assert_eq!(runtime.task_settings(), TaskSettings::with_max_depth(5));
+        Ok(())
     }
 
     #[test]
-    fn builder_defaults_to_empty_catalog_defaults_and_default_tools() {
-        let runtime = AgentRuntimeBuilder::new().build();
+    fn builder_defaults_to_empty_catalog_defaults_and_default_tools() -> TestResult {
+        let runtime = AgentRuntimeBuilder::new().build()?;
 
         assert_eq!(runtime.catalog().iter().count(), 0);
         assert_eq!(runtime.defaults(), &AgentDefaults::default());
         assert_eq!(runtime.task_settings(), TaskSettings::default());
         assert_eq!(runtime.tools(), default_tools().as_slice());
+        Ok(())
     }
 
     #[test]
-    fn builder_caches_permission_rulesets() {
+    fn builder_caches_permission_rulesets() -> TestResult {
         let runtime = AgentRuntimeBuilder::new()
             .catalog(AgentCatalog::from_entries([AgentConfig {
                 name: "planner".into(),
@@ -170,7 +176,7 @@ mod tests {
                 tool_settings: AgentToolSettings::default(),
                 prompt: Default::default(),
             }]))
-            .build();
+            .build()?;
 
         let first = runtime
             .permission_ruleset("planner")
@@ -181,5 +187,6 @@ mod tests {
 
         assert!(Arc::ptr_eq(&first, &second));
         assert!(first.is_allowed(read_meta::NAME, "*"));
+        Ok(())
     }
 }

--- a/src/llm-coding-tools-agents/src/runtime/mod.rs
+++ b/src/llm-coding-tools-agents/src/runtime/mod.rs
@@ -29,14 +29,16 @@
 //! # Example
 //!
 //! ```no_run
-//! use llm_coding_tools_agents::{AgentCatalog, AgentDefaults, AgentRuntimeBuilder};
-//!
+//! # use llm_coding_tools_agents::{AgentCatalog, AgentDefaults, AgentRuntimeBuilder};
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let runtime = AgentRuntimeBuilder::new()
 //!     .catalog(AgentCatalog::new())
 //!     .defaults(AgentDefaults::with_model("openai/gpt-4o"))
-//!     .build();
+//!     .build()?;
 //!
 //! assert!(runtime.catalog().iter().count() == 0);
+//! # Ok(())
+//! # }
 //! ```
 
 mod builder;

--- a/src/llm-coding-tools-agents/src/runtime/state.rs
+++ b/src/llm-coding-tools-agents/src/runtime/state.rs
@@ -9,7 +9,7 @@ use super::task::{build_runtime_task_caches, TaskTargetSummary};
 use super::tool_catalog::ToolCatalogEntry;
 use crate::{AgentCatalog, RulesetExt};
 use ahash::AHashMap;
-use llm_coding_tools_core::permissions::Ruleset;
+use llm_coding_tools_core::permissions::{ExpandError, Ruleset};
 use llm_coding_tools_core::TaskSettings;
 use std::sync::Arc;
 
@@ -55,20 +55,20 @@ impl AgentRuntime {
         defaults: AgentDefaults,
         task_settings: TaskSettings,
         tools: Vec<ToolCatalogEntry>,
-    ) -> Self {
+    ) -> Result<Self, ExpandError> {
         let permission_rulesets = catalog
             .iter()
             .map(|agent| {
-                (
+                Ok((
                     agent.name.to_string(),
-                    Arc::new(Ruleset::from_permission_config(&agent.permission)),
-                )
+                    Arc::new(Ruleset::from_permission_config(&agent.permission)?),
+                ))
             })
-            .collect();
+            .collect::<Result<AHashMap<_, _>, ExpandError>>()?;
         let (allowed_tools_by_caller, callable_target_summaries_by_caller) =
             build_runtime_task_caches(&catalog, &permission_rulesets, &tools);
 
-        Self {
+        Ok(Self {
             catalog,
             defaults,
             task_settings,
@@ -76,7 +76,7 @@ impl AgentRuntime {
             permission_rulesets,
             allowed_tools_by_caller,
             callable_target_summaries_by_caller,
-        }
+        })
     }
 
     /// Returns the loaded agent definitions.

--- a/src/llm-coding-tools-agents/src/runtime/task.rs
+++ b/src/llm-coding-tools-agents/src/runtime/task.rs
@@ -8,7 +8,7 @@
 use super::tool_catalog::{ToolCatalogEntry, ToolCatalogKind};
 use crate::{AgentCatalog, AgentConfig, AgentMode, RulesetExt};
 use ahash::AHashMap;
-use llm_coding_tools_core::permissions::Ruleset;
+use llm_coding_tools_core::permissions::{ExpandError, Ruleset};
 use llm_coding_tools_core::tool_metadata::task as task_meta;
 use std::sync::Arc;
 
@@ -34,8 +34,8 @@ pub struct TaskTargetSummary {
 pub fn summarize_callable_targets(
     catalog: &AgentCatalog,
     caller_name: &str,
-) -> Vec<TaskTargetSummary> {
-    summarize_targets(callable_targets(catalog, caller_name))
+) -> Result<Vec<TaskTargetSummary>, ExpandError> {
+    Ok(summarize_targets(callable_targets(catalog, caller_name)?))
 }
 
 /// Returns the agents that `caller_name` (the currently running agent) may delegate to via Task.
@@ -52,15 +52,18 @@ pub fn summarize_callable_targets(
 /// `mode: all` and `mode: subagent` targets for OpenCode compatibility. When
 /// `permission.task` is present, its rules filter target names with the normal
 /// last-match-wins permission semantics.
-pub fn callable_targets<'a>(catalog: &'a AgentCatalog, caller_name: &str) -> Vec<&'a AgentConfig> {
+pub fn callable_targets<'a>(
+    catalog: &'a AgentCatalog,
+    caller_name: &str,
+) -> Result<Vec<&'a AgentConfig>, ExpandError> {
     let Some(caller) = catalog.by_name(caller_name) else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
-    let task_rules = Ruleset::from_permission_config(&caller.permission);
+    let task_rules = Ruleset::from_permission_config(&caller.permission)?;
     // Sort to give deterministic ordering regardless of catalog iteration order;
     // the result feeds into LLM prompts and cached summaries that must be stable.
     let agents = sorted_agents(catalog);
-    filter_callable_targets(&agents, caller, &task_rules)
+    Ok(filter_callable_targets(&agents, caller, &task_rules))
 }
 
 /// Pre-compute per-agent task caches for the entire catalog in one pass.
@@ -186,10 +189,12 @@ mod tests {
     use crate::{AgentConfig, AgentMode, AgentRuntimeBuilder, AgentToolSettings};
     use ahash::AHashMap;
     use indexmap::IndexMap;
-    use llm_coding_tools_core::permissions::PermissionAction;
+    use llm_coding_tools_core::permissions::{ExpandError, PermissionAction};
     use llm_coding_tools_core::tool_metadata::{
         bash as bash_meta, read as read_meta, task as task_meta, write as write_meta,
     };
+
+    type TestResult = Result<(), ExpandError>;
 
     fn agent(
         name: &str,
@@ -236,7 +241,7 @@ mod tests {
 
     /// Unknown callers yield no targets.
     #[test]
-    fn callable_targets_returns_empty_for_unknown_caller() {
+    fn callable_targets_returns_empty_for_unknown_caller() -> TestResult {
         let catalog = AgentCatalog::from_entries([agent(
             "agent-a",
             AgentMode::All,
@@ -244,13 +249,14 @@ mod tests {
             allow_tools(&[task_meta::NAME]),
         )]);
 
-        let targets = callable_targets(&catalog, "nonexistent");
+        let targets = callable_targets(&catalog, "nonexistent")?;
         assert!(targets.is_empty());
+        Ok(())
     }
 
     /// Primary-mode agents are excluded from callable targets.
     #[test]
-    fn callable_targets_filters_primary_targets_even_when_allowed() {
+    fn callable_targets_filters_primary_targets_even_when_allowed() -> TestResult {
         let catalog = AgentCatalog::from_entries([
             agent(
                 "caller",
@@ -273,17 +279,18 @@ mod tests {
             ),
         ]);
 
-        let targets = callable_targets(&catalog, "caller");
+        let targets = callable_targets(&catalog, "caller")?;
         let names: Vec<_> = targets.iter().map(|t| t.name.as_ref()).collect();
         assert!(names.contains(&"all-target"));
         assert!(names.contains(&"subagent-target"));
         assert!(!names.contains(&"primary-target"));
         assert!(names.contains(&"caller"));
+        Ok(())
     }
 
     /// Self-delegation is allowed when mode and permission both permit.
     #[test]
-    fn callable_targets_keeps_self_when_mode_and_permission_allow_it() {
+    fn callable_targets_keeps_self_when_mode_and_permission_allow_it() -> TestResult {
         let catalog = AgentCatalog::from_entries([agent(
             "self-agent",
             AgentMode::All,
@@ -291,13 +298,14 @@ mod tests {
             allow_tools(&[task_meta::NAME]),
         )]);
 
-        let targets = callable_targets(&catalog, "self-agent");
+        let targets = callable_targets(&catalog, "self-agent")?;
         assert!(targets.iter().any(|t| t.name.as_ref() == "self-agent"));
+        Ok(())
     }
 
     /// Without explicit `permission.task`, Task defaults to all non-primary targets.
     #[test]
-    fn callable_targets_default_to_all_non_primary_when_task_permission_is_absent() {
+    fn callable_targets_default_to_all_non_primary_when_task_permission_is_absent() -> TestResult {
         let catalog = AgentCatalog::from_entries([
             agent(
                 "caller",
@@ -320,14 +328,15 @@ mod tests {
             ),
         ]);
 
-        let targets = callable_targets(&catalog, "caller");
+        let targets = callable_targets(&catalog, "caller")?;
         let names: Vec<_> = targets.iter().map(|t| t.name.as_ref()).collect();
         assert_eq!(names, vec!["all-target", "subagent-target"]);
+        Ok(())
     }
 
     /// Wildcard patterns are evaluated; specific patterns override wildcards.
     #[test]
-    fn callable_targets_honor_wildcard_and_specific_rules_in_order() {
+    fn callable_targets_honor_wildcard_and_specific_rules_in_order() -> TestResult {
         let catalog = AgentCatalog::from_entries([
             agent(
                 "caller",
@@ -352,15 +361,16 @@ mod tests {
             ),
         ]);
 
-        let targets = callable_targets(&catalog, "caller");
+        let targets = callable_targets(&catalog, "caller")?;
         let names: Vec<_> = targets.iter().map(|t| t.name.as_ref()).collect();
         assert!(names.contains(&"review-agent"));
         assert!(!names.contains(&"other-agent"));
+        Ok(())
     }
 
     /// Later patterns take precedence (last-match-wins).
     #[test]
-    fn callable_targets_use_last_match_wins_precedence() {
+    fn callable_targets_use_last_match_wins_precedence() -> TestResult {
         let catalog = AgentCatalog::from_entries([
             agent(
                 "caller",
@@ -385,15 +395,16 @@ mod tests {
             ),
         ]);
 
-        let targets = callable_targets(&catalog, "caller");
+        let targets = callable_targets(&catalog, "caller")?;
         let names: Vec<_> = targets.iter().map(|t| t.name.as_ref()).collect();
         assert!(!names.contains(&"review-agent"));
         assert!(!names.contains(&"other-agent"));
+        Ok(())
     }
 
     /// OpenCode-style task allowlists support both exact names and wildcards.
     #[test]
-    fn callable_targets_support_opencode_style_allowlists() {
+    fn callable_targets_support_opencode_style_allowlists() -> TestResult {
         let catalog = AgentCatalog::from_entries([
             agent(
                 "orchestrator",
@@ -434,7 +445,7 @@ mod tests {
             ),
         ]);
 
-        let targets = callable_targets(&catalog, "orchestrator");
+        let targets = callable_targets(&catalog, "orchestrator")?;
         let names: Vec<_> = targets.iter().map(|t| t.name.as_ref()).collect();
         assert_eq!(
             names,
@@ -445,11 +456,12 @@ mod tests {
                 "orchestrator-runner",
             ]
         );
+        Ok(())
     }
 
     /// Summaries are alphabetically sorted and preserve target descriptions.
     #[test]
-    fn summaries_are_sorted_and_preserve_target_descriptions() {
+    fn summaries_are_sorted_and_preserve_target_descriptions() -> TestResult {
         let catalog = AgentCatalog::from_entries([
             agent(
                 "zebra",
@@ -471,7 +483,7 @@ mod tests {
             ),
         ]);
 
-        let summaries = summarize_callable_targets(&catalog, "caller");
+        let summaries = summarize_callable_targets(&catalog, "caller")?;
 
         let names: Vec<&str> = summaries.iter().map(|s| s.name.as_ref()).collect();
         assert_eq!(names, vec!["alpha", "caller", "zebra"]);
@@ -487,22 +499,24 @@ mod tests {
             .find(|s| s.name.as_ref() == "zebra")
             .unwrap();
         assert_eq!(zebra_summary.description.as_ref(), "Zebra description");
+        Ok(())
     }
 
     /// Explicit deny on `permission.task` suppresses all task targets.
     #[test]
-    fn summaries_return_empty_when_task_is_explicitly_denied() {
+    fn summaries_return_empty_when_task_is_explicitly_denied() -> TestResult {
         let catalog = AgentCatalog::from_entries([
             agent("caller", AgentMode::All, "Caller", deny_task()),
             agent("target", AgentMode::All, "Target", IndexMap::new()),
         ]);
 
-        let summaries = summarize_callable_targets(&catalog, "caller");
+        let summaries = summarize_callable_targets(&catalog, "caller")?;
         assert!(summaries.is_empty());
+        Ok(())
     }
 
     #[test]
-    fn allowed_tools_keeps_task_when_a_target_is_callable() {
+    fn allowed_tools_keeps_task_when_a_target_is_callable() -> TestResult {
         let runtime = AgentRuntimeBuilder::new()
             .catalog(AgentCatalog::from_entries([
                 agent(
@@ -517,7 +531,7 @@ mod tests {
                 agent("reader", AgentMode::Subagent, "Reader", IndexMap::new()),
                 agent("writer", AgentMode::Subagent, "Writer", IndexMap::new()),
             ]))
-            .build();
+            .build()?;
 
         let names: Vec<_> = runtime
             .allowed_tools("caller")
@@ -526,10 +540,11 @@ mod tests {
             .collect();
 
         assert_eq!(names, vec![task_meta::NAME]);
+        Ok(())
     }
 
     #[test]
-    fn allowed_tools_omits_task_when_no_targets_are_callable() {
+    fn allowed_tools_omits_task_when_no_targets_are_callable() -> TestResult {
         let runtime = AgentRuntimeBuilder::new()
             .catalog(AgentCatalog::from_entries([
                 agent(
@@ -545,7 +560,7 @@ mod tests {
                     IndexMap::new(),
                 ),
             ]))
-            .build();
+            .build()?;
 
         let names: Vec<_> = runtime
             .allowed_tools("caller")
@@ -555,5 +570,6 @@ mod tests {
 
         assert!(names.contains(&read_meta::NAME));
         assert!(!names.contains(&task_meta::NAME));
+        Ok(())
     }
 }

--- a/src/llm-coding-tools-core/README.md
+++ b/src/llm-coding-tools-core/README.md
@@ -269,15 +269,18 @@ permission:
 With last-match-wins, the final `"*": deny` rule overrides earlier `task` matches.
 
 ```rust
-use llm_coding_tools_core::permissions::{PermissionAction, Rule, Ruleset};
+use llm_coding_tools_core::permissions::{ExpandError, PermissionAction, Rule, Ruleset};
 
+# fn main() -> Result<(), ExpandError> {
 let mut rules = Ruleset::new();
-rules.push(Rule::new("bash", "*", PermissionAction::Allow));
-rules.push(Rule::new("task", "orchestrator-*", PermissionAction::Allow));
-rules.push(Rule::new("task", "*", PermissionAction::Deny));
+rules.push(Rule::new("bash", "*", PermissionAction::Allow)?);
+rules.push(Rule::new("task", "orchestrator-*", PermissionAction::Allow)?);
+rules.push(Rule::new("task", "*", PermissionAction::Deny)?);
 
 assert_eq!(rules.evaluate("bash", "any-agent"), PermissionAction::Allow);
 assert_eq!(rules.evaluate("task", "orchestrator-review"), PermissionAction::Deny); // last-match-wins
+# Ok(())
+# }
 ```
 
 ## Credentials

--- a/src/llm-coding-tools-core/benches/permissions.rs
+++ b/src/llm-coding-tools-core/benches/permissions.rs
@@ -37,18 +37,20 @@ fn build_ruleset(
     let mut ruleset = Ruleset::with_capacity(rule_count);
 
     for idx in 0..(rule_count - 1) {
-        ruleset.push(Rule::new(
-            format!("tool-{idx}"),
-            format!("/workspace/other-{idx}.txt"),
-            PermissionAction::Deny,
-        ));
+        ruleset.push(
+            Rule::new(
+                format!("tool-{idx}"),
+                format!("/workspace/other-{idx}.txt"),
+                PermissionAction::Deny,
+            )
+            .expect("benchmark fixture patterns should not fail expansion"),
+        );
     }
 
-    ruleset.push(Rule::new(
-        final_permission,
-        final_pattern,
-        PermissionAction::Allow,
-    ));
+    ruleset.push(
+        Rule::new(final_permission, final_pattern, PermissionAction::Allow)
+            .expect("benchmark fixture patterns should not fail expansion"),
+    );
     ruleset
 }
 

--- a/src/llm-coding-tools-core/src/permissions.rs
+++ b/src/llm-coding-tools-core/src/permissions.rs
@@ -35,13 +35,14 @@
 //! ```
 //!
 //! ```rust
-//! use llm_coding_tools_core::permissions::{PermissionAction, Rule, Ruleset};
+//! use llm_coding_tools_core::permissions::{ExpandError, PermissionAction, Rule, Ruleset};
 //!
+//! # fn main() -> Result<(), ExpandError> {
 //! let mut rules = Ruleset::new();
-//! rules.push(Rule::new("*", "*", PermissionAction::Allow));    // Allow all
-//! rules.push(Rule::new("bash", "*", PermissionAction::Deny));  // Except bash
-//! rules.push(Rule::new("task", "*", PermissionAction::Deny));  // Except task
-//! rules.push(Rule::new("task", "orchestrator-*", PermissionAction::Allow)); // But allow `orchestrator-*` task
+//! rules.push(Rule::new("*", "*", PermissionAction::Allow)?);    // Allow all
+//! rules.push(Rule::new("bash", "*", PermissionAction::Deny)?);  // Except bash
+//! rules.push(Rule::new("task", "*", PermissionAction::Deny)?);  // Except task
+//! rules.push(Rule::new("task", "orchestrator-*", PermissionAction::Allow)?); // But allow `orchestrator-*` task
 //!
 //! assert_eq!(rules.evaluate("bash", "any-agent"), PermissionAction::Deny);
 //! assert_eq!(rules.evaluate("read", "any-agent"), PermissionAction::Allow);
@@ -50,6 +51,8 @@
 //!     PermissionAction::Allow
 //! );
 //! assert_eq!(rules.evaluate("task", "other-agent"), PermissionAction::Deny);
+//! # Ok(())
+//! # }
 //! ```
 
 use crate::internal::hash64::hash_u64;
@@ -57,6 +60,10 @@ use crate::internal::hash64::Hash64;
 use crate::path::allowed_glob::normalize::expand_pattern;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+
+/// Error returned when shell expansion of a rule pattern fails
+/// (e.g., `$HOME` is unset).
+pub type ExpandError = shellexpand::LookupError<std::env::VarError>;
 
 /// Permission level for tool access.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -117,24 +124,24 @@ impl Rule {
     /// use llm_coding_tools_core::permissions::{Rule, PermissionAction};
     ///
     /// // Exact match on permission key
-    /// let exact = Rule::new("bash", "*", PermissionAction::Allow);
+    /// let exact = Rule::new("bash", "*", PermissionAction::Allow).unwrap();
     ///
     /// // Wildcard permission key matches any tool
-    /// let wildcard = Rule::new("*", "*", PermissionAction::Allow);
+    /// let wildcard = Rule::new("*", "*", PermissionAction::Allow).unwrap();
     /// ```
     pub fn new(
         permission: impl Into<Box<str>>,
         pattern: impl Into<Box<str>>,
         action: PermissionAction,
-    ) -> Self {
+    ) -> Result<Self, ExpandError> {
         let permission = permission.into();
         let pattern_box: Box<str> = pattern.into();
         let pattern: Box<str> = match expand_pattern(&pattern_box) {
             Ok(Cow::Borrowed(_)) => pattern_box,
             Ok(Cow::Owned(s)) => s.into_boxed_str(),
-            Err(_) => pattern_box,
+            Err(e) => return Err(e),
         };
-        Self {
+        Ok(Self {
             permission_hash: hash_u64(&permission),
             pattern_hash: hash_u64(&pattern),
             permission_is_wildcard: permission.contains('*') || permission.contains('?'),
@@ -142,7 +149,7 @@ impl Rule {
             permission,
             pattern,
             action,
-        }
+        })
     }
 
     /// Returns the permission key pattern.
@@ -441,6 +448,8 @@ mod tests {
     use temp_env;
     use tempfile::TempDir;
 
+    type TestResult = Result<(), ExpandError>;
+
     fn build_and_eval(
         rules: &[(&str, &str, PermissionAction)],
         permission: &str,
@@ -448,7 +457,7 @@ mod tests {
     ) -> PermissionAction {
         let mut ruleset = Ruleset::new();
         for (perm, pat, action) in rules {
-            ruleset.push(Rule::new(*perm, *pat, *action));
+            ruleset.push(Rule::new(*perm, *pat, *action).unwrap());
         }
         ruleset.evaluate(permission, subject)
     }
@@ -510,75 +519,79 @@ mod tests {
 
     /// A plain permission key without `*` or `?` must not set the wildcard flag.
     #[test]
-    fn exact_key_should_not_set_wildcard_flag() {
-        let rule = Rule::new("bash", "*", PermissionAction::Allow);
+    fn exact_key_should_not_set_wildcard_flag() -> TestResult {
+        let rule = Rule::new("bash", "*", PermissionAction::Allow)?;
         assert_eq!(rule.permission(), "bash");
         assert_eq!(rule.permission_hash(), hash_u64("bash").as_u64());
         assert!(!rule.permission_is_wildcard());
         assert_eq!(rule.action(), PermissionAction::Allow);
+        Ok(())
     }
 
     /// A lone `*` permission key must set the wildcard flag.
     #[test]
-    fn star_key_should_set_wildcard_flag() {
-        let rule = Rule::new("*", "*", PermissionAction::Allow);
+    fn star_key_should_set_wildcard_flag() -> TestResult {
+        let rule = Rule::new("*", "*", PermissionAction::Allow)?;
         assert_eq!(rule.permission(), "*");
         assert_eq!(rule.permission_hash(), hash_u64("*").as_u64());
         assert!(rule.permission_is_wildcard());
+        Ok(())
     }
 
     /// A permission key like `"bash*"` ends with a wildcard and must set the flag.
     #[test]
-    fn partial_wildcard_key_should_set_wildcard_flag() {
-        let rule = Rule::new("bash*", "*", PermissionAction::Allow);
+    fn partial_wildcard_key_should_set_wildcard_flag() -> TestResult {
+        let rule = Rule::new("bash*", "*", PermissionAction::Allow)?;
         assert_eq!(rule.permission(), "bash*");
         assert_eq!(rule.permission_hash(), hash_u64("bash*").as_u64());
         assert!(rule.permission_is_wildcard());
+        Ok(())
     }
 
     /// A subject pattern containing `*` must set the pattern wildcard flag, leaving permission untouched.
     #[test]
-    fn wildcard_subject_should_set_wildcard_flag() {
-        let rule = Rule::new("bash", "orchestrator-*", PermissionAction::Allow);
+    fn wildcard_subject_should_set_wildcard_flag() -> TestResult {
+        let rule = Rule::new("bash", "orchestrator-*", PermissionAction::Allow)?;
         assert_eq!(rule.pattern(), "orchestrator-*");
         assert_eq!(rule.pattern_hash(), hash_u64("orchestrator-*").as_u64());
         assert!(rule.pattern_is_wildcard());
         assert!(!rule.permission_is_wildcard());
+        Ok(())
     }
 
     /// A plain subject string without wildcards must not set the pattern wildcard flag.
     #[test]
-    fn exact_subject_should_not_set_wildcard_flag() {
-        let rule = Rule::new("bash", "exact-subject", PermissionAction::Allow);
+    fn exact_subject_should_not_set_wildcard_flag() -> TestResult {
+        let rule = Rule::new("bash", "exact-subject", PermissionAction::Allow)?;
         assert_eq!(rule.pattern(), "exact-subject");
         assert_eq!(rule.pattern_hash(), hash_u64("exact-subject").as_u64());
         assert!(!rule.pattern_is_wildcard());
         assert!(!rule.permission_is_wildcard());
+        Ok(())
     }
 
     #[test]
-    fn rule_permission_hash_should_be_case_sensitive() {
-        let upper = Rule::new("BASH", "*", PermissionAction::Allow);
-        let lower = Rule::new("bash", "*", PermissionAction::Allow);
+    fn rule_permission_hash_should_be_case_sensitive() -> TestResult {
+        let upper = Rule::new("BASH", "*", PermissionAction::Allow)?;
+        let lower = Rule::new("bash", "*", PermissionAction::Allow)?;
         assert_ne!(upper.permission_hash(), lower.permission_hash());
+        Ok(())
     }
 
     #[test]
-    fn rule_pattern_hash_should_be_case_sensitive() {
-        let upper = Rule::new("bash", "SUBJECT", PermissionAction::Allow);
-        let lower = Rule::new("bash", "subject", PermissionAction::Allow);
+    fn rule_pattern_hash_should_be_case_sensitive() -> TestResult {
+        let upper = Rule::new("bash", "SUBJECT", PermissionAction::Allow)?;
+        let lower = Rule::new("bash", "subject", PermissionAction::Allow)?;
         assert_ne!(upper.pattern_hash(), lower.pattern_hash());
+        Ok(())
     }
 
     #[test]
     fn rule_should_be_56_byte_clone() {
         assert_eq!(std::mem::size_of::<Rule>(), 56);
-        // Rule is Clone but not Copy (contains owned Box<str>)
         fn assert_clone<T: Clone>() {}
         assert_clone::<Rule>();
     }
-
-    // --- Ruleset evaluate ---
 
     #[test]
     fn evaluate_when_no_rules_should_deny() {
@@ -701,35 +714,38 @@ mod tests {
     // --- Ruleset convenience ---
 
     #[test]
-    fn is_allowed_should_reflect_evaluate() {
+    fn is_allowed_should_reflect_evaluate() -> TestResult {
         let mut ruleset = Ruleset::new();
-        ruleset.push(Rule::new("bash", "*", PermissionAction::Allow));
+        ruleset.push(Rule::new("bash", "*", PermissionAction::Allow)?);
         assert!(ruleset.is_allowed("bash", "any"));
         assert!(!ruleset.is_allowed("task", "any"));
+        Ok(())
     }
 
     #[test]
-    fn merge_should_append_and_override() {
+    fn merge_should_append_and_override() -> TestResult {
         let mut base = Ruleset::new();
-        base.push(Rule::new("bash", "*", PermissionAction::Deny));
+        base.push(Rule::new("bash", "*", PermissionAction::Deny)?);
 
         let mut override_rules = Ruleset::new();
-        override_rules.push(Rule::new("bash", "*", PermissionAction::Allow));
+        override_rules.push(Rule::new("bash", "*", PermissionAction::Allow)?);
 
         base.merge(&override_rules);
         assert_eq!(base.evaluate("bash", "any"), PermissionAction::Allow);
+        Ok(())
     }
 
     #[test]
-    fn merged_should_concatenate_in_order() {
+    fn merged_should_concatenate_in_order() -> TestResult {
         let mut r1 = Ruleset::new();
-        r1.push(Rule::new("a", "*", PermissionAction::Deny));
+        r1.push(Rule::new("a", "*", PermissionAction::Deny)?);
 
         let mut r2 = Ruleset::new();
-        r2.push(Rule::new("a", "*", PermissionAction::Allow));
+        r2.push(Rule::new("a", "*", PermissionAction::Allow)?);
 
         let combined = Ruleset::merged([&r1, &r2]);
         assert_eq!(combined.evaluate("a", "x"), PermissionAction::Allow);
+        Ok(())
     }
 
     // --- Rule::new with expansion integration ---
@@ -737,13 +753,13 @@ mod tests {
     /// Verifies that a rule created with `~/` pattern matches the expanded home path.
     #[cfg(not(windows))]
     #[test]
-    fn rule_with_tilde_pattern_should_match_expanded_path() {
+    fn rule_with_tilde_pattern_should_match_expanded_path() -> TestResult {
         let temp_dir = TempDir::new().unwrap();
         let temp_home = temp_dir.path().canonicalize().unwrap();
 
-        temp_env::with_var("HOME", Some(&temp_home), || {
+        temp_env::with_var("HOME", Some(&temp_home), || -> TestResult {
             let mut ruleset = Ruleset::new();
-            ruleset.push(Rule::new("read", "~/projects/*", PermissionAction::Allow));
+            ruleset.push(Rule::new("read", "~/projects/*", PermissionAction::Allow)?);
 
             let subject = format!("{}/projects/src/lib.rs", temp_home.to_str().unwrap());
             assert_eq!(
@@ -751,22 +767,23 @@ mod tests {
                 PermissionAction::Allow,
                 "expanded ~/ pattern should match real path"
             );
-        });
+            Ok(())
+        })
     }
 
     /// Verifies that a rule created with `$HOME/` pattern matches the expanded path.
     #[test]
-    fn rule_with_dollar_home_pattern_should_match_expanded_path() {
+    fn rule_with_dollar_home_pattern_should_match_expanded_path() -> TestResult {
         let temp_dir = TempDir::new().unwrap();
         let temp_home = temp_dir.path().canonicalize().unwrap();
 
-        temp_env::with_var("HOME", Some(&temp_home), || {
+        temp_env::with_var("HOME", Some(&temp_home), || -> TestResult {
             let mut ruleset = Ruleset::new();
             ruleset.push(Rule::new(
                 "read",
                 "$HOME/.config/*",
                 PermissionAction::Allow,
-            ));
+            )?);
 
             let subject = format!("{}/.config/app.conf", temp_home.to_str().unwrap());
             assert_eq!(
@@ -774,16 +791,21 @@ mod tests {
                 PermissionAction::Allow,
                 "expanded $HOME/ pattern should match real path"
             );
-        });
+            Ok(())
+        })
     }
 
     /// Verifies that rules without shell patterns evaluate correctly after
     /// the expansion change (regression guard).
     #[test]
-    fn rule_without_shell_patterns_evaluates_correctly() {
+    fn rule_without_shell_patterns_evaluates_correctly() -> TestResult {
         let mut ruleset = Ruleset::new();
-        ruleset.push(Rule::new("bash", "*", PermissionAction::Allow));
-        ruleset.push(Rule::new("task", "orchestrator-*", PermissionAction::Allow));
+        ruleset.push(Rule::new("bash", "*", PermissionAction::Allow)?);
+        ruleset.push(Rule::new(
+            "task",
+            "orchestrator-*",
+            PermissionAction::Allow,
+        )?);
 
         assert_eq!(
             ruleset.evaluate("bash", "anything"),
@@ -794,5 +816,6 @@ mod tests {
             PermissionAction::Allow
         );
         assert_eq!(ruleset.evaluate("task", "other"), PermissionAction::Deny);
+        Ok(())
     }
 }

--- a/src/llm-coding-tools-core/src/permissions.rs
+++ b/src/llm-coding-tools-core/src/permissions.rs
@@ -457,7 +457,10 @@ mod tests {
     ) -> PermissionAction {
         let mut ruleset = Ruleset::new();
         for (perm, pat, action) in rules {
-            ruleset.push(Rule::new(*perm, *pat, *action).unwrap());
+            ruleset.push(Rule::new(*perm, *pat, *action).expect(&format!(
+                "failed to create Rule for permission {:?}, pattern {:?}, action {:?}",
+                perm, pat, action
+            )));
         }
         ruleset.evaluate(permission, subject)
     }

--- a/src/llm-coding-tools-core/src/permissions_ext.rs
+++ b/src/llm-coding-tools-core/src/permissions_ext.rs
@@ -6,18 +6,22 @@
 //! # Example
 //!
 //! ```
-//! use llm_coding_tools_core::permissions::{PermissionAction, Rule, Ruleset};
+//! use llm_coding_tools_core::permissions::{ExpandError, PermissionAction, Rule, Ruleset};
 //! use llm_coding_tools_core::permissions_ext::OptionRulesetExt;
 //!
-//! // With ruleset configured to allow all
+//! # fn main() -> Result<(), ExpandError> {
 //! let mut ruleset = Ruleset::new();
-//! ruleset.push(Rule::new("*", "*", PermissionAction::Allow));
+//! ruleset.push(Rule::new("*", "*", PermissionAction::Allow)?);
+//!
+//! // With ruleset configured to allow all
 //! let result: Option<&Ruleset> = Some(&ruleset);
-//! result.check("bash", "some-command").unwrap();
+//! assert!(result.check("bash", "some-command").is_ok());
 //!
 //! // Without ruleset (always allows)
 //! let no_ruleset: Option<&Ruleset> = None;
-//! no_ruleset.check("bash", "any-command").unwrap(); // Always Ok(())
+//! assert!(no_ruleset.check("bash", "any-command").is_ok()); // Always Ok(())
+//! # Ok(())
+//! # }
 //! ```
 
 use crate::error::{ToolError, ToolResult};
@@ -56,7 +60,9 @@ impl OptionRulesetExt for Option<&Ruleset> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::permissions::Rule;
+    use crate::permissions::{ExpandError, Rule};
+
+    type TestResult = Result<(), ExpandError>;
 
     #[test]
     fn option_ruleset_ext_without_ruleset_allows_access() {
@@ -65,13 +71,13 @@ mod tests {
     }
 
     #[test]
-    fn option_ruleset_ext_returns_permission_denied_for_denied_subject() {
+    fn option_ruleset_ext_returns_permission_denied_for_denied_subject() -> TestResult {
         let mut ruleset = Ruleset::new();
         ruleset.push(Rule::new(
             "read",
             "/tmp/allowed.txt",
             PermissionAction::Allow,
-        ));
+        )?);
 
         let err = Some(&ruleset).check("read", "/tmp/denied.txt").unwrap_err();
 
@@ -82,13 +88,15 @@ mod tests {
                 subject,
             } if subject == "/tmp/denied.txt"
         ));
+        Ok(())
     }
 
     #[test]
-    fn option_ruleset_ext_returns_ok_for_allowed() {
+    fn option_ruleset_ext_returns_ok_for_allowed() -> TestResult {
         let mut ruleset = Ruleset::new();
-        ruleset.push(Rule::new("read", "*", PermissionAction::Allow));
+        ruleset.push(Rule::new("read", "*", PermissionAction::Allow)?);
 
         assert!(Some(&ruleset).check("read", "/tmp/file.txt").is_ok());
+        Ok(())
     }
 }

--- a/src/llm-coding-tools-core/src/tools/bash/blocking_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/bash/blocking_impl.rs
@@ -231,10 +231,12 @@ fn build_host_wrap(command: &str, workdir: Option<&Path>) -> ToolResult<CommandW
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::permissions::{PermissionAction, Rule, Ruleset};
+    use crate::permissions::{ExpandError, PermissionAction, Rule, Ruleset};
     use crate::tool_metadata::bash as bash_meta;
     use crate::tools::{BashRequest, BashSettings};
     use tempfile::TempDir;
+
+    type TestResult = Result<(), ExpandError>;
 
     #[test]
     fn execute_echo_returns_output() {
@@ -259,14 +261,14 @@ mod tests {
     }
 
     #[test]
-    fn rejected_command_returns_permission_denied() {
+    fn rejected_command_returns_permission_denied() -> TestResult {
         let mut ruleset = Ruleset::new();
-        ruleset.push(Rule::new(bash_meta::NAME, "*", PermissionAction::Allow));
+        ruleset.push(Rule::new(bash_meta::NAME, "*", PermissionAction::Allow)?);
         ruleset.push(Rule::new(
             bash_meta::NAME,
             "echo hello",
             PermissionAction::Deny,
-        ));
+        )?);
 
         let err = execute_command(
             &BashExecutionMode::Host,
@@ -288,6 +290,7 @@ mod tests {
             err,
             ToolError::PermissionDenied { tool: "bash", .. }
         ));
+        Ok(())
     }
 
     #[test]

--- a/src/llm-coding-tools-core/src/tools/bash/tokio_impl.rs
+++ b/src/llm-coding-tools-core/src/tools/bash/tokio_impl.rs
@@ -272,10 +272,12 @@ fn build_host_wrap(command: &str, workdir: Option<&Path>) -> ToolResult<CommandW
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::permissions::{PermissionAction, Rule, Ruleset};
+    use crate::permissions::{ExpandError, PermissionAction, Rule, Ruleset};
     use crate::tool_metadata::bash as bash_meta;
     use crate::tools::{BashRequest, BashSettings};
     use tempfile::TempDir;
+
+    type TestResult = Result<(), ExpandError>;
 
     #[tokio::test]
     async fn execute_echo_returns_output() {
@@ -301,14 +303,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejected_command_returns_permission_denied() {
+    async fn rejected_command_returns_permission_denied() -> TestResult {
         let mut ruleset = Ruleset::new();
-        ruleset.push(Rule::new(bash_meta::NAME, "*", PermissionAction::Allow));
+        ruleset.push(Rule::new(bash_meta::NAME, "*", PermissionAction::Allow)?);
         ruleset.push(Rule::new(
             bash_meta::NAME,
             "echo hello",
             PermissionAction::Deny,
-        ));
+        )?);
 
         let err = execute_command(
             &BashExecutionMode::Host,
@@ -331,6 +333,7 @@ mod tests {
             err,
             ToolError::PermissionDenied { tool: "bash", .. }
         ));
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/llm-coding-tools-core/src/tools/edit.rs
+++ b/src/llm-coding-tools-core/src/tools/edit.rs
@@ -201,9 +201,11 @@ pub async fn edit_file<R: PathResolver>(
 mod tests {
     use super::*;
     use crate::path::AbsolutePathResolver;
-    use crate::permissions::{PermissionAction, Rule};
+    use crate::permissions::{ExpandError, PermissionAction, Rule};
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    type TestResult = Result<(), ExpandError>;
 
     fn create_temp_file(content: &str) -> NamedTempFile {
         let mut file = NamedTempFile::new().unwrap();
@@ -256,17 +258,17 @@ mod tests {
     }
 
     #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]
-    async fn edit_rejects_denied_path() {
+    async fn edit_rejects_denied_path() -> TestResult {
         let file = create_temp_file("hello world");
         let resolver = AbsolutePathResolver;
 
         let mut ruleset = Ruleset::new();
-        ruleset.push(Rule::new("edit", "*", PermissionAction::Allow));
+        ruleset.push(Rule::new("edit", "*", PermissionAction::Allow)?);
         ruleset.push(Rule::new(
             "edit",
             file.path().to_string_lossy().into_owned(),
             PermissionAction::Deny,
-        ));
+        )?);
 
         let err = edit_file(
             &resolver,
@@ -285,5 +287,6 @@ mod tests {
             err,
             EditError::Tool(ToolError::PermissionDenied { tool: "edit", .. })
         ));
+        Ok(())
     }
 }

--- a/src/llm-coding-tools-core/src/tools/glob.rs
+++ b/src/llm-coding-tools-core/src/tools/glob.rs
@@ -240,12 +240,14 @@ pub fn glob_files<R: PathResolver>(
 mod tests {
     use super::*;
     use crate::path::AbsolutePathResolver;
-    use crate::permissions::{PermissionAction, Rule};
+    use crate::permissions::{ExpandError, PermissionAction, Rule};
     use rstest::rstest;
     use std::fs::{self, File, FileTimes};
     use std::io::Write;
     use std::time::{Duration, SystemTime};
     use tempfile::TempDir;
+
+    type TestResult = Result<(), ExpandError>;
 
     fn create_test_tree() -> TempDir {
         let dir = TempDir::new().unwrap();
@@ -433,7 +435,7 @@ mod tests {
     }
 
     #[test]
-    fn glob_filters_denied_files_before_returning_output() {
+    fn glob_filters_denied_files_before_returning_output() -> TestResult {
         let dir = TempDir::new().unwrap();
         let resolver = AbsolutePathResolver;
         let allowed = dir.path().join("allowed.txt");
@@ -442,12 +444,12 @@ mod tests {
         File::create(&denied).unwrap();
 
         let mut ruleset = Ruleset::new();
-        ruleset.push(Rule::new(glob_meta::NAME, "*", PermissionAction::Allow));
+        ruleset.push(Rule::new(glob_meta::NAME, "*", PermissionAction::Allow)?);
         ruleset.push(Rule::new(
             glob_meta::NAME,
             denied.to_string_lossy().into_owned(),
             PermissionAction::Deny,
-        ));
+        )?);
 
         let result = glob_files(
             &resolver,
@@ -460,5 +462,6 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.files, vec!["allowed.txt".to_string()]);
+        Ok(())
     }
 }

--- a/src/llm-coding-tools-core/src/tools/grep.rs
+++ b/src/llm-coding-tools-core/src/tools/grep.rs
@@ -472,9 +472,11 @@ fn collect_file_matches(
 mod tests {
     use super::*;
     use crate::path::AbsolutePathResolver;
-    use crate::permissions::{PermissionAction, Rule};
+    use crate::permissions::{ExpandError, PermissionAction, Rule};
     use rstest::rstest;
     use tempfile::tempdir;
+
+    type TestResult = Result<(), ExpandError>;
 
     // GrepSettings and GrepFormattingSettings tests
     #[test]
@@ -814,7 +816,7 @@ mod tests {
     }
 
     #[test]
-    fn grep_skips_denied_files_before_counting_matches() {
+    fn grep_skips_denied_files_before_counting_matches() -> TestResult {
         let temp = tempdir().unwrap();
         let allowed = temp.path().join("allowed.txt");
         let denied = temp.path().join("denied.txt");
@@ -823,12 +825,12 @@ mod tests {
         let resolver = AbsolutePathResolver;
 
         let mut ruleset = Ruleset::new();
-        ruleset.push(Rule::new(grep_meta::NAME, "*", PermissionAction::Allow));
+        ruleset.push(Rule::new(grep_meta::NAME, "*", PermissionAction::Allow)?);
         ruleset.push(Rule::new(
             grep_meta::NAME,
             denied.to_string_lossy().into_owned(),
             PermissionAction::Deny,
-        ));
+        )?);
 
         let result = grep_search(
             &resolver,
@@ -845,5 +847,6 @@ mod tests {
         assert_eq!(result.match_count, 1);
         assert_eq!(result.files.len(), 1);
         assert_eq!(result.files[0].path, allowed.to_string_lossy());
+        Ok(())
     }
 }

--- a/src/llm-coding-tools-core/src/tools/read.rs
+++ b/src/llm-coding-tools-core/src/tools/read.rs
@@ -419,10 +419,12 @@ pub async fn read_file<R: PathResolver>(
 mod tests {
     use super::*;
     use crate::path::AbsolutePathResolver;
-    use crate::permissions::{PermissionAction, Rule};
+    use crate::permissions::{ExpandError, PermissionAction, Rule};
     use rstest::rstest;
     use std::io::Write as _;
     use tempfile::NamedTempFile;
+
+    type TestResult = Result<(), ExpandError>;
 
     #[maybe_async::maybe_async]
     async fn read_temp_file(
@@ -605,18 +607,18 @@ mod tests {
     }
 
     #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]
-    async fn read_request_rejects_denied_path() {
+    async fn read_request_rejects_denied_path() -> TestResult {
         let mut temp = NamedTempFile::new().unwrap();
         temp.write_all(b"line1\n").unwrap();
         let resolver = AbsolutePathResolver;
 
         let mut ruleset = Ruleset::new();
-        ruleset.push(Rule::new("read", "*", PermissionAction::Allow));
+        ruleset.push(Rule::new("read", "*", PermissionAction::Allow)?);
         ruleset.push(Rule::new(
             "read",
             temp.path().to_string_lossy().into_owned(),
             PermissionAction::Deny,
-        ));
+        )?);
 
         let err = read_file(
             &resolver,
@@ -634,5 +636,6 @@ mod tests {
             err,
             ToolError::PermissionDenied { tool: "read", .. }
         ));
+        Ok(())
     }
 }

--- a/src/llm-coding-tools-core/src/tools/write.rs
+++ b/src/llm-coding-tools-core/src/tools/write.rs
@@ -111,8 +111,10 @@ pub async fn write_file<R: PathResolver>(
 mod tests {
     use super::*;
     use crate::path::AbsolutePathResolver;
-    use crate::permissions::{PermissionAction, Rule};
+    use crate::permissions::{ExpandError, PermissionAction, Rule};
     use tempfile::TempDir;
+
+    type TestResult = Result<(), ExpandError>;
 
     #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]
     async fn write_creates_new_file() {
@@ -156,18 +158,18 @@ mod tests {
     }
 
     #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]
-    async fn write_rejects_denied_path() {
+    async fn write_rejects_denied_path() -> TestResult {
         let temp = TempDir::new().unwrap();
         let file_path = temp.path().join("denied.txt");
         let resolver = AbsolutePathResolver;
 
         let mut ruleset = Ruleset::new();
-        ruleset.push(Rule::new("write", "*", PermissionAction::Allow));
+        ruleset.push(Rule::new("write", "*", PermissionAction::Allow)?);
         ruleset.push(Rule::new(
             "write",
             file_path.to_string_lossy().into_owned(),
             PermissionAction::Deny,
-        ));
+        )?);
 
         let err = write_file(
             &resolver,
@@ -184,5 +186,6 @@ mod tests {
             err,
             ToolError::PermissionDenied { tool: "write", .. }
         ));
+        Ok(())
     }
 }

--- a/src/llm-coding-tools-serdesai/README.md
+++ b/src/llm-coding-tools-serdesai/README.md
@@ -113,7 +113,7 @@ let runtime = AgentRuntimeBuilder::new()
     .catalog(catalog)
     .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4o-mini"))
     // .max_task_depth(5) // Optional: defaults to 3 Task hops
-    .build();
+    .build()?;
 
 let build_context = AgentBuildContext::new(
     Arc::new(runtime),

--- a/src/llm-coding-tools-serdesai/examples/serdesai-agents.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-agents.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let runtime = AgentRuntimeBuilder::new()
         .catalog(catalog)
         .defaults(AgentDefaults::with_model(MODEL_ID))
-        .build();
+        .build()?;
     let build_context = AgentBuildContext::new(
         Arc::new(runtime),
         Arc::new(load_result.catalog),

--- a/src/llm-coding-tools-serdesai/examples/serdesai-task.rs
+++ b/src/llm-coding-tools-serdesai/examples/serdesai-task.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let runtime = AgentRuntimeBuilder::new()
         .catalog(catalog)
         .defaults(AgentDefaults::with_model(MODEL_ID))
-        .build();
+        .build()?;
     let build_context = AgentBuildContext::new(
         Arc::new(runtime),
         Arc::new(load_result.catalog),

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
@@ -320,13 +320,15 @@ mod tests {
         Modality, ModelCatalog, ModelInfo, ProviderIdx, ProviderInfo, ProviderModelSource,
         ProviderSource, ProviderType,
     };
-    use llm_coding_tools_core::permissions::PermissionAction;
+    use llm_coding_tools_core::permissions::{ExpandError, PermissionAction};
     use llm_coding_tools_core::tool_metadata::{
         bash as bash_meta, glob as glob_meta, grep as grep_meta, read as read_meta,
     };
     use serdes_ai::AgentBuilder;
     use serdes_ai_models::MockModel;
     use std::collections::HashSet;
+
+    type TestResult = Result<(), ExpandError>;
 
     /// Builds an agent using a mock model instead of a real one.
     fn build_with_mock(
@@ -427,7 +429,7 @@ mod tests {
     }
 
     #[test]
-    fn build_filters_tools_by_permission() {
+    fn build_filters_tools_by_permission() -> TestResult {
         let credentials = credentials();
         let catalog = catalog();
 
@@ -442,7 +444,7 @@ mod tests {
                 agent("no-tools", IndexMap::new(), "prompt"),
             ]))
             .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
-            .build();
+            .build()?;
 
         // Agent with permissions gets only the allowed tools
         let prepared = prepare_build(&runtime, "with-tools", &catalog, &credentials, true)
@@ -458,10 +460,11 @@ mod tests {
             .expect("should succeed");
         let agent = build_with_mock(&prepared, "no-tools");
         assert!(agent.tools().is_empty());
+        Ok(())
     }
 
     #[test]
-    fn build_uses_agent_model_and_sampling_over_defaults() {
+    fn build_uses_agent_model_and_sampling_over_defaults() -> TestResult {
         let credentials = credentials();
         let catalog = catalog();
 
@@ -480,7 +483,7 @@ mod tests {
                 temperature: Some(1.0),
                 top_p: Some(0.95),
             })
-            .build();
+            .build()?;
 
         // Agent-level settings win over defaults
         let prepared = prepare_build(&runtime, "planner", &catalog, &credentials, true)
@@ -488,17 +491,18 @@ mod tests {
         assert_eq!(prepared.model_spec.as_ref(), "openrouter:openai/gpt-4o");
         assert!((prepared.temperature.unwrap() - 0.4).abs() < 1e-6);
         assert!((prepared.top_p.unwrap() - 0.8).abs() < 1e-6);
+        Ok(())
     }
 
     #[test]
-    fn build_handles_catalog_edge_cases() {
+    fn build_handles_catalog_edge_cases() -> TestResult {
         let credentials = credentials();
         let catalog = catalog();
 
         // Unknown agent name returns clear error
         let runtime = AgentRuntimeBuilder::new()
             .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
-            .build();
+            .build()?;
         let err = prepare_build(&runtime, "missing", &catalog, &credentials, true)
             .err()
             .expect("should fail");
@@ -525,20 +529,21 @@ mod tests {
                 ),
             ]))
             .defaults(AgentDefaults::default())
-            .build();
+            .build()?;
         let prepared =
             prepare_build(&runtime, "dupe", &catalog, &credentials, true).expect("should succeed");
         assert_eq!(prepared.model_spec.as_ref(), "openrouter:openai/gpt-4o");
         let agent = build_with_mock(&prepared, "dupe");
         assert_eq!(agent.tools().len(), 1);
         assert_eq!(agent.tools()[0].name(), glob_meta::NAME);
+        Ok(())
     }
 
     /// Verifies that `tool_settings.line_numbers` selects the correct generic
     /// tool variant by checking tool descriptions (the only observable difference
     /// between `ReadTool::<true>` and `ReadTool::<false>`).
     #[test]
-    fn build_wires_line_numbers_to_correct_tool_variant() {
+    fn build_wires_line_numbers_to_correct_tool_variant() -> TestResult {
         let credentials = credentials();
         let catalog = catalog();
 
@@ -554,7 +559,7 @@ mod tests {
                 "prompt",
             )]))
             .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
-            .build();
+            .build()?;
 
         let prepared = prepare_build(&runtime_true, "numbered", &catalog, &credentials, true)
             .expect("should succeed");
@@ -590,7 +595,7 @@ mod tests {
                 prompt: "prompt".into(),
             }]))
             .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
-            .build();
+            .build()?;
 
         let prepared = prepare_build(&runtime_false, "raw", &catalog, &credentials, true)
             .expect("should succeed");
@@ -609,5 +614,6 @@ mod tests {
             !tools[grep_meta::NAME].contains("line numbers"),
             "grep with line_numbers=false should not mention line numbers"
         );
+        Ok(())
     }
 }

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/task.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/task.rs
@@ -145,10 +145,12 @@ mod tests {
         Modality, ModelCatalog, ModelInfo, ProviderIdx, ProviderInfo, ProviderModelSource,
         ProviderSource, ProviderType,
     };
-    use llm_coding_tools_core::permissions::PermissionAction;
+    use llm_coding_tools_core::permissions::{ExpandError, PermissionAction};
     use llm_coding_tools_core::tool_metadata::{
         read as read_meta, task as task_meta, write as write_meta,
     };
+
+    type TestResult = Result<(), ExpandError>;
 
     fn agent(
         name: &str,
@@ -217,7 +219,7 @@ mod tests {
     }
 
     #[test]
-    fn build_agent_skips_task_tool_when_no_targets_are_callable() {
+    fn build_agent_skips_task_tool_when_no_targets_are_callable() -> TestResult {
         let credentials = credentials();
         let model_catalog = Arc::new(catalog());
 
@@ -232,7 +234,7 @@ mod tests {
                 agent("other", AgentMode::Primary, allow_tools(&[]), "prompt"),
             ]))
             .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
-            .build();
+            .build()?;
 
         let context = Arc::new(TaskBuildContext {
             runtime: Arc::new(runtime),
@@ -243,10 +245,11 @@ mod tests {
         let agent = build_agent(context, "caller", 0).expect("build should succeed");
         let names: Vec<_> = agent.tools().iter().map(|t| t.name()).collect();
         assert!(!names.contains(&task_meta::NAME));
+        Ok(())
     }
 
     #[test]
-    fn build_agent_attaches_task_when_callable_targets_exist() {
+    fn build_agent_attaches_task_when_callable_targets_exist() -> TestResult {
         let credentials = credentials();
         let model_catalog = Arc::new(catalog());
 
@@ -266,7 +269,7 @@ mod tests {
                 ),
             ]))
             .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
-            .build();
+            .build()?;
 
         let context = Arc::new(TaskBuildContext {
             runtime: Arc::new(runtime),
@@ -278,10 +281,11 @@ mod tests {
         let names: Vec<_> = agent.tools().iter().map(|t| t.name()).collect();
         assert!(names.contains(&task_meta::NAME));
         assert!(names.contains(&read_meta::NAME));
+        Ok(())
     }
 
     #[test]
-    fn build_agent_attaches_task_when_task_permission_is_target_scoped() {
+    fn build_agent_attaches_task_when_task_permission_is_target_scoped() -> TestResult {
         let credentials = credentials();
         let model_catalog = Arc::new(catalog());
 
@@ -299,7 +303,7 @@ mod tests {
                 agent("reader", AgentMode::Subagent, allow_tools(&[]), "prompt"),
             ]))
             .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
-            .build();
+            .build()?;
 
         let context = Arc::new(TaskBuildContext {
             runtime: Arc::new(runtime),
@@ -310,10 +314,11 @@ mod tests {
         let agent = build_agent(context, "caller", 0).expect("build should succeed");
         let names: Vec<_> = agent.tools().iter().map(|t| t.name()).collect();
         assert_eq!(names, vec![task_meta::NAME]);
+        Ok(())
     }
 
     #[test]
-    fn build_agent_attaches_task_when_permission_task_is_absent() {
+    fn build_agent_attaches_task_when_permission_task_is_absent() -> TestResult {
         let credentials = credentials();
         let model_catalog = Arc::new(catalog());
 
@@ -328,7 +333,7 @@ mod tests {
                 agent("reader", AgentMode::Subagent, allow_tools(&[]), "prompt"),
             ]))
             .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
-            .build();
+            .build()?;
 
         let context = Arc::new(TaskBuildContext {
             runtime: Arc::new(runtime),
@@ -336,16 +341,15 @@ mod tests {
             credentials,
         });
 
-        // OpenCode-compatible default: omitting `permission.task` still exposes Task.
-        // Any non-primary callable target keeps delegation available to the caller.
         let agent = build_agent(context, "caller", 0).expect("build should succeed");
         let names: Vec<_> = agent.tools().iter().map(|t| t.name()).collect();
         assert!(names.contains(&read_meta::NAME));
         assert!(names.contains(&task_meta::NAME));
+        Ok(())
     }
 
     #[test]
-    fn agent_build_context_omits_task_tool_when_no_targets_are_callable() {
+    fn agent_build_context_omits_task_tool_when_no_targets_are_callable() -> TestResult {
         let model_catalog = Arc::new(catalog());
         let credentials = credentials();
 
@@ -360,18 +364,17 @@ mod tests {
                 agent("other", AgentMode::Primary, allow_tools(&[]), "prompt"),
             ]))
             .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
-            .build();
+            .build()?;
 
         let context = AgentBuildContext::new(Arc::new(runtime), model_catalog, credentials);
         let agent = context.build("caller").expect("build should succeed");
         let names: Vec<_> = agent.tools().iter().map(|t| t.name()).collect();
         assert!(!names.contains(&task_meta::NAME));
+        Ok(())
     }
 
     #[test]
-    fn build_agent_omits_task_tool_at_max_depth() {
-        // Mid-chain: an already-delegated agent (depth=1) at max_task_depth=1
-        // must not receive the Task tool.
+    fn build_agent_omits_task_tool_at_max_depth() -> TestResult {
         let credentials = credentials();
         let model_catalog = Arc::new(catalog());
 
@@ -392,7 +395,7 @@ mod tests {
             ]))
             .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
             .max_task_depth(1)
-            .build();
+            .build()?;
 
         let context = Arc::new(TaskBuildContext {
             runtime: Arc::new(runtime),
@@ -404,11 +407,11 @@ mod tests {
         let names: Vec<_> = agent.tools().iter().map(|t| t.name()).collect();
         assert!(!names.contains(&task_meta::NAME));
         assert!(names.contains(&read_meta::NAME));
+        Ok(())
     }
 
     #[test]
-    fn agent_build_context_omits_task_tool_when_max_depth_is_zero() {
-        // Root agent: max_task_depth=0 disables delegation entirely from the start.
+    fn agent_build_context_omits_task_tool_when_max_depth_is_zero() -> TestResult {
         let model_catalog = Arc::new(catalog());
         let credentials = credentials();
 
@@ -429,12 +432,13 @@ mod tests {
             ]))
             .defaults(AgentDefaults::with_model("openrouter/openai/gpt-4.1-mini"))
             .max_task_depth(0)
-            .build();
+            .build()?;
 
         let context = AgentBuildContext::new(Arc::new(runtime), model_catalog, credentials);
         let agent = context.build("caller").expect("build should succeed");
         let names: Vec<_> = agent.tools().iter().map(|t| t.name()).collect();
         assert!(!names.contains(&task_meta::NAME));
         assert!(names.contains(&read_meta::NAME));
+        Ok(())
     }
 }

--- a/src/llm-coding-tools-serdesai/src/task/handle.rs
+++ b/src/llm-coding-tools-serdesai/src/task/handle.rs
@@ -163,7 +163,7 @@ mod tests {
         Modality, ModelCatalog, ModelInfo, ProviderIdx, ProviderInfo, ProviderModelSource,
         ProviderSource, ProviderType,
     };
-    use llm_coding_tools_core::permissions::PermissionAction;
+    use llm_coding_tools_core::permissions::{ExpandError, PermissionAction};
 
     fn agent(
         name: &str,
@@ -237,10 +237,10 @@ mod tests {
     }
 
     fn build_test_context(
-        runtime: llm_coding_tools_agents::AgentRuntime,
+        runtime: Result<llm_coding_tools_agents::AgentRuntime, ExpandError>,
     ) -> Arc<TaskBuildContext<CredentialResolver<false>>> {
         Arc::new(TaskBuildContext::new_for_test(
-            Arc::new(runtime),
+            Arc::new(runtime.expect("test fixture should not fail pattern expansion")),
             Arc::new(catalog()),
             credentials(),
         ))


### PR DESCRIPTION
Previously, `Rule::new()` would silently ignore failures when expanding shell patterns (e.g., `$HOME/file.txt` with unset `$HOME`). This PR changes the signature to return `Result<Rule, ExpandError>`, ensuring misconfigurations are discovered at startup rather than silently ignored.

## Changes

### Core API Change
- **`Rule::new`** now returns `Result<Rule, ExpandError>` instead of `Rule`
- **`from_permission_config`** trait method updated to return `Result<Ruleset, ExpandError>`
- **`AgentRuntime::from_parts`** and **`AgentRuntimeBuilder::build`** now propagate the error

### Error Propagation Chain
```
Rule::new → from_permission_config → AgentRuntime::from_parts → AgentRuntimeBuilder::build
```

### Call Site Updates
- **Tests**: Use `?` operator with `type TestResult = Result<(), ExpandError>`
- **Benchmarks**: Use `.expect()` with descriptive messages (hardcoded patterns can't fail)
- **Doc examples**: Use hidden `fn main() → Result<...>` wrappers for clean `?` usage

## Why
Silent failures hurt discoverability. If a user misconfigures a rule like:
```yaml
read:
  - $HOME/secrets/*
```
and `$HOME` is unset, they should find out **immediately at startup**, not discover later that their permission rules aren't working as expected. Failing fast makes misconfigurations obvious and fixes easy.