### PR TITLE
Optimize file I/O tools in llm-coding-tools-core and fix some misc bugs.

### DIFF
--- a/src/llm-coding-tools-core/Cargo.toml
+++ b/src/llm-coding-tools-core/Cargo.toml
@@ -128,3 +128,26 @@ harness = false
 [[bench]]
 name = "permissions"
 harness = false
+
+[[bench]]
+name = "tools_read"
+harness = false
+required-features = ["blocking"]
+
+[[bench]]
+name = "tools_grep"
+harness = false
+
+[[bench]]
+name = "tools_edit"
+harness = false
+required-features = ["blocking"]
+
+[[bench]]
+name = "tools_glob"
+harness = false
+
+[[bench]]
+name = "tools_write"
+harness = false
+required-features = ["blocking"]

--- a/src/llm-coding-tools-core/benches/common/corpus_large.rs
+++ b/src/llm-coding-tools-core/benches/common/corpus_large.rs
@@ -1,0 +1,770 @@
+// Sourced from codex-rs (Apache-2.0): core/src/unified_exec/session_manager.rs
+// https://github.com/openai/codex
+// Line statistics match aggregate Rust codebase averages (see common/mod.rs).
+
+use rand::Rng;
+use std::cmp::Reverse;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Notify;
+use tokio::sync::mpsc;
+use tokio::time::Duration;
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+
+use crate::bash::extract_bash_command;
+use crate::codex::Session;
+use crate::codex::TurnContext;
+use crate::exec_env::create_env;
+use crate::protocol::BackgroundEventEvent;
+use crate::protocol::EventMsg;
+use crate::sandboxing::ExecEnv;
+use crate::sandboxing::SandboxPermissions;
+use crate::tools::orchestrator::ToolOrchestrator;
+use crate::tools::runtimes::unified_exec::UnifiedExecRequest as UnifiedExecToolRequest;
+use crate::tools::runtimes::unified_exec::UnifiedExecRuntime;
+use crate::tools::sandboxing::ToolCtx;
+use crate::truncate::TruncationPolicy;
+use crate::truncate::approx_token_count;
+use crate::truncate::formatted_truncate_text;
+
+use super::CommandTranscript;
+use super::ExecCommandRequest;
+use super::MAX_UNIFIED_EXEC_SESSIONS;
+use super::SessionEntry;
+use super::SessionStore;
+use super::UnifiedExecContext;
+use super::UnifiedExecError;
+use super::UnifiedExecResponse;
+use super::UnifiedExecSessionManager;
+use super::WARNING_UNIFIED_EXEC_SESSIONS;
+use super::WriteStdinRequest;
+use super::async_watcher::emit_exec_end_for_unified_exec;
+use super::async_watcher::spawn_exit_watcher;
+use super::async_watcher::start_streaming_output;
+use super::clamp_yield_time;
+use super::generate_chunk_id;
+use super::resolve_max_tokens;
+use super::session::OutputBuffer;
+use super::session::OutputHandles;
+use super::session::UnifiedExecSession;
+
+const UNIFIED_EXEC_ENV: [(&str, &str); 8] = [
+    ("NO_COLOR", "1"),
+    ("TERM", "dumb"),
+    ("LANG", "C.UTF-8"),
+    ("LC_CTYPE", "C.UTF-8"),
+    ("LC_ALL", "C.UTF-8"),
+    ("COLORTERM", ""),
+    ("PAGER", "cat"),
+    ("GIT_PAGER", "cat"),
+];
+
+fn apply_unified_exec_env(mut env: HashMap<String, String>) -> HashMap<String, String> {
+    for (key, value) in UNIFIED_EXEC_ENV {
+        env.insert(key.to_string(), value.to_string());
+    }
+    env
+}
+
+struct PreparedSessionHandles {
+    writer_tx: mpsc::Sender<Vec<u8>>,
+    output_buffer: OutputBuffer,
+    output_notify: Arc<Notify>,
+    cancellation_token: CancellationToken,
+    session_ref: Arc<Session>,
+    turn_ref: Arc<TurnContext>,
+    command: Vec<String>,
+    process_id: String,
+}
+
+impl UnifiedExecSessionManager {
+    pub(crate) async fn allocate_process_id(&self) -> String {
+        loop {
+            let mut store = self.session_store.lock().await;
+
+            let process_id = if !cfg!(test) && !cfg!(feature = "deterministic_process_ids") {
+                // production mode → random
+                rand::rng().random_range(1_000..100_000).to_string()
+            } else {
+                // test or deterministic mode
+                let next = store
+                    .reserved_sessions_id
+                    .iter()
+                    .filter_map(|s| s.parse::<i32>().ok())
+                    .max()
+                    .map(|m| std::cmp::max(m, 999) + 1)
+                    .unwrap_or(1000);
+
+                next.to_string()
+            };
+
+            if store.reserved_sessions_id.contains(&process_id) {
+                continue;
+            }
+
+            store.reserved_sessions_id.insert(process_id.clone());
+            return process_id;
+        }
+    }
+
+    pub(crate) async fn release_process_id(&self, process_id: &str) {
+        let mut store = self.session_store.lock().await;
+        store.remove(process_id);
+    }
+
+    pub(crate) async fn exec_command(
+        &self,
+        request: ExecCommandRequest,
+        context: &UnifiedExecContext,
+    ) -> Result<UnifiedExecResponse, UnifiedExecError> {
+        let cwd = request
+            .workdir
+            .clone()
+            .unwrap_or_else(|| context.turn.cwd.clone());
+
+        let session = self
+            .open_session_with_sandbox(
+                &request.command,
+                cwd.clone(),
+                request.sandbox_permissions,
+                request.justification,
+                context,
+            )
+            .await;
+
+        let session = match session {
+            Ok(session) => Arc::new(session),
+            Err(err) => {
+                self.release_process_id(&request.process_id).await;
+                return Err(err);
+            }
+        };
+
+        let transcript = Arc::new(tokio::sync::Mutex::new(CommandTranscript::default()));
+        start_streaming_output(&session, context, Arc::clone(&transcript));
+
+        let max_tokens = resolve_max_tokens(request.max_output_tokens);
+        let yield_time_ms = clamp_yield_time(request.yield_time_ms);
+
+        let start = Instant::now();
+        // For the initial exec_command call, we both stream output to events
+        // (via start_streaming_output above) and collect a snapshot here for
+        // the tool response body.
+        let OutputHandles {
+            output_buffer,
+            output_notify,
+            cancellation_token,
+        } = session.output_handles();
+        let deadline = start + Duration::from_millis(yield_time_ms);
+        let collected = Self::collect_output_until_deadline(
+            &output_buffer,
+            &output_notify,
+            &cancellation_token,
+            deadline,
+        )
+        .await;
+        let wall_time = Instant::now().saturating_duration_since(start);
+
+        let text = String::from_utf8_lossy(&collected).to_string();
+        let output = formatted_truncate_text(&text, TruncationPolicy::Tokens(max_tokens));
+        let exit_code = session.exit_code();
+        let has_exited = session.has_exited() || exit_code.is_some();
+        let chunk_id = generate_chunk_id();
+        let process_id = request.process_id.clone();
+        if has_exited {
+            // Short‑lived command: emit ExecCommandEnd immediately using the
+            // same helper as the background watcher, so all end events share
+            // one implementation.
+            let exit = exit_code.unwrap_or(-1);
+            emit_exec_end_for_unified_exec(
+                Arc::clone(&context.session),
+                Arc::clone(&context.turn),
+                context.call_id.clone(),
+                request.command.clone(),
+                cwd,
+                Some(process_id),
+                Arc::clone(&transcript),
+                output.clone(),
+                exit,
+                wall_time,
+            )
+            .await;
+
+            self.release_process_id(&request.process_id).await;
+            session.check_for_sandbox_denial_with_text(&text).await?;
+        } else {
+            // Long‑lived command: persist the session so write_stdin can reuse
+            // it, and register a background watcher that will emit
+            // ExecCommandEnd when the PTY eventually exits (even if no further
+            // tool calls are made).
+            self.store_session(
+                Arc::clone(&session),
+                context,
+                &request.command,
+                cwd.clone(),
+                start,
+                process_id,
+                Arc::clone(&transcript),
+            )
+            .await;
+
+            Self::emit_waiting_status(&context.session, &context.turn, &request.command).await;
+        };
+
+        let original_token_count = approx_token_count(&text);
+        let response = UnifiedExecResponse {
+            event_call_id: context.call_id.clone(),
+            chunk_id,
+            wall_time,
+            output,
+            raw_output: collected,
+            process_id: if has_exited {
+                None
+            } else {
+                Some(request.process_id.clone())
+            },
+            exit_code,
+            original_token_count: Some(original_token_count),
+            session_command: Some(request.command.clone()),
+        };
+
+        Ok(response)
+    }
+
+    pub(crate) async fn write_stdin(
+        &self,
+        request: WriteStdinRequest<'_>,
+    ) -> Result<UnifiedExecResponse, UnifiedExecError> {
+        let process_id = request.process_id.to_string();
+
+        let PreparedSessionHandles {
+            writer_tx,
+            output_buffer,
+            output_notify,
+            cancellation_token,
+            session_ref,
+            turn_ref,
+            command: session_command,
+            process_id,
+            ..
+        } = self.prepare_session_handles(process_id.as_str()).await?;
+
+        if !request.input.is_empty() {
+            Self::send_input(&writer_tx, request.input.as_bytes()).await?;
+            // Give the remote process a brief window to react so that we are
+            // more likely to capture its output in the poll below.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        let max_tokens = resolve_max_tokens(request.max_output_tokens);
+        let yield_time_ms = clamp_yield_time(request.yield_time_ms);
+        let start = Instant::now();
+        let deadline = start + Duration::from_millis(yield_time_ms);
+        let collected = Self::collect_output_until_deadline(
+            &output_buffer,
+            &output_notify,
+            &cancellation_token,
+            deadline,
+        )
+        .await;
+        let wall_time = Instant::now().saturating_duration_since(start);
+
+        let text = String::from_utf8_lossy(&collected).to_string();
+        let output = formatted_truncate_text(&text, TruncationPolicy::Tokens(max_tokens));
+        let original_token_count = approx_token_count(&text);
+        let chunk_id = generate_chunk_id();
+
+        // After polling, refresh_session_state tells us whether the PTY is
+        // still alive or has exited and been removed from the store; we thread
+        // that through so the handler can tag TerminalInteraction with an
+        // appropriate process_id and exit_code.
+        let status = self.refresh_session_state(process_id.as_str()).await;
+        let (process_id, exit_code, event_call_id) = match status {
+            SessionStatus::Alive {
+                exit_code,
+                call_id,
+                process_id,
+            } => (Some(process_id), exit_code, call_id),
+            SessionStatus::Exited { exit_code, entry } => {
+                let call_id = entry.call_id.clone();
+                (None, exit_code, call_id)
+            }
+            SessionStatus::Unknown => {
+                return Err(UnifiedExecError::UnknownSessionId {
+                    process_id: request.process_id.to_string(),
+                });
+            }
+        };
+
+        let response = UnifiedExecResponse {
+            event_call_id,
+            chunk_id,
+            wall_time,
+            output,
+            raw_output: collected,
+            process_id,
+            exit_code,
+            original_token_count: Some(original_token_count),
+            session_command: Some(session_command.clone()),
+        };
+
+        if response.process_id.is_some() {
+            Self::emit_waiting_status(&session_ref, &turn_ref, &session_command).await;
+        }
+
+        Ok(response)
+    }
+
+    async fn refresh_session_state(&self, process_id: &str) -> SessionStatus {
+        let mut store = self.session_store.lock().await;
+        let Some(entry) = store.sessions.get(process_id) else {
+            return SessionStatus::Unknown;
+        };
+
+        let exit_code = entry.session.exit_code();
+        let process_id = entry.process_id.clone();
+
+        if entry.session.has_exited() {
+            let Some(entry) = store.remove(&process_id) else {
+                return SessionStatus::Unknown;
+            };
+            SessionStatus::Exited {
+                exit_code,
+                entry: Box::new(entry),
+            }
+        } else {
+            SessionStatus::Alive {
+                exit_code,
+                call_id: entry.call_id.clone(),
+                process_id,
+            }
+        }
+    }
+
+    async fn prepare_session_handles(
+        &self,
+        process_id: &str,
+    ) -> Result<PreparedSessionHandles, UnifiedExecError> {
+        let mut store = self.session_store.lock().await;
+        let entry =
+            store
+                .sessions
+                .get_mut(process_id)
+                .ok_or(UnifiedExecError::UnknownSessionId {
+                    process_id: process_id.to_string(),
+                })?;
+        entry.last_used = Instant::now();
+        let OutputHandles {
+            output_buffer,
+            output_notify,
+            cancellation_token,
+        } = entry.session.output_handles();
+
+        Ok(PreparedSessionHandles {
+            writer_tx: entry.session.writer_sender(),
+            output_buffer,
+            output_notify,
+            cancellation_token,
+            session_ref: Arc::clone(&entry.session_ref),
+            turn_ref: Arc::clone(&entry.turn_ref),
+            command: entry.command.clone(),
+            process_id: entry.process_id.clone(),
+        })
+    }
+
+    async fn send_input(
+        writer_tx: &mpsc::Sender<Vec<u8>>,
+        data: &[u8],
+    ) -> Result<(), UnifiedExecError> {
+        writer_tx
+            .send(data.to_vec())
+            .await
+            .map_err(|_| UnifiedExecError::WriteToStdin)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn store_session(
+        &self,
+        session: Arc<UnifiedExecSession>,
+        context: &UnifiedExecContext,
+        command: &[String],
+        cwd: PathBuf,
+        started_at: Instant,
+        process_id: String,
+        transcript: Arc<tokio::sync::Mutex<CommandTranscript>>,
+    ) {
+        let entry = SessionEntry {
+            session: Arc::clone(&session),
+            session_ref: Arc::clone(&context.session),
+            turn_ref: Arc::clone(&context.turn),
+            call_id: context.call_id.clone(),
+            process_id: process_id.clone(),
+            command: command.to_vec(),
+            last_used: started_at,
+        };
+        let number_sessions = {
+            let mut store = self.session_store.lock().await;
+            Self::prune_sessions_if_needed(&mut store);
+            store.sessions.insert(process_id.clone(), entry);
+            store.sessions.len()
+        };
+
+        if number_sessions >= WARNING_UNIFIED_EXEC_SESSIONS {
+            context
+                .session
+                .record_model_warning(
+                    format!("The maximum number of unified exec sessions you can keep open is {WARNING_UNIFIED_EXEC_SESSIONS} and you currently have {number_sessions} sessions open. Reuse older sessions or close them to prevent automatic pruning of old session"),
+                    &context.turn
+                )
+                .await;
+        };
+
+        spawn_exit_watcher(
+            Arc::clone(&session),
+            Arc::clone(&context.session),
+            Arc::clone(&context.turn),
+            context.call_id.clone(),
+            command.to_vec(),
+            cwd,
+            process_id,
+            transcript,
+            started_at,
+        );
+    }
+
+    async fn emit_waiting_status(
+        session: &Arc<Session>,
+        turn: &Arc<TurnContext>,
+        command: &[String],
+    ) {
+        let command_display = if let Some((_, script)) = extract_bash_command(command) {
+            script.to_string()
+        } else {
+            command.join(" ")
+        };
+        let message = format!("Waiting for `{command_display}`");
+        session
+            .send_event(
+                turn.as_ref(),
+                EventMsg::BackgroundEvent(BackgroundEventEvent { message }),
+            )
+            .await;
+    }
+
+    pub(crate) async fn open_session_with_exec_env(
+        &self,
+        env: &ExecEnv,
+    ) -> Result<UnifiedExecSession, UnifiedExecError> {
+        let (program, args) = env
+            .command
+            .split_first()
+            .ok_or(UnifiedExecError::MissingCommandLine)?;
+
+        let spawned = codex_utils_pty::spawn_pty_process(
+            program,
+            args,
+            env.cwd.as_path(),
+            &env.env,
+            &env.arg0,
+        )
+        .await
+        .map_err(|err| UnifiedExecError::create_session(err.to_string()))?;
+        UnifiedExecSession::from_spawned(spawned, env.sandbox).await
+    }
+
+    pub(super) async fn open_session_with_sandbox(
+        &self,
+        command: &[String],
+        cwd: PathBuf,
+        sandbox_permissions: SandboxPermissions,
+        justification: Option<String>,
+        context: &UnifiedExecContext,
+    ) -> Result<UnifiedExecSession, UnifiedExecError> {
+        let env = apply_unified_exec_env(create_env(&context.turn.shell_environment_policy));
+        let features = context.session.features();
+        let mut orchestrator = ToolOrchestrator::new();
+        let mut runtime = UnifiedExecRuntime::new(self);
+        let exec_approval_requirement = context
+            .session
+            .services
+            .exec_policy
+            .create_exec_approval_requirement_for_command(
+                &features,
+                command,
+                context.turn.approval_policy,
+                &context.turn.sandbox_policy,
+                sandbox_permissions,
+            )
+            .await;
+        let req = UnifiedExecToolRequest::new(
+            command.to_vec(),
+            cwd,
+            env,
+            sandbox_permissions,
+            justification,
+            exec_approval_requirement,
+        );
+        let tool_ctx = ToolCtx {
+            session: context.session.as_ref(),
+            turn: context.turn.as_ref(),
+            call_id: context.call_id.clone(),
+            tool_name: "exec_command".to_string(),
+        };
+        orchestrator
+            .run(
+                &mut runtime,
+                &req,
+                &tool_ctx,
+                context.turn.as_ref(),
+                context.turn.approval_policy,
+            )
+            .await
+            .map_err(|e| UnifiedExecError::create_session(format!("{e:?}")))
+    }
+
+    pub(super) async fn collect_output_until_deadline(
+        output_buffer: &OutputBuffer,
+        output_notify: &Arc<Notify>,
+        cancellation_token: &CancellationToken,
+        deadline: Instant,
+    ) -> Vec<u8> {
+        const POST_EXIT_OUTPUT_GRACE: Duration = Duration::from_millis(50);
+
+        let mut collected: Vec<u8> = Vec::with_capacity(4096);
+        let mut exit_signal_received = cancellation_token.is_cancelled();
+        loop {
+            let drained_chunks;
+            let mut wait_for_output = None;
+            {
+                let mut guard = output_buffer.lock().await;
+                drained_chunks = guard.drain();
+                if drained_chunks.is_empty() {
+                    wait_for_output = Some(output_notify.notified());
+                }
+            }
+
+            if drained_chunks.is_empty() {
+                exit_signal_received |= cancellation_token.is_cancelled();
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining == Duration::ZERO {
+                    break;
+                }
+
+                let notified = wait_for_output.unwrap_or_else(|| output_notify.notified());
+                if exit_signal_received {
+                    let grace = remaining.min(POST_EXIT_OUTPUT_GRACE);
+                    if tokio::time::timeout(grace, notified).await.is_err() {
+                        break;
+                    }
+                    continue;
+                }
+
+                tokio::pin!(notified);
+                let exit_notified = cancellation_token.cancelled();
+                tokio::pin!(exit_notified);
+                tokio::select! {
+                    _ = &mut notified => {}
+                    _ = &mut exit_notified => exit_signal_received = true,
+                    _ = tokio::time::sleep(remaining) => break,
+                }
+                continue;
+            }
+
+            for chunk in drained_chunks {
+                collected.extend_from_slice(&chunk);
+            }
+
+            exit_signal_received |= cancellation_token.is_cancelled();
+            if Instant::now() >= deadline {
+                break;
+            }
+        }
+
+        collected
+    }
+
+    fn prune_sessions_if_needed(store: &mut SessionStore) -> bool {
+        if store.sessions.len() < MAX_UNIFIED_EXEC_SESSIONS {
+            return false;
+        }
+
+        let meta: Vec<(String, Instant, bool)> = store
+            .sessions
+            .iter()
+            .map(|(id, entry)| (id.clone(), entry.last_used, entry.session.has_exited()))
+            .collect();
+
+        if let Some(session_id) = Self::session_id_to_prune_from_meta(&meta) {
+            if let Some(entry) = store.remove(&session_id) {
+                entry.session.terminate();
+            }
+            return true;
+        }
+
+        false
+    }
+
+    // Centralized pruning policy so we can easily swap strategies later.
+    fn session_id_to_prune_from_meta(meta: &[(String, Instant, bool)]) -> Option<String> {
+        if meta.is_empty() {
+            return None;
+        }
+
+        let mut by_recency = meta.to_vec();
+        by_recency.sort_by_key(|(_, last_used, _)| Reverse(*last_used));
+        let protected: HashSet<String> = by_recency
+            .iter()
+            .take(8)
+            .map(|(process_id, _, _)| process_id.clone())
+            .collect();
+
+        let mut lru = meta.to_vec();
+        lru.sort_by_key(|(_, last_used, _)| *last_used);
+
+        if let Some((process_id, _, _)) = lru
+            .iter()
+            .find(|(process_id, _, exited)| !protected.contains(process_id) && *exited)
+        {
+            return Some(process_id.clone());
+        }
+
+        lru.into_iter()
+            .find(|(process_id, _, _)| !protected.contains(process_id))
+            .map(|(process_id, _, _)| process_id)
+    }
+
+    pub(crate) async fn terminate_all_sessions(&self) {
+        let entries: Vec<SessionEntry> = {
+            let mut sessions = self.session_store.lock().await;
+            let entries: Vec<SessionEntry> =
+                sessions.sessions.drain().map(|(_, entry)| entry).collect();
+            sessions.reserved_sessions_id.clear();
+            entries
+        };
+
+        for entry in entries {
+            entry.session.terminate();
+        }
+    }
+}
+
+enum SessionStatus {
+    Alive {
+        exit_code: Option<i32>,
+        call_id: String,
+        process_id: String,
+    },
+    Exited {
+        exit_code: Option<i32>,
+        entry: Box<SessionEntry>,
+    },
+    Unknown,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use tokio::time::Duration;
+    use tokio::time::Instant;
+
+    #[test]
+    fn unified_exec_env_injects_defaults() {
+        let env = apply_unified_exec_env(HashMap::new());
+        let expected = HashMap::from([
+            ("NO_COLOR".to_string(), "1".to_string()),
+            ("TERM".to_string(), "dumb".to_string()),
+            ("LANG".to_string(), "C.UTF-8".to_string()),
+            ("LC_CTYPE".to_string(), "C.UTF-8".to_string()),
+            ("LC_ALL".to_string(), "C.UTF-8".to_string()),
+            ("COLORTERM".to_string(), String::new()),
+            ("PAGER".to_string(), "cat".to_string()),
+            ("GIT_PAGER".to_string(), "cat".to_string()),
+        ]);
+
+        assert_eq!(env, expected);
+    }
+
+    #[test]
+    fn unified_exec_env_overrides_existing_values() {
+        let mut base = HashMap::new();
+        base.insert("NO_COLOR".to_string(), "0".to_string());
+        base.insert("PATH".to_string(), "/usr/bin".to_string());
+
+        let env = apply_unified_exec_env(base);
+
+        assert_eq!(env.get("NO_COLOR"), Some(&"1".to_string()));
+        assert_eq!(env.get("PATH"), Some(&"/usr/bin".to_string()));
+    }
+
+    #[test]
+    fn pruning_prefers_exited_sessions_outside_recently_used() {
+        let now = Instant::now();
+        let id = |n: i32| n.to_string();
+        let meta = vec![
+            (id(1), now - Duration::from_secs(40), false),
+            (id(2), now - Duration::from_secs(30), true),
+            (id(3), now - Duration::from_secs(20), false),
+            (id(4), now - Duration::from_secs(19), false),
+            (id(5), now - Duration::from_secs(18), false),
+            (id(6), now - Duration::from_secs(17), false),
+            (id(7), now - Duration::from_secs(16), false),
+            (id(8), now - Duration::from_secs(15), false),
+            (id(9), now - Duration::from_secs(14), false),
+            (id(10), now - Duration::from_secs(13), false),
+        ];
+
+        let candidate = UnifiedExecSessionManager::session_id_to_prune_from_meta(&meta);
+
+        assert_eq!(candidate, Some(id(2)));
+    }
+
+    #[test]
+    fn pruning_falls_back_to_lru_when_no_exited() {
+        let now = Instant::now();
+        let id = |n: i32| n.to_string();
+        let meta = vec![
+            (id(1), now - Duration::from_secs(40), false),
+            (id(2), now - Duration::from_secs(30), false),
+            (id(3), now - Duration::from_secs(20), false),
+            (id(4), now - Duration::from_secs(19), false),
+            (id(5), now - Duration::from_secs(18), false),
+            (id(6), now - Duration::from_secs(17), false),
+            (id(7), now - Duration::from_secs(16), false),
+            (id(8), now - Duration::from_secs(15), false),
+            (id(9), now - Duration::from_secs(14), false),
+            (id(10), now - Duration::from_secs(13), false),
+        ];
+
+        let candidate = UnifiedExecSessionManager::session_id_to_prune_from_meta(&meta);
+
+        assert_eq!(candidate, Some(id(1)));
+    }
+
+    #[test]
+    fn pruning_protects_recent_sessions_even_if_exited() {
+        let now = Instant::now();
+        let id = |n: i32| n.to_string();
+        let meta = vec![
+            (id(1), now - Duration::from_secs(40), false),
+            (id(2), now - Duration::from_secs(30), false),
+            (id(3), now - Duration::from_secs(20), true),
+            (id(4), now - Duration::from_secs(19), false),
+            (id(5), now - Duration::from_secs(18), false),
+            (id(6), now - Duration::from_secs(17), false),
+            (id(7), now - Duration::from_secs(16), false),
+            (id(8), now - Duration::from_secs(15), false),
+            (id(9), now - Duration::from_secs(14), false),
+            (id(10), now - Duration::from_secs(13), true),
+        ];
+
+        let candidate = UnifiedExecSessionManager::session_id_to_prune_from_meta(&meta);
+
+        // (10) is exited but among the last 8; we should drop the LRU outside that set.
+        assert_eq!(candidate, Some(id(1)));
+    }
+}
+

--- a/src/llm-coding-tools-core/benches/common/corpus_medium.rs
+++ b/src/llm-coding-tools-core/benches/common/corpus_medium.rs
@@ -1,0 +1,356 @@
+// Sourced from codex-rs (Apache-2.0): mcp-server/src/outgoing_message.rs
+// https://github.com/openai/codex
+// Line statistics match aggregate Rust codebase averages (see common/mod.rs).
+
+use std::collections::HashMap;
+use std::sync::atomic::AtomicI64;
+use std::sync::atomic::Ordering;
+
+use codex_core::protocol::Event;
+use mcp_types::JSONRPC_VERSION;
+use mcp_types::JSONRPCError;
+use mcp_types::JSONRPCErrorError;
+use mcp_types::JSONRPCMessage;
+use mcp_types::JSONRPCNotification;
+use mcp_types::JSONRPCRequest;
+use mcp_types::JSONRPCResponse;
+use mcp_types::RequestId;
+use mcp_types::Result;
+use serde::Serialize;
+use tokio::sync::Mutex;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tracing::warn;
+
+use crate::error_code::INTERNAL_ERROR_CODE;
+
+/// Sends messages to the client and manages request callbacks.
+pub(crate) struct OutgoingMessageSender {
+    next_request_id: AtomicI64,
+    sender: mpsc::UnboundedSender<OutgoingMessage>,
+    request_id_to_callback: Mutex<HashMap<RequestId, oneshot::Sender<Result>>>,
+}
+
+impl OutgoingMessageSender {
+    pub(crate) fn new(sender: mpsc::UnboundedSender<OutgoingMessage>) -> Self {
+        Self {
+            next_request_id: AtomicI64::new(0),
+            sender,
+            request_id_to_callback: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) async fn send_request(
+        &self,
+        method: &str,
+        params: Option<serde_json::Value>,
+    ) -> oneshot::Receiver<Result> {
+        let id = RequestId::Integer(self.next_request_id.fetch_add(1, Ordering::Relaxed));
+        let outgoing_message_id = id.clone();
+        let (tx_approve, rx_approve) = oneshot::channel();
+        {
+            let mut request_id_to_callback = self.request_id_to_callback.lock().await;
+            request_id_to_callback.insert(id, tx_approve);
+        }
+
+        let outgoing_message = OutgoingMessage::Request(OutgoingRequest {
+            id: outgoing_message_id,
+            method: method.to_string(),
+            params,
+        });
+        let _ = self.sender.send(outgoing_message);
+        rx_approve
+    }
+
+    pub(crate) async fn notify_client_response(&self, id: RequestId, result: Result) {
+        let entry = {
+            let mut request_id_to_callback = self.request_id_to_callback.lock().await;
+            request_id_to_callback.remove_entry(&id)
+        };
+
+        match entry {
+            Some((id, sender)) => {
+                if let Err(err) = sender.send(result) {
+                    warn!("could not notify callback for {id:?} due to: {err:?}");
+                }
+            }
+            None => {
+                warn!("could not find callback for {id:?}");
+            }
+        }
+    }
+
+    pub(crate) async fn send_response<T: Serialize>(&self, id: RequestId, response: T) {
+        match serde_json::to_value(response) {
+            Ok(result) => {
+                let outgoing_message = OutgoingMessage::Response(OutgoingResponse { id, result });
+                let _ = self.sender.send(outgoing_message);
+            }
+            Err(err) => {
+                self.send_error(
+                    id,
+                    JSONRPCErrorError {
+                        code: INTERNAL_ERROR_CODE,
+                        message: format!("failed to serialize response: {err}"),
+                        data: None,
+                    },
+                )
+                .await;
+            }
+        }
+    }
+
+    /// This is used with the MCP server, but not the more general JSON-RPC app
+    /// server. Prefer [`OutgoingMessageSender::send_server_notification`] where
+    /// possible.
+    pub(crate) async fn send_event_as_notification(
+        &self,
+        event: &Event,
+        meta: Option<OutgoingNotificationMeta>,
+    ) {
+        #[expect(clippy::expect_used)]
+        let event_json = serde_json::to_value(event).expect("Event must serialize");
+
+        let params = if let Ok(params) = serde_json::to_value(OutgoingNotificationParams {
+            meta,
+            event: event_json.clone(),
+        }) {
+            params
+        } else {
+            warn!("Failed to serialize event as OutgoingNotificationParams");
+            event_json
+        };
+
+        self.send_notification(OutgoingNotification {
+            method: "codex/event".to_string(),
+            params: Some(params.clone()),
+        })
+        .await;
+    }
+
+    pub(crate) async fn send_notification(&self, notification: OutgoingNotification) {
+        let outgoing_message = OutgoingMessage::Notification(notification);
+        let _ = self.sender.send(outgoing_message);
+    }
+
+    pub(crate) async fn send_error(&self, id: RequestId, error: JSONRPCErrorError) {
+        let outgoing_message = OutgoingMessage::Error(OutgoingError { id, error });
+        let _ = self.sender.send(outgoing_message);
+    }
+}
+
+/// Outgoing message from the server to the client.
+pub(crate) enum OutgoingMessage {
+    Request(OutgoingRequest),
+    Notification(OutgoingNotification),
+    Response(OutgoingResponse),
+    Error(OutgoingError),
+}
+
+impl From<OutgoingMessage> for JSONRPCMessage {
+    fn from(val: OutgoingMessage) -> Self {
+        use OutgoingMessage::*;
+        match val {
+            Request(OutgoingRequest { id, method, params }) => {
+                JSONRPCMessage::Request(JSONRPCRequest {
+                    jsonrpc: JSONRPC_VERSION.into(),
+                    id,
+                    method,
+                    params,
+                })
+            }
+            Notification(OutgoingNotification { method, params }) => {
+                JSONRPCMessage::Notification(JSONRPCNotification {
+                    jsonrpc: JSONRPC_VERSION.into(),
+                    method,
+                    params,
+                })
+            }
+            Response(OutgoingResponse { id, result }) => {
+                JSONRPCMessage::Response(JSONRPCResponse {
+                    jsonrpc: JSONRPC_VERSION.into(),
+                    id,
+                    result,
+                })
+            }
+            Error(OutgoingError { id, error }) => JSONRPCMessage::Error(JSONRPCError {
+                jsonrpc: JSONRPC_VERSION.into(),
+                id,
+                error,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct OutgoingRequest {
+    pub id: RequestId,
+    pub method: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct OutgoingNotification {
+    pub method: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct OutgoingNotificationParams {
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<OutgoingNotificationMeta>,
+
+    #[serde(flatten)]
+    pub event: serde_json::Value,
+}
+
+// Additional mcp-specific data to be added to a [`codex_core::protocol::Event`] as notification.params._meta
+// MCP Spec: https://modelcontextprotocol.io/specification/2025-06-18/basic#meta
+// Typescript Schema: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/0695a497eb50a804fc0e88c18a93a21a675d6b3e/schema/2025-06-18/schema.ts
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct OutgoingNotificationMeta {
+    pub request_id: Option<RequestId>,
+}
+
+impl OutgoingNotificationMeta {
+    pub(crate) fn new(request_id: Option<RequestId>) -> Self {
+        Self { request_id }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct OutgoingResponse {
+    pub id: RequestId,
+    pub result: Result,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct OutgoingError {
+    pub error: JSONRPCErrorError,
+    pub id: RequestId,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use anyhow::Result;
+    use codex_core::protocol::AskForApproval;
+    use codex_core::protocol::EventMsg;
+    use codex_core::protocol::SandboxPolicy;
+    use codex_core::protocol::SessionConfiguredEvent;
+    use codex_protocol::ConversationId;
+    use codex_protocol::openai_models::ReasoningEffort;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_send_event_as_notification() -> Result<()> {
+        let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel::<OutgoingMessage>();
+        let outgoing_message_sender = OutgoingMessageSender::new(outgoing_tx);
+
+        let conversation_id = ConversationId::new();
+        let rollout_file = NamedTempFile::new()?;
+        let event = Event {
+            id: "1".to_string(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id: conversation_id,
+                model: "gpt-4o".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                approval_policy: AskForApproval::Never,
+                sandbox_policy: SandboxPolicy::ReadOnly,
+                cwd: PathBuf::from("/home/user/project"),
+                reasoning_effort: Some(ReasoningEffort::default()),
+                history_log_id: 1,
+                history_entry_count: 1000,
+                initial_messages: None,
+                rollout_path: rollout_file.path().to_path_buf(),
+            }),
+        };
+
+        outgoing_message_sender
+            .send_event_as_notification(&event, None)
+            .await;
+
+        let result = outgoing_rx.recv().await.unwrap();
+        let OutgoingMessage::Notification(OutgoingNotification { method, params }) = result else {
+            panic!("expected Notification for first message");
+        };
+        assert_eq!(method, "codex/event");
+
+        let Ok(expected_params) = serde_json::to_value(&event) else {
+            panic!("Event must serialize");
+        };
+        assert_eq!(params, Some(expected_params));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_send_event_as_notification_with_meta() -> Result<()> {
+        let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel::<OutgoingMessage>();
+        let outgoing_message_sender = OutgoingMessageSender::new(outgoing_tx);
+
+        let conversation_id = ConversationId::new();
+        let rollout_file = NamedTempFile::new()?;
+        let session_configured_event = SessionConfiguredEvent {
+            session_id: conversation_id,
+            model: "gpt-4o".to_string(),
+            model_provider_id: "test-provider".to_string(),
+            approval_policy: AskForApproval::Never,
+            sandbox_policy: SandboxPolicy::ReadOnly,
+            cwd: PathBuf::from("/home/user/project"),
+            reasoning_effort: Some(ReasoningEffort::default()),
+            history_log_id: 1,
+            history_entry_count: 1000,
+            initial_messages: None,
+            rollout_path: rollout_file.path().to_path_buf(),
+        };
+        let event = Event {
+            id: "1".to_string(),
+            msg: EventMsg::SessionConfigured(session_configured_event.clone()),
+        };
+        let meta = OutgoingNotificationMeta {
+            request_id: Some(RequestId::String("123".to_string())),
+        };
+
+        outgoing_message_sender
+            .send_event_as_notification(&event, Some(meta))
+            .await;
+
+        let result = outgoing_rx.recv().await.unwrap();
+        let OutgoingMessage::Notification(OutgoingNotification { method, params }) = result else {
+            panic!("expected Notification for first message");
+        };
+        assert_eq!(method, "codex/event");
+        let expected_params = json!({
+            "_meta": {
+                "requestId": "123",
+            },
+            "id": "1",
+            "msg": {
+                "type": "session_configured",
+                "session_id": session_configured_event.session_id,
+                "model": "gpt-4o",
+                "model_provider_id": "test-provider",
+                "approval_policy": "never",
+                "sandbox_policy": {
+                    "type": "read-only"
+                },
+                "cwd": "/home/user/project",
+                "reasoning_effort": session_configured_event.reasoning_effort,
+                "history_log_id": session_configured_event.history_log_id,
+                "history_entry_count": session_configured_event.history_entry_count,
+                "rollout_path": rollout_file.path().to_path_buf(),
+            }
+        });
+        assert_eq!(params.unwrap(), expected_params);
+        Ok(())
+    }
+}
+

--- a/src/llm-coding-tools-core/benches/common/corpus_small.rs
+++ b/src/llm-coding-tools-core/benches/common/corpus_small.rs
@@ -1,0 +1,122 @@
+// Sourced from codex-rs (Apache-2.0): core/src/tools/handlers/plan.rs
+// https://github.com/openai/codex
+// Line statistics match aggregate Rust codebase averages (see common/mod.rs).
+
+use crate::client_common::tools::ResponsesApiTool;
+use crate::client_common::tools::ToolSpec;
+use crate::codex::Session;
+use crate::codex::TurnContext;
+use crate::function_tool::FunctionCallError;
+use crate::tools::context::ToolInvocation;
+use crate::tools::context::ToolOutput;
+use crate::tools::context::ToolPayload;
+use crate::tools::registry::ToolHandler;
+use crate::tools::registry::ToolKind;
+use crate::tools::spec::JsonSchema;
+use async_trait::async_trait;
+use codex_protocol::plan_tool::UpdatePlanArgs;
+use codex_protocol::protocol::EventMsg;
+use std::collections::BTreeMap;
+use std::sync::LazyLock;
+
+pub struct PlanHandler;
+
+pub static PLAN_TOOL: LazyLock<ToolSpec> = LazyLock::new(|| {
+    let mut plan_item_props = BTreeMap::new();
+    plan_item_props.insert("step".to_string(), JsonSchema::String { description: None });
+    plan_item_props.insert(
+        "status".to_string(),
+        JsonSchema::String {
+            description: Some("One of: pending, in_progress, completed".to_string()),
+        },
+    );
+
+    let plan_items_schema = JsonSchema::Array {
+        description: Some("The list of steps".to_string()),
+        items: Box::new(JsonSchema::Object {
+            properties: plan_item_props,
+            required: Some(vec!["step".to_string(), "status".to_string()]),
+            additional_properties: Some(false.into()),
+        }),
+    };
+
+    let mut properties = BTreeMap::new();
+    properties.insert(
+        "explanation".to_string(),
+        JsonSchema::String { description: None },
+    );
+    properties.insert("plan".to_string(), plan_items_schema);
+
+    ToolSpec::Function(ResponsesApiTool {
+        name: "update_plan".to_string(),
+        description: r#"Updates the task plan.
+Provide an optional explanation and a list of plan items, each with a step and status.
+At most one step can be in_progress at a time.
+"#
+        .to_string(),
+        strict: false,
+        parameters: JsonSchema::Object {
+            properties,
+            required: Some(vec!["plan".to_string()]),
+            additional_properties: Some(false.into()),
+        },
+    })
+});
+
+#[async_trait]
+impl ToolHandler for PlanHandler {
+    fn kind(&self) -> ToolKind {
+        ToolKind::Function
+    }
+
+    async fn handle(&self, invocation: ToolInvocation) -> Result<ToolOutput, FunctionCallError> {
+        let ToolInvocation {
+            session,
+            turn,
+            call_id,
+            payload,
+            ..
+        } = invocation;
+
+        let arguments = match payload {
+            ToolPayload::Function { arguments } => arguments,
+            _ => {
+                return Err(FunctionCallError::RespondToModel(
+                    "update_plan handler received unsupported payload".to_string(),
+                ));
+            }
+        };
+
+        let content =
+            handle_update_plan(session.as_ref(), turn.as_ref(), arguments, call_id).await?;
+
+        Ok(ToolOutput::Function {
+            content,
+            content_items: None,
+            success: Some(true),
+        })
+    }
+}
+
+/// This function doesn't do anything useful. However, it gives the model a structured way to record its plan that clients can read and render.
+/// So it's the _inputs_ to this function that are useful to clients, not the outputs and neither are actually useful for the model other
+/// than forcing it to come up and document a plan (TBD how that affects performance).
+pub(crate) async fn handle_update_plan(
+    session: &Session,
+    turn_context: &TurnContext,
+    arguments: String,
+    _call_id: String,
+) -> Result<String, FunctionCallError> {
+    let args = parse_update_plan_arguments(&arguments)?;
+    session
+        .send_event(turn_context, EventMsg::PlanUpdate(args))
+        .await;
+    Ok("Plan updated".to_string())
+}
+
+fn parse_update_plan_arguments(arguments: &str) -> Result<UpdatePlanArgs, FunctionCallError> {
+    serde_json::from_str::<UpdatePlanArgs>(arguments).map_err(|e| {
+        FunctionCallError::RespondToModel(format!("failed to parse function arguments: {e}"))
+    })
+}
+

--- a/src/llm-coding-tools-core/benches/common/mod.rs
+++ b/src/llm-coding-tools-core/benches/common/mod.rs
@@ -1,0 +1,54 @@
+//! Shared test data generators for tool benchmarks.
+//!
+//! Benchmark test data sourced from real Rust files (Apache-2.0, codex-rs):
+//!
+//!   - Small  (122 lines): core/src/tools/handlers/plan.rs
+//!   - Medium (356 lines): mcp-server/src/outgoing_message.rs
+//!   - Large  (770 lines): core/src/unified_exec/session_manager.rs
+//!
+//! # Corpus selection methodology
+//!
+//! These files were not picked arbitrarily. They were chosen to be
+//! **statistically representative** of real Rust source code:
+//!
+//! 1. Every `.rs` file under `/home/sewer/Project` (~3,300 files) was scanned
+//!    and three per-file metrics were recorded:
+//!    - Non-blank average line length
+//!    - Blank line ratio
+//!    - Average bytes per line
+//!
+//! 2. Population-wide averages were computed across all files:
+//!
+//!    | Metric                       | Population average |
+//!    |------------------------------|--------------------|
+//!    | Non-blank avg line length    | 37.7 chars         |
+//!    | Blank line ratio             | ~10.5%             |
+//!    | Avg bytes/line               | 34.7               |
+//!
+//! 3. Each candidate file was scored by distance from these population
+//!    averages. The three files above were the closest matches across the
+//!    small / medium / large size brackets.
+
+const CORPUS_SMALL_RAW: &str = include_str!("corpus_small.rs");
+const CORPUS_MEDIUM_RAW: &str = include_str!("corpus_medium.rs");
+const CORPUS_LARGE_RAW: &str = include_str!("corpus_large.rs");
+
+#[derive(Clone, Copy)]
+pub enum CorpusSize {
+    Small,
+    Medium,
+    Large,
+}
+
+pub fn corpus_content(size: CorpusSize) -> &'static str {
+    match size {
+        CorpusSize::Small => CORPUS_SMALL_RAW,
+        CorpusSize::Medium => CORPUS_MEDIUM_RAW,
+        CorpusSize::Large => CORPUS_LARGE_RAW,
+    }
+}
+
+#[allow(dead_code)] // Used by some benchmarks but not all
+pub fn corpus_crlf(size: CorpusSize) -> String {
+    corpus_content(size).replace('\n', "\r\n")
+}

--- a/src/llm-coding-tools-core/benches/tools_edit.rs
+++ b/src/llm-coding-tools-core/benches/tools_edit.rs
@@ -1,0 +1,181 @@
+//! Benchmarks for the `edit_file` tool.
+//!
+//! Tests exact string replacement performance across file sizes and scenarios
+//! using real Rust source files as test data.
+//!
+//! # Benchmark Groups
+//!
+//! - `edit_file`: Core edit performance across sizes and match counts
+//!
+//! # Test Cases
+//!
+//! ```text
+//! | Case             | Source    | Occurrences | replace_all | What it tests                      |
+//! |------------------|-----------|-------------|-------------|------------------------------------|
+//! | rename_string    | corpus S  | 1           | false       | Rename a string literal            |
+//! | change_type      | corpus M  | 1           | false       | Change a type annotation           |
+//! | update_constant  | corpus L  | 1           | false       | Update a numeric constant          |
+//! | replace_all      | corpus L  | many        | true        | Bulk rename across many occurrences|
+//! | not_found        | corpus M  | 0           | false       | Error path: string not found       |
+//! ```
+//!
+//! # Running Benchmarks
+//!
+//! Quick run (1s per benchmark):
+//! ```sh
+//! cargo bench -p llm-coding-tools-core --no-default-features --features blocking --bench tools_edit -- --sample-size 10 --measurement-time 1 --warm-up-time 1
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::corpus_content;
+use common::CorpusSize;
+use core::hint::black_box;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+use llm_coding_tools_core::path::AbsolutePathResolver;
+use llm_coding_tools_core::tools::{edit_file, EditRequest, EditSettings};
+use tempfile::TempDir;
+
+fn create_temp_file(content: &str) -> (TempDir, String) {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test_input.rs");
+    std::fs::write(&file_path, content).unwrap();
+    (temp_dir, file_path.to_str().unwrap().to_owned())
+}
+
+fn bench_edit_file(c: &mut Criterion) {
+    let mut group = c.benchmark_group("edit_file");
+
+    let resolver = AbsolutePathResolver;
+    let settings = EditSettings::new();
+
+    let content_small = corpus_content(CorpusSize::Small);
+    let content_medium = corpus_content(CorpusSize::Medium);
+    let content_large = corpus_content(CorpusSize::Large);
+
+    // Case 1: rename_string - rename a string literal in a small file
+    {
+        let content = content_small;
+        group.throughput(Throughput::Elements(1));
+        group.bench_function("rename_string", |b| {
+            b.iter_batched(
+                || create_temp_file(content),
+                |(_dir, path)| {
+                    black_box(edit_file(
+                        &resolver,
+                        EditRequest {
+                            file_path: path,
+                            old_string: "update_plan".to_owned(),
+                            new_string: "update_task_plan".to_owned(),
+                            replace_all: false,
+                        },
+                        &settings,
+                    ))
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+
+    // Case 2: change_type - change a type annotation in a medium file
+    {
+        let content = content_medium;
+        group.throughput(Throughput::Elements(1));
+        group.bench_function("change_type", |b| {
+            b.iter_batched(
+                || create_temp_file(content),
+                |(_dir, path)| {
+                    black_box(edit_file(
+                        &resolver,
+                        EditRequest {
+                            file_path: path,
+                            old_string: "mpsc::UnboundedSender<OutgoingMessage>".to_owned(),
+                            new_string: "mpsc::Sender<OutgoingMessage>".to_owned(),
+                            replace_all: false,
+                        },
+                        &settings,
+                    ))
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+
+    // Case 3: update_constant - update a numeric constant in a large file
+    {
+        let content = content_large;
+        group.throughput(Throughput::Elements(1));
+        group.bench_function("update_constant", |b| {
+            b.iter_batched(
+                || create_temp_file(content),
+                |(_dir, path)| {
+                    black_box(edit_file(
+                        &resolver,
+                        EditRequest {
+                            file_path: path,
+                            old_string: "Duration::from_millis(100)".to_owned(),
+                            new_string: "Duration::from_millis(200)".to_owned(),
+                            replace_all: false,
+                        },
+                        &settings,
+                    ))
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+
+    // Case 4: replace_all - bulk rename in a large file
+    {
+        let content = content_large;
+        group.throughput(Throughput::Elements(1));
+        group.bench_function("replace_all", |b| {
+            b.iter_batched(
+                || create_temp_file(content),
+                |(_dir, path)| {
+                    black_box(edit_file(
+                        &resolver,
+                        EditRequest {
+                            file_path: path,
+                            old_string: "process_id".to_owned(),
+                            new_string: "session_id".to_owned(),
+                            replace_all: true,
+                        },
+                        &settings,
+                    ))
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+
+    // Case 5: not_found - old_string not in file (error path)
+    {
+        let content = content_medium;
+        group.throughput(Throughput::Elements(1));
+        group.bench_function("not_found", |b| {
+            b.iter_batched(
+                || create_temp_file(content),
+                |(_dir, path)| {
+                    black_box(edit_file(
+                        &resolver,
+                        EditRequest {
+                            file_path: path,
+                            old_string: "__NONEXISTENT_STRING_XYZ_12345__".to_owned(),
+                            new_string: "replaced".to_owned(),
+                            replace_all: false,
+                        },
+                        &settings,
+                    ))
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_edit_file);
+criterion_main!(benches);

--- a/src/llm-coding-tools-core/benches/tools_glob.rs
+++ b/src/llm-coding-tools-core/benches/tools_glob.rs
@@ -12,10 +12,10 @@
 //! ```text
 //! | Case         | Files | Pattern      | Matches | What it tests                         |
 //! |--------------|-------|--------------|---------|---------------------------------------|
-//! | small_tree   | ~10   | **/*.rs      | ~10     | Small project, fast walk              |
-//! | large_tree   | ~300  | **/*.rs      | ~300    | Large monorepo, many matches          |
-//! | no_matches   | ~300  | *.xyz        | 0       | Walk with no matches, full traversal  |
-//! | deep_nesting | ~10   | **/*.rs      | ~10     | Deep directory nesting, path handling |
+//! | small_tree   | 8     | **/*.rs      | 5       | Small project, fast walk              |
+//! | large_tree   | 300   | **/*.rs      | 150     | Large monorepo, many matches          |
+//! | no_matches   | 300   | *.xyz        | 0       | Walk with no matches, full traversal  |
+//! | deep_nesting | 10    | **/*.rs      | 10      | Deep directory nesting, path handling |
 //! ```
 //!
 //! # Running Benchmarks

--- a/src/llm-coding-tools-core/benches/tools_glob.rs
+++ b/src/llm-coding-tools-core/benches/tools_glob.rs
@@ -1,0 +1,219 @@
+//! Benchmarks for the `glob_files` tool.
+//!
+//! Tests glob matching performance across different directory tree sizes,
+//! match densities, and nesting depths using real Rust source files as test data.
+//!
+//! # Benchmark Groups
+//!
+//! - `glob_files`: Core glob-walk performance across tree shapes
+//!
+//! # Test Cases
+//!
+//! ```text
+//! | Case         | Files | Pattern      | Matches | What it tests                         |
+//! |--------------|-------|--------------|---------|---------------------------------------|
+//! | small_tree   | ~10   | **/*.rs      | ~10     | Small project, fast walk              |
+//! | large_tree   | ~300  | **/*.rs      | ~300    | Large monorepo, many matches          |
+//! | no_matches   | ~300  | *.xyz        | 0       | Walk with no matches, full traversal  |
+//! | deep_nesting | ~10   | **/*.rs      | ~10     | Deep directory nesting, path handling |
+//! ```
+//!
+//! # Running Benchmarks
+//!
+//! Quick run (1s per benchmark):
+//! ```sh
+//! cargo bench -p llm-coding-tools-core --bench tools_glob -- --sample-size 10 --measurement-time 1 --warm-up-time 1
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::corpus_content;
+use common::CorpusSize;
+use core::hint::black_box;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use llm_coding_tools_core::path::AbsolutePathResolver;
+use llm_coding_tools_core::tools::{glob_files, GlobRequest, GlobSettings};
+use std::fs;
+use tempfile::TempDir;
+
+/// Temporary directory fixture for benchmark tests.
+///
+/// Holds a temporary directory and its metadata for use in glob performance tests.
+/// The [`TempDir`] is kept alive for the duration of the benchmark to prevent premature cleanup.
+struct TreeFixture {
+    /// Temporary directory that owns the test files.
+    #[allow(dead_code)] // Used to keep temp dir alive (prevent drop)
+    temp_dir: TempDir,
+    /// Absolute path to the fixture root directory.
+    path: String,
+    /// Number of files in the fixture tree.
+    file_count: usize,
+}
+
+/// Creates a small test fixture with typical Rust project structure.
+///
+/// Layout:
+/// ```text
+/// src/lib.rs, src/main.rs, src/utils/mod.rs
+/// tests/integration.rs
+/// benches/bench_main.rs
+/// Cargo.toml, README.md, .gitignore
+/// ```
+fn create_small_tree() -> TreeFixture {
+    let temp_dir = TempDir::new().unwrap();
+    let base = temp_dir.path();
+
+    let dirs = ["src", "src/utils", "tests", "benches"];
+    for dir in &dirs {
+        fs::create_dir_all(base.join(dir)).unwrap();
+    }
+
+    let files = [
+        "src/lib.rs",
+        "src/utils/mod.rs",
+        "src/main.rs",
+        "tests/integration.rs",
+        "benches/bench_main.rs",
+        "Cargo.toml",
+        "README.md",
+        ".gitignore",
+    ];
+
+    for file in &files {
+        let content = corpus_content(CorpusSize::Small);
+        fs::write(base.join(file), content).unwrap();
+    }
+
+    TreeFixture {
+        path: base.to_str().unwrap().to_owned(),
+        temp_dir,
+        file_count: files.len(),
+    }
+}
+
+/// Creates a large test fixture simulating a monorepo structure.
+///
+/// Layout:
+/// ```text
+/// src/module_{00-31}/file_{000-004}.{rs,txt}  (250 files: 5 per module, 50 modules)
+/// root_{000-049}.toml                         (50 files)
+/// ```
+fn create_large_tree() -> TreeFixture {
+    let temp_dir = TempDir::new().unwrap();
+    let base = temp_dir.path();
+
+    let mut count = 0;
+    let sizes = [CorpusSize::Small, CorpusSize::Medium, CorpusSize::Large];
+
+    // Create 50 modules, each with 5 files (mixed rs/txt extensions)
+    for module in 0..50 {
+        let dir = base.join(format!("src/module_{module:02x}"));
+        fs::create_dir_all(&dir).unwrap();
+
+        for file_idx in 0..5 {
+            let size = sizes[file_idx % 3];
+            let ext = if file_idx % 4 == 0 { "txt" } else { "rs" };
+            fs::write(
+                dir.join(format!("file_{file_idx:03}.{ext}")),
+                corpus_content(size),
+            )
+            .unwrap();
+            count += 1;
+        }
+    }
+
+    // Create 50 root-level toml files
+    for i in 0..50 {
+        fs::write(
+            base.join(format!("root_{i:03}.toml")),
+            corpus_content(CorpusSize::Small),
+        )
+        .unwrap();
+        count += 1;
+    }
+
+    TreeFixture {
+        path: base.to_str().unwrap().to_owned(),
+        temp_dir,
+        file_count: count,
+    }
+}
+
+/// Creates a deeply nested test fixture for path handling stress tests.
+///
+/// Layout (10 files):
+/// ```text
+/// level_0/data.rs
+/// level_0/level_1/data.rs
+/// level_0/.../level_9/data.rs
+/// ```
+fn create_deep_nesting_tree() -> TreeFixture {
+    let temp_dir = TempDir::new().unwrap();
+    let base = temp_dir.path();
+
+    let mut current = base.to_path_buf();
+    let mut count = 0;
+
+    // Create 10 nested levels, each with a data.rs file
+    for level in 0..10 {
+        current = current.join(format!("level_{level}"));
+        fs::create_dir_all(&current).unwrap();
+        fs::write(current.join("data.rs"), corpus_content(CorpusSize::Small)).unwrap();
+        count += 1;
+    }
+
+    TreeFixture {
+        path: base.to_str().unwrap().to_owned(),
+        temp_dir,
+        file_count: count,
+    }
+}
+
+/// Benchmarks [`glob_files`] performance across different tree shapes.
+///
+/// Tests four scenarios: small tree (8 files), large tree (300 files),
+/// no-match traversal, and deep nesting (10 levels). Each case measures
+/// glob matching throughput using [`AbsolutePathResolver`].
+fn bench_glob_files(c: &mut Criterion) {
+    let mut group = c.benchmark_group("glob_files");
+
+    let small = create_small_tree();
+    let large = create_large_tree();
+    let deep = create_deep_nesting_tree();
+
+    let resolver = AbsolutePathResolver;
+    let settings = GlobSettings::new().with_limit(1000).unwrap();
+
+    let cases: Vec<(&str, &str, &str, usize)> = vec![
+        ("small_tree", &small.path, "**/*.rs", small.file_count),
+        ("large_tree", &large.path, "**/*.rs", large.file_count),
+        ("no_matches", &large.path, "*.xyz", large.file_count),
+        ("deep_nesting", &deep.path, "**/*.rs", deep.file_count),
+    ];
+
+    for (case_name, path, pattern, file_count) in &cases {
+        group.throughput(Throughput::Elements(*file_count as u64));
+        group.bench_with_input(
+            BenchmarkId::new("AbsolutePathResolver", *case_name),
+            &(*path, *pattern),
+            |b, &(path, pattern)| {
+                b.iter(|| {
+                    black_box(glob_files(
+                        black_box(&resolver),
+                        GlobRequest {
+                            pattern: pattern.to_string(),
+                            path: path.to_string(),
+                        },
+                        black_box(&settings),
+                    ))
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_glob_files);
+criterion_main!(benches);

--- a/src/llm-coding-tools-core/benches/tools_grep.rs
+++ b/src/llm-coding-tools-core/benches/tools_grep.rs
@@ -1,0 +1,270 @@
+//! Benchmarks for the `grep_search` tool.
+//!
+//! Tests grep performance across different file layouts, pattern complexity,
+//! match densities, and line-number formatting modes using real Rust source
+//! files as test data.
+//!
+//! # Benchmark Groups
+//!
+//! - `grep_search`: Core search + format with/without line numbers
+//! - `grep_format`: Formatting only (search result reuse) with/without line numbers
+//!
+//! # Test Cases
+//!
+//! ```text
+//! | Case            | Files | Pattern       | What it tests                    |
+//! |-----------------|-------|---------------|----------------------------------|
+//! | single_file     | 1     | fn            | Single file, many matches        |
+//! | multi_file      | 10    | fn            | Multi-file, moderate matches     |
+//! | no_matches      | 10    | xyznonexistent| No matches, fast rejection        |
+//! | regex_pattern   | 10    | fn\s+\w+      | Complex regex matching           |
+//! | large_tree      | 30    | fn            | Large directory tree traversal    |
+//! ```
+//!
+//! # Running Benchmarks
+//!
+//! Quick run:
+//! ```sh
+//! cargo bench -p llm-coding-tools-core --bench tools_grep -- --sample-size 10 --measurement-time 1 --warm-up-time 1
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{corpus_content, CorpusSize};
+use core::hint::black_box;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use llm_coding_tools_core::path::AbsolutePathResolver;
+use llm_coding_tools_core::tools::{
+    grep_search, GrepFormattingSettings, GrepRequest, GrepSettings,
+};
+use std::fs;
+use tempfile::TempDir;
+
+/// Holds a test directory with precomputed match counts for benchmarking.
+struct TestDir {
+    #[allow(dead_code)] // Used to keep temp dir alive (prevent drop)
+    temp_dir: TempDir,
+    path: String,
+    total_matches: usize,
+}
+
+/// Creates a single-file test fixture for benchmarking single-file grep performance.
+///
+/// Layout:
+/// ```text
+/// plan.rs (small corpus)
+/// ```
+fn create_single_file() -> TestDir {
+    let temp_dir = TempDir::new().unwrap();
+    let content = corpus_content(CorpusSize::Small);
+    fs::write(temp_dir.path().join("plan.rs"), content).unwrap();
+    let matches = content.lines().filter(|l| l.contains("fn ")).count();
+    TestDir {
+        path: temp_dir.path().to_str().unwrap().to_owned(),
+        temp_dir,
+        total_matches: matches,
+    }
+}
+
+/// Creates a test fixture with 10 Rust files cycling through corpus sizes.
+///
+/// Layout:
+/// ```text
+/// {prefix}0.rs (small corpus)
+/// {prefix}1.rs (medium corpus)
+/// {prefix}2.rs (large corpus)
+/// ... (10 files total, cycling small/medium/large)
+/// ```
+fn create_test_files(prefix: &str) -> TestDir {
+    let temp_dir = TempDir::new().unwrap();
+    let mut total_matches = 0;
+    for (i, size) in [CorpusSize::Small, CorpusSize::Medium, CorpusSize::Large]
+        .iter()
+        .cycle()
+        .enumerate()
+        .take(10)
+    {
+        let content = corpus_content(*size);
+        let name = format!("{prefix}{i}.rs");
+        fs::write(temp_dir.path().join(name), content).unwrap();
+        total_matches += content.lines().filter(|l| l.contains("fn ")).count();
+    }
+    TestDir {
+        path: temp_dir.path().to_str().unwrap().to_owned(),
+        temp_dir,
+        total_matches,
+    }
+}
+
+fn create_multi_file() -> TestDir {
+    create_test_files("file_")
+}
+
+fn create_no_matches() -> TestDir {
+    let mut dir = create_test_files("nomatch_");
+    dir.total_matches = 0;
+    dir
+}
+
+fn create_regex_pattern() -> TestDir {
+    create_test_files("src_")
+}
+
+/// Creates a test fixture with nested directories for benchmarking large tree traversal.
+///
+/// Layout:
+/// ```text
+/// src/module_00/mod_0.rs (small corpus)
+/// src/module_01/mod_1.rs (medium corpus)
+/// src/module_02/mod_2.rs (large corpus)
+/// ... (30 modules total, cycling small/medium/large)
+/// ```
+fn create_large_tree() -> TestDir {
+    let temp_dir = TempDir::new().unwrap();
+    let mut total_matches = 0;
+    let sizes = [CorpusSize::Small, CorpusSize::Medium, CorpusSize::Large];
+    for i in 0..30 {
+        let size = sizes[i % 3];
+        let content = corpus_content(size);
+        let dir = temp_dir.path().join(format!("src/module_{i:02x}"));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join(format!("mod_{i}.rs")), content).unwrap();
+        total_matches += content.lines().filter(|l| l.contains("fn ")).count();
+    }
+    TestDir {
+        path: temp_dir.path().to_str().unwrap().to_owned(),
+        temp_dir,
+        total_matches,
+    }
+}
+
+/// Benchmarks `grep_search` with formatting across different test cases.
+fn bench_grep_search(c: &mut Criterion) {
+    let mut group = c.benchmark_group("grep_search");
+
+    // Setup: create test directories
+    let single = create_single_file();
+    let multi = create_multi_file();
+    let no_matches = create_no_matches();
+    let regex_case = create_regex_pattern();
+    let large = create_large_tree();
+
+    // Setup: shared resolver and settings
+    let resolver = AbsolutePathResolver;
+    let settings = GrepSettings::new().with_max_limit(1000).unwrap();
+
+    // Test cases: (name, directory, pattern, expected match count)
+    let cases: Vec<(&str, &TestDir, &str, usize)> = vec![
+        ("single_file", &single, "fn ", single.total_matches),
+        ("multi_file", &multi, "fn ", multi.total_matches),
+        (
+            "no_matches",
+            &no_matches,
+            "xyznonexistent",
+            no_matches.total_matches,
+        ),
+        (
+            "regex_pattern",
+            &regex_case,
+            r"fn\s+\w+",
+            regex_case.total_matches,
+        ),
+        ("large_tree", &large, "fn ", large.total_matches),
+    ];
+
+    // Benchmark each case with and without line numbers
+    for (case_name, test_dir, pattern, expected_matches) in &cases {
+        group.throughput(Throughput::Elements(*expected_matches as u64));
+        group.bench_with_input(
+            BenchmarkId::new("with_line_numbers", case_name),
+            pattern,
+            |b, pat| {
+                let request = GrepRequest {
+                    pattern: pat.to_string(),
+                    path: test_dir.path.clone(),
+                    include: None,
+                    limit: None,
+                };
+                b.iter(|| {
+                    let result = grep_search(
+                        black_box(&resolver),
+                        GrepRequest {
+                            pattern: request.pattern.clone(),
+                            path: request.path.clone(),
+                            include: request.include.clone(),
+                            limit: request.limit,
+                        },
+                        black_box(&settings),
+                    )
+                    .unwrap();
+                    black_box(result.format(GrepFormattingSettings::new()))
+                })
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("without_line_numbers", case_name),
+            pattern,
+            |b, pat| {
+                let request = GrepRequest {
+                    pattern: pat.to_string(),
+                    path: test_dir.path.clone(),
+                    include: None,
+                    limit: None,
+                };
+                b.iter(|| {
+                    let result = grep_search(
+                        black_box(&resolver),
+                        GrepRequest {
+                            pattern: request.pattern.clone(),
+                            path: request.path.clone(),
+                            include: request.include.clone(),
+                            limit: request.limit,
+                        },
+                        black_box(&settings),
+                    )
+                    .unwrap();
+                    black_box(result.format(GrepFormattingSettings::new().with_line_numbers(false)))
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmarks formatting of precomputed search results (isolates formatting overhead from search).
+fn bench_grep_format(c: &mut Criterion) {
+    let mut group = c.benchmark_group("grep_format");
+
+    let large = create_large_tree();
+    let resolver = AbsolutePathResolver;
+    let settings = GrepSettings::new().with_max_limit(1000).unwrap();
+
+    let search_result = grep_search(
+        &resolver,
+        GrepRequest {
+            pattern: "fn ".to_string(),
+            path: large.path.clone(),
+            include: None,
+            limit: None,
+        },
+        &settings,
+    )
+    .unwrap();
+
+    group.throughput(Throughput::Elements(search_result.match_count as u64));
+    group.bench_function("with_line_numbers", |b| {
+        b.iter(|| black_box(search_result.format(GrepFormattingSettings::new())))
+    });
+    group.bench_function("without_line_numbers", |b| {
+        b.iter(|| {
+            black_box(search_result.format(GrepFormattingSettings::new().with_line_numbers(false)))
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_grep_search, bench_grep_format);
+criterion_main!(benches);

--- a/src/llm-coding-tools-core/benches/tools_read.rs
+++ b/src/llm-coding-tools-core/benches/tools_read.rs
@@ -1,0 +1,197 @@
+//! Benchmarks for the `read_file` tool.
+//!
+//! Tests file reading performance across different file sizes, offsets,
+//! line endings, and line-number modes.
+//!
+//! # Benchmark Groups
+//!
+//! - `read_file/with_line_numbers`: Read with `L{n}: ` prefix on each line
+//! - `read_file/without_line_numbers`: Read raw content without prefixes
+//!
+//! # Test Cases (per mode)
+//!
+//! ```text
+//! | Case          | Source    | What it tests                     |
+//! |---------------|-----------|-----------------------------------|
+//! | small_file    | corpus S  | Small file, fits in one read      |
+//! | medium_file   | corpus M  | Medium file, buffered reads       |
+//! | large_file    | corpus L  | Large file, many lines processed  |
+//! | offset_read   | corpus M  | Offset + limit, partial read      |
+//! | crlf_file     | corpus M  | CRLF stripping overhead           |
+//! ```
+//!
+//! # Running Benchmarks
+//!
+//! Quick run:
+//! ```sh
+//! cargo bench -p llm-coding-tools-core --no-default-features --features blocking --bench tools_read -- --sample-size 10 --measurement-time 1 --warm-up-time 1
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{corpus_content, corpus_crlf, CorpusSize};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use llm_coding_tools_core::path::AbsolutePathResolver;
+use llm_coding_tools_core::tools::{read_file, ReadRequest, ReadSettings};
+use std::fs;
+use tempfile::TempDir;
+
+/// Holds a temporary test file for benchmarking.
+///
+/// The [`TempDir`] keeps the file alive until the struct is dropped.
+struct TestFile {
+    /// Temporary directory containing the test file.
+    #[allow(dead_code)] // Used to keep temp dir alive (prevent drop)
+    temp_dir: TempDir,
+    /// Absolute path to the test file.
+    path: String,
+    /// Number of lines in the file content.
+    line_count: usize,
+}
+
+/// Creates a temporary file with the given content for benchmarking.
+fn create_test_file(content: &str) -> TestFile {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test_input.rs");
+    fs::write(&file_path, content).unwrap();
+    let line_count = content.lines().count();
+    TestFile {
+        path: file_path.to_str().unwrap().to_owned(),
+        temp_dir,
+        line_count,
+    }
+}
+
+/// Benchmarks `read_file` across file sizes, offsets, line endings, and line-number modes.
+fn bench_read_file(c: &mut Criterion) {
+    let mut group = c.benchmark_group("read_file");
+
+    // Setup: create test files with various corpus sizes
+    let small = create_test_file(corpus_content(CorpusSize::Small));
+    let medium = create_test_file(corpus_content(CorpusSize::Medium));
+    let large = create_test_file(corpus_content(CorpusSize::Large));
+    let crlf = create_test_file(&corpus_crlf(CorpusSize::Medium));
+
+    // Setup: create resolver and settings variants
+    let resolver = AbsolutePathResolver;
+    let settings_ln = ReadSettings::new();
+    let settings_no_ln = ReadSettings::new().with_line_numbers(false);
+    let settings_offset_ln = ReadSettings::new().with_limits(50, 2000).unwrap();
+    let settings_offset_no_ln = ReadSettings::new()
+        .with_limits(50, 2000)
+        .unwrap()
+        .with_line_numbers(false);
+
+    /// Test case configuration for a single benchmark run.
+    struct Case {
+        /// Identifier shown in benchmark output.
+        name: &'static str,
+        /// Path to the file to read.
+        path: String,
+        /// Starting line offset (1-indexed).
+        offset: usize,
+        /// Maximum lines to read, or `None` for entire file.
+        limit: Option<usize>,
+        /// Expected line count for throughput measurement.
+        line_count: usize,
+    }
+
+    // Test cases: define scenarios to benchmark
+    let cases: Vec<Case> = vec![
+        Case {
+            name: "small_file",
+            path: small.path.clone(),
+            offset: 1,
+            limit: None,
+            line_count: small.line_count,
+        },
+        Case {
+            name: "medium_file",
+            path: medium.path.clone(),
+            offset: 1,
+            limit: None,
+            line_count: medium.line_count,
+        },
+        Case {
+            name: "large_file",
+            path: large.path.clone(),
+            offset: 1,
+            limit: None,
+            line_count: large.line_count,
+        },
+        Case {
+            name: "offset_read",
+            path: medium.path.clone(),
+            offset: 50,
+            limit: Some(50),
+            line_count: 50,
+        },
+        Case {
+            name: "crlf_file",
+            path: crlf.path.clone(),
+            offset: 1,
+            limit: None,
+            line_count: crlf.line_count,
+        },
+    ];
+
+    // Benchmark loop: run each case with and without line numbers
+    for case in &cases {
+        let settings_for_case_ln = if case.name == "offset_read" {
+            settings_offset_ln.clone()
+        } else {
+            settings_ln.clone()
+        };
+        let settings_for_case_no_ln = if case.name == "offset_read" {
+            settings_offset_no_ln.clone()
+        } else {
+            settings_no_ln.clone()
+        };
+
+        group.throughput(Throughput::Elements(case.line_count as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("with_line_numbers", case.name),
+            &case.path,
+            |b, path| {
+                let s = &settings_for_case_ln;
+                b.iter(|| {
+                    read_file(
+                        &resolver,
+                        ReadRequest {
+                            file_path: path.clone(),
+                            offset: case.offset,
+                            limit: case.limit,
+                        },
+                        s,
+                    )
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("without_line_numbers", case.name),
+            &case.path,
+            |b, path| {
+                let s = &settings_for_case_no_ln;
+                b.iter(|| {
+                    read_file(
+                        &resolver,
+                        ReadRequest {
+                            file_path: path.clone(),
+                            offset: case.offset,
+                            limit: case.limit,
+                        },
+                        s,
+                    )
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_read_file);
+criterion_main!(benches);

--- a/src/llm-coding-tools-core/benches/tools_write.rs
+++ b/src/llm-coding-tools-core/benches/tools_write.rs
@@ -1,0 +1,96 @@
+//! Benchmarks for the `write_file` tool.
+//!
+//! Tests file writing performance across different content sizes and
+//! directory nesting depths using real Rust source files as test data.
+//!
+//! # Benchmark Groups
+//!
+//! - `write_file`: Core write performance across sizes and scenarios
+//!
+//! # Test Cases
+//!
+//! ```text
+//! | Case          | Content   | Path depth | What it tests                         |
+//! |---------------|-----------|------------|---------------------------------------|
+//! | small_write   | corpus S  | 1          | Small write to flat directory         |
+//! | medium_write  | corpus M  | 1          | Medium write to flat directory        |
+//! | large_write   | corpus L  | 1          | Large write to flat directory         |
+//! | nested_dirs   | corpus S  | 4 (a/b/c/) | Write creating nested directories    |
+//! ```
+//!
+//! # Running Benchmarks
+//!
+//! Quick run (1s per benchmark):
+//! ```sh
+//! cargo bench -p llm-coding-tools-core --no-default-features --features blocking --bench tools_write -- --sample-size 10 --measurement-time 1 --warm-up-time 1
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::corpus_content;
+use common::CorpusSize;
+use core::hint::black_box;
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use llm_coding_tools_core::path::AbsolutePathResolver;
+use llm_coding_tools_core::tools::{write_file, WriteRequest, WriteSettings};
+use tempfile::TempDir;
+
+fn bench_write_file(c: &mut Criterion) {
+    let mut group = c.benchmark_group("write_file");
+
+    // Setup: resolver and settings
+    let resolver = AbsolutePathResolver;
+    let settings = WriteSettings::new();
+
+    // Setup: load corpus content
+    let small_content = corpus_content(CorpusSize::Small).to_owned();
+    let medium_content = corpus_content(CorpusSize::Medium).to_owned();
+    let large_content = corpus_content(CorpusSize::Large).to_owned();
+
+    // Test cases definition
+    let cases: Vec<(&str, String, &str)> = vec![
+        ("small_write", small_content, "small.rs"),
+        ("medium_write", medium_content, "medium.rs"),
+        ("large_write", large_content, "large.rs"),
+        (
+            "nested_dirs",
+            corpus_content(CorpusSize::Small).to_owned(),
+            "a/b/c/deep.rs",
+        ),
+    ];
+
+    // Benchmark loop
+    for (case_name, content, file_name) in &cases {
+        group.throughput(Throughput::Bytes(content.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new("AbsolutePathResolver", case_name),
+            content,
+            |b, content| {
+                b.iter_batched(
+                    || {
+                        let dir = TempDir::new().unwrap();
+                        let path = dir.path().join(file_name);
+                        (dir, path.to_str().unwrap().to_owned(), content.clone())
+                    },
+                    |(_dir, path, content)| {
+                        black_box(write_file(
+                            &resolver,
+                            WriteRequest {
+                                file_path: path,
+                                content,
+                            },
+                            &settings,
+                        ))
+                    },
+                    BatchSize::SmallInput,
+                )
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_write_file);
+criterion_main!(benches);

--- a/src/llm-coding-tools-core/src/tools/edit.rs
+++ b/src/llm-coding-tools-core/src/tools/edit.rs
@@ -156,15 +156,13 @@ pub async fn edit_file<R: PathResolver>(
 
     let (new_content, replacement_count) = if request.replace_all {
         // Single-pass: build the result string while counting every match.
-        let needle = &request.old_string;
-        let needle_len = needle.len();
-        let replacement = &request.new_string;
+        let needle_len = request.old_string.len();
         let mut result = String::with_capacity(content.len());
         let mut last_end = 0;
         let mut count: usize = 0;
-        for (idx, _) in content.match_indices(needle) {
+        for (idx, _) in content.match_indices(&request.old_string) {
             result.push_str(&content[last_end..idx]);
-            result.push_str(replacement);
+            result.push_str(&request.new_string);
             last_end = idx + needle_len;
             count += 1;
         }
@@ -175,12 +173,12 @@ pub async fn edit_file<R: PathResolver>(
         (result, count)
     } else {
         // Fast path for single replacement: find the first match, then check for a second to detect ambiguity.
-        let needle = &request.old_string;
-        let needle_len = needle.len();
-        let Some(first_idx) = content.find(needle) else {
+        let needle_len = request.old_string.len();
+        let Some(first_idx) = content.find(&request.old_string) else {
             return Err(EditError::NotFound);
         };
-        if content[first_idx + 1..].contains(needle) {
+        // E.g. "aa" in "aaa" — two overlapping occurrences starting at 0 and 1.
+        if content[first_idx + 1..].contains(&request.old_string) {
             return Err(EditError::AmbiguousMatch);
         }
         // Build the edited string directly from slices to avoid rescanning.

--- a/src/llm-coding-tools-core/src/tools/edit.rs
+++ b/src/llm-coding-tools-core/src/tools/edit.rs
@@ -155,34 +155,38 @@ pub async fn edit_file<R: PathResolver>(
     let content = fs::read_to_string(&path).await?;
 
     let (new_content, replacement_count) = if request.replace_all {
-        // replace_all reports the exact number of replacements, so this path
-        // counts every match.
-        let count = content.matches(&request.old_string).count();
+        // Single-pass: build the result string while counting every match.
+        let needle = &request.old_string;
+        let needle_len = needle.len();
+        let replacement = &request.new_string;
+        let mut result = String::with_capacity(content.len());
+        let mut last_end = 0;
+        let mut count: usize = 0;
+        for (idx, _) in content.match_indices(needle) {
+            result.push_str(&content[last_end..idx]);
+            result.push_str(replacement);
+            last_end = idx + needle_len;
+            count += 1;
+        }
         if count == 0 {
             return Err(EditError::NotFound);
         }
-
-        (
-            content.replace(&request.old_string, &request.new_string),
-            count,
-        )
+        result.push_str(&content[last_end..]);
+        (result, count)
     } else {
-        // Fast path for single replacement: advance a single non-overlapping
-        // matcher until the second match (if any), then stop.
-        let mut matches = content.match_indices(&request.old_string);
-        let Some((first_idx, _)) = matches.next() else {
+        // Fast path for single replacement: find the first match, then check for a second to detect ambiguity.
+        let needle = &request.old_string;
+        let needle_len = needle.len();
+        let Some(first_idx) = content.find(needle) else {
             return Err(EditError::NotFound);
         };
-        if matches.next().is_some() {
+        if content[first_idx + 1..].contains(needle) {
             return Err(EditError::AmbiguousMatch);
         }
-
-        let tail_start = first_idx + request.old_string.len();
-
         // Build the edited string directly from slices to avoid rescanning.
-        let mut replaced = String::with_capacity(
-            content.len() - request.old_string.len() + request.new_string.len(),
-        );
+        let tail_start = first_idx + needle_len;
+        let mut replaced =
+            String::with_capacity(content.len() - needle_len + request.new_string.len());
         replaced.push_str(&content[..first_idx]);
         replaced.push_str(&request.new_string);
         replaced.push_str(&content[tail_start..]);
@@ -191,10 +195,12 @@ pub async fn edit_file<R: PathResolver>(
 
     fs::write(&path, &new_content).await?;
 
-    Ok(format!(
-        "Successfully replaced {} occurrence(s)",
-        replacement_count
-    ))
+    let mut msg = String::with_capacity(38);
+    let _ = core::fmt::write(
+        &mut msg,
+        core::format_args!("Successfully replaced {} occurrence(s)", replacement_count),
+    );
+    Ok(msg)
 }
 
 #[cfg(test)]
@@ -255,6 +261,30 @@ mod tests {
         .await
         .unwrap_err();
         assert!(matches!(err, EditError::NotFound));
+    }
+
+    #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]
+    async fn overlapping_match_is_ambiguous() {
+        let file = create_temp_file("aaa");
+        let resolver = AbsolutePathResolver;
+
+        let err = edit_file(
+            &resolver,
+            EditRequest {
+                file_path: file.path().to_str().unwrap().to_string(),
+                old_string: "aa".to_string(),
+                new_string: "x".to_string(),
+                replace_all: false,
+            },
+            &EditSettings::new(),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, EditError::AmbiguousMatch),
+            "expected AmbiguousMatch for overlapping occurrences of 'aa' in 'aaa', got {:?}",
+            err
+        );
     }
 
     #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]

--- a/src/llm-coding-tools-core/src/tools/glob.rs
+++ b/src/llm-coding-tools-core/src/tools/glob.rs
@@ -149,7 +149,7 @@ pub fn glob_files<R: PathResolver>(
 
     let matcher = Glob::new(&request.pattern)?.compile_matcher();
 
-    let mut files_with_mtime: Vec<(String, SystemTime)> = Vec::new();
+    let mut entries: Vec<(std::path::PathBuf, SystemTime)> = Vec::new();
     let mut errors: Vec<String> = Vec::with_capacity(8);
 
     let walker = WalkBuilder::new(&path)
@@ -177,7 +177,7 @@ pub fn glob_files<R: PathResolver>(
         }
 
         let rel_path = match entry.path().strip_prefix(&path) {
-            Ok(p) => p.to_string_lossy().into_owned(),
+            Ok(p) => p,
             Err(err) => {
                 errors.push(format!(
                     "failed to make '{}' relative to '{}': {err}",
@@ -188,22 +188,31 @@ pub fn glob_files<R: PathResolver>(
             }
         };
 
-        // Normalise Windows backslashes to forward slashes for glob pattern matching
-        #[cfg(windows)]
-        let rel_path = rel_path.replace('\\', "/");
-
-        if rel_path.is_empty() {
+        if rel_path.as_os_str().is_empty() {
             continue;
         }
 
-        if !matcher.is_match(&rel_path) {
+        let rel_str = rel_path.to_string_lossy();
+
+        // Normalise Windows backslashes to forward slashes for glob pattern matching
+        #[cfg(windows)]
+        let rel_str: std::borrow::Cow<'_, str> = {
+            use std::borrow::Cow;
+            if rel_str.contains('\\') {
+                Cow::Owned(rel_str.replace('\\', "/"))
+            } else {
+                rel_str
+            }
+        };
+
+        if !matcher.is_match(rel_str.as_ref()) {
             continue;
         }
 
         // If target is in a location it's not allowed to access, it needs
         // to be filtered out.
-        let entry_subject = entry.path().to_string_lossy();
         if let Some(ruleset) = settings.permission() {
+            let entry_subject = entry.path().to_string_lossy();
             if !ruleset.is_allowed(glob_meta::NAME, entry_subject.as_ref()) {
                 continue;
             }
@@ -215,17 +224,27 @@ pub fn glob_files<R: PathResolver>(
             .and_then(|m| m.modified().ok())
             .unwrap_or(SystemTime::UNIX_EPOCH);
 
-        files_with_mtime.push((rel_path, mtime));
+        entries.push((rel_path.to_path_buf(), mtime));
     }
 
-    files_with_mtime.sort_by_key(|entry| std::cmp::Reverse(entry.1));
+    let total = entries.len();
+    let truncated = total > limit;
 
-    let truncated = files_with_mtime.len() > limit;
+    if total <= limit {
+        entries.sort_by(|a, b| b.1.cmp(&a.1));
+    } else {
+        entries.select_nth_unstable_by(limit - 1, |a, b| b.1.cmp(&a.1));
+        entries[..limit].sort_by(|a, b| b.1.cmp(&a.1));
+    }
 
-    let files: Vec<String> = files_with_mtime
-        .into_iter()
-        .take(limit)
-        .map(|(path, _)| path)
+    let files: Vec<String> = entries[..limit.min(total)]
+        .iter()
+        .map(|(p, _)| {
+            let s = p.to_string_lossy().into_owned();
+            #[cfg(windows)]
+            let s = s.replace('\\', "/");
+            s
+        })
         .collect();
 
     Ok(GlobOutput {
@@ -463,5 +482,285 @@ mod tests {
 
         assert_eq!(result.files, vec!["allowed.txt".to_string()]);
         Ok(())
+    }
+
+    fn create_nested_gitignore_tree() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path();
+
+        fs::create_dir_all(base.join(".git")).unwrap();
+
+        let mut root_gi = File::create(base.join(".gitignore")).unwrap();
+        writeln!(root_gi, "build/").unwrap();
+
+        fs::create_dir_all(base.join("src/subdir")).unwrap();
+        File::create(base.join("src/main.rs")).unwrap();
+        File::create(base.join("src/subdir/keep.rs")).unwrap();
+
+        fs::create_dir_all(base.join("build")).unwrap();
+        File::create(base.join("build/output.rs")).unwrap();
+
+        let mut subdir_gi = File::create(base.join("src/subdir/.gitignore")).unwrap();
+        writeln!(subdir_gi, "*.tmp").unwrap();
+        File::create(base.join("src/subdir/test.tmp")).unwrap();
+
+        dir
+    }
+
+    #[test]
+    fn glob_root_gitignore_excludes_build_dir_with_rs_pattern() {
+        let dir = create_nested_gitignore_tree();
+        let resolver = AbsolutePathResolver;
+
+        let result = glob_files(
+            &resolver,
+            GlobRequest {
+                pattern: "**/*.rs".to_string(),
+                path: dir.path().to_str().unwrap().to_string(),
+            },
+            &GlobSettings::new().with_limit(1000).unwrap(),
+        )
+        .unwrap();
+
+        assert!(
+            !result.files.iter().any(|f| f.contains("build")),
+            "root .gitignore excludes build/, but build/output.rs appeared: {:?}",
+            result.files
+        );
+        assert!(
+            result.files.iter().any(|f| f.contains("main.rs")),
+            "expected src/main.rs in results: {:?}",
+            result.files
+        );
+    }
+
+    #[test]
+    fn glob_nested_gitignore_excludes_tmp_files() {
+        let dir = create_nested_gitignore_tree();
+        let resolver = AbsolutePathResolver;
+
+        let result = glob_files(
+            &resolver,
+            GlobRequest {
+                pattern: "**/*".to_string(),
+                path: dir.path().to_str().unwrap().to_string(),
+            },
+            &GlobSettings::new().with_limit(1000).unwrap(),
+        )
+        .unwrap();
+
+        assert!(
+            !result.files.iter().any(|f| f.contains("test.tmp")),
+            "nested .gitignore excludes *.tmp, but src/subdir/test.tmp appeared: {:?}",
+            result.files
+        );
+        assert!(
+            result.files.iter().any(|f| f.contains("keep.rs")),
+            "expected src/subdir/keep.rs in results: {:?}",
+            result.files
+        );
+    }
+
+    #[test]
+    fn glob_handles_empty_directory() {
+        let dir = TempDir::new().unwrap();
+        let resolver = AbsolutePathResolver;
+
+        let result = glob_files(
+            &resolver,
+            GlobRequest {
+                pattern: "**/*".to_string(),
+                path: dir.path().to_str().unwrap().to_string(),
+            },
+            &GlobSettings::new().with_limit(1000).unwrap(),
+        )
+        .unwrap();
+
+        assert!(
+            result.files.is_empty(),
+            "empty dir should yield no files: {:?}",
+            result.files
+        );
+        assert!(!result.truncated);
+        assert!(!result.partial);
+    }
+
+    #[test]
+    fn glob_handles_pattern_matching_nothing() {
+        let dir = create_test_tree();
+        let resolver = AbsolutePathResolver;
+
+        let result = glob_files(
+            &resolver,
+            GlobRequest {
+                pattern: "**/*.xyz".to_string(),
+                path: dir.path().to_str().unwrap().to_string(),
+            },
+            &GlobSettings::new().with_limit(1000).unwrap(),
+        )
+        .unwrap();
+
+        assert!(
+            result.files.is_empty(),
+            "no .xyz files exist: {:?}",
+            result.files
+        );
+        assert!(!result.truncated);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn glob_does_not_follow_symlinks_to_directories() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TempDir::new().unwrap();
+        let base = dir.path();
+
+        fs::create_dir_all(base.join("real_dir")).unwrap();
+        File::create(base.join("real_dir/inside.txt")).unwrap();
+        File::create(base.join("top.txt")).unwrap();
+
+        symlink(base.join("real_dir"), base.join("link_dir")).unwrap();
+
+        let resolver = AbsolutePathResolver;
+        let result = glob_files(
+            &resolver,
+            GlobRequest {
+                pattern: "**/*.txt".to_string(),
+                path: base.to_str().unwrap().to_string(),
+            },
+            &GlobSettings::new().with_limit(1000).unwrap(),
+        )
+        .unwrap();
+
+        assert!(
+            !result.files.iter().any(|f| f.starts_with("link_dir/")),
+            "symlinked directory contents should not be traversed via link_dir: {:?}",
+            result.files
+        );
+        assert!(
+            result.files.iter().any(|f| f == "real_dir/inside.txt"),
+            "real directory contents should still be traversed: {:?}",
+            result.files
+        );
+        assert!(
+            result.files.iter().any(|f| f == "top.txt"),
+            "expected top.txt in results: {:?}",
+            result.files
+        );
+    }
+
+    #[test]
+    fn glob_sets_truncated_flag_when_results_exceed_limit() {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path();
+        for i in 0..5 {
+            File::create(base.join(format!("file{i}.txt"))).unwrap();
+        }
+
+        let resolver = AbsolutePathResolver;
+        let result = glob_files(
+            &resolver,
+            GlobRequest {
+                pattern: "**/*.txt".to_string(),
+                path: base.to_str().unwrap().to_string(),
+            },
+            &GlobSettings::new().with_limit(3).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(result.files.len(), 3, "should return exactly limit items");
+        assert!(result.truncated, "truncated flag should be set");
+    }
+
+    #[test]
+    fn glob_truncated_false_when_within_limit() {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path();
+        File::create(base.join("a.txt")).unwrap();
+        File::create(base.join("b.txt")).unwrap();
+
+        let resolver = AbsolutePathResolver;
+        let result = glob_files(
+            &resolver,
+            GlobRequest {
+                pattern: "**/*.txt".to_string(),
+                path: base.to_str().unwrap().to_string(),
+            },
+            &GlobSettings::new().with_limit(100).unwrap(),
+        )
+        .unwrap();
+
+        assert!(
+            !result.truncated,
+            "truncated should be false when files <= limit"
+        );
+    }
+
+    #[test]
+    fn glob_permission_filtering_with_override_builder_pattern() -> TestResult {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path();
+        let allowed_path = base.join("allowed.rs");
+        let denied_path = base.join("denied.rs");
+        File::create(&allowed_path).unwrap();
+        File::create(&denied_path).unwrap();
+
+        let mut ruleset = Ruleset::new();
+        ruleset.push(Rule::new(glob_meta::NAME, "*", PermissionAction::Allow)?);
+        ruleset.push(Rule::new(
+            glob_meta::NAME,
+            denied_path.to_string_lossy().into_owned(),
+            PermissionAction::Deny,
+        )?);
+
+        let resolver = AbsolutePathResolver;
+        let result = glob_files(
+            &resolver,
+            GlobRequest {
+                pattern: "**/*.rs".to_string(),
+                path: base.to_str().unwrap().to_string(),
+            },
+            &GlobSettings::new()
+                .with_limit(1000)
+                .unwrap()
+                .with_permission(Some(Arc::new(ruleset))),
+        )
+        .unwrap();
+
+        assert_eq!(result.files, vec!["allowed.rs".to_string()]);
+        Ok(())
+    }
+
+    #[test]
+    fn glob_nested_gitignore_without_root_gitignore() {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path();
+
+        fs::create_dir_all(base.join(".git")).unwrap();
+        fs::create_dir_all(base.join("src/subdir")).unwrap();
+        File::create(base.join("src/main.rs")).unwrap();
+        File::create(base.join("src/subdir/keep.rs")).unwrap();
+
+        let mut subdir_gi = File::create(base.join("src/subdir/.gitignore")).unwrap();
+        writeln!(subdir_gi, "*.tmp").unwrap();
+        File::create(base.join("src/subdir/test.tmp")).unwrap();
+
+        let resolver = AbsolutePathResolver;
+        let result = glob_files(
+            &resolver,
+            GlobRequest {
+                pattern: "**/*".to_string(),
+                path: base.to_str().unwrap().to_string(),
+            },
+            &GlobSettings::new().with_limit(1000).unwrap(),
+        )
+        .unwrap();
+
+        assert!(
+            !result.files.iter().any(|f| f.contains("test.tmp")),
+            "nested .gitignore should exclude *.tmp even without root .gitignore: {:?}",
+            result.files
+        );
     }
 }

--- a/src/llm-coding-tools-core/src/tools/glob.rs
+++ b/src/llm-coding-tools-core/src/tools/glob.rs
@@ -231,10 +231,10 @@ pub fn glob_files<R: PathResolver>(
     let truncated = total > limit;
 
     if total <= limit {
-        entries.sort_by(|a, b| b.1.cmp(&a.1));
+        entries.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
     } else {
-        entries.select_nth_unstable_by(limit - 1, |a, b| b.1.cmp(&a.1));
-        entries[..limit].sort_by(|a, b| b.1.cmp(&a.1));
+        entries.select_nth_unstable_by(limit - 1, |a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        entries[..limit].sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
     }
 
     let files: Vec<String> = entries[..limit.min(total)]
@@ -425,6 +425,53 @@ mod tests {
             "expected newer file before older: {:?}",
             result.files
         );
+    }
+
+    #[rstest]
+    #[case::within_limit(
+        &["c.txt", "a.txt", "b.txt"],
+        1000,
+        vec!["a.txt", "b.txt", "c.txt"],
+        false,
+    )]
+    #[case::truncated(
+        &["e.txt", "c.txt", "a.txt", "d.txt", "b.txt"],
+        3,
+        vec!["a.txt", "b.txt", "c.txt"],
+        true,
+    )]
+    fn glob_sorts_deterministically_with_identical_mtimes(
+        #[case] files: &[&str],
+        #[case] limit: usize,
+        #[case] expected: Vec<&str>,
+        #[case] expected_truncated: bool,
+    ) {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path();
+        let resolver = AbsolutePathResolver;
+
+        let same_time = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
+        for name in files {
+            let f = File::create(base.join(name)).unwrap();
+            f.set_times(FileTimes::new().set_modified(same_time))
+                .unwrap();
+        }
+
+        let result = glob_files(
+            &resolver,
+            GlobRequest {
+                pattern: "**/*.txt".to_string(),
+                path: base.to_str().unwrap().to_string(),
+            },
+            &GlobSettings::new().with_limit(limit).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.files, expected,
+            "entries with identical mtimes must be sorted lexicographically by path"
+        );
+        assert_eq!(result.truncated, expected_truncated);
     }
 
     #[test]

--- a/src/llm-coding-tools-core/src/tools/glob.rs
+++ b/src/llm-coding-tools-core/src/tools/glob.rs
@@ -1,6 +1,7 @@
 //! Glob pattern file matching operation.
 
 use crate::error::{ToolError, ToolResult};
+use crate::path::allowed_glob::normalize::normalize_path;
 use crate::path::PathResolver;
 use crate::permissions::Ruleset;
 use crate::permissions_ext::OptionRulesetExt;
@@ -15,7 +16,9 @@ use std::time::SystemTime;
 /// Serde-friendly glob request owned by the core crate.
 #[derive(Debug, Deserialize)]
 pub struct GlobRequest {
+    /// Glob pattern to match against file paths (e.g. `"**/*.rs"`).
     pub pattern: String,
+    /// Absolute or relative directory path to search.
     pub path: String,
 }
 
@@ -31,7 +34,9 @@ impl GlobRequest {
 /// The `limit` field caps the number of file paths returned.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlobSettings {
+    /// Maximum number of file paths to return.
     limit: usize,
+    /// Optional permission ruleset controlling which paths may be traversed.
     permission: Option<Arc<Ruleset>>,
 }
 
@@ -127,13 +132,31 @@ pub struct GlobOutput {
 ///
 /// Results are sorted by modification time (newest first) and respect `.gitignore`.
 /// The `limit` parameter controls the maximum number of files returned.
+///
+/// # Arguments
+/// - `resolver` - [`PathResolver`] used to resolve `request.path` to an absolute directory.
+/// - `request` - The glob request containing the pattern and search directory.
+/// - `settings` - Runtime settings including result limit and optional permission ruleset.
+///
+/// # Returns
+/// - [`GlobOutput`] with matched file paths, sorted newest-first, plus truncation and
+///   error metadata.
+///
+/// # Errors
+/// - Returns [`ToolError::InvalidPath`] when the resolved path is not a directory.
+/// - Returns a [`ToolError`] when the glob pattern fails to compile.
+/// - Returns a [`ToolError`] when path resolution fails.
+/// - Returns a [`ToolError`] when the permission check denies access to the search directory.
 pub fn glob_files<R: PathResolver>(
     resolver: &R,
     request: GlobRequest,
     settings: &GlobSettings,
 ) -> ToolResult<GlobOutput> {
+    // Resolve the requested path to an absolute directory.
     let path = resolver.resolve(&request.path)?;
     let search_subject = path.to_string_lossy();
+
+    // Check that the caller is allowed to glob inside this directory.
     settings
         .permission()
         .check(glob_meta::NAME, search_subject.as_ref())?;
@@ -147,11 +170,13 @@ pub fn glob_files<R: PathResolver>(
 
     let limit = settings.limit();
 
+    // Compile the glob pattern once for repeated matching.
     let matcher = Glob::new(&request.pattern)?.compile_matcher();
 
     let mut entries: Vec<(std::path::PathBuf, SystemTime)> = Vec::new();
     let mut errors: Vec<String> = Vec::with_capacity(8);
 
+    // Walk the directory tree, honouring .gitignore at every level.
     let walker = WalkBuilder::new(&path)
         .hidden(false)
         .git_ignore(true)
@@ -160,6 +185,7 @@ pub fn glob_files<R: PathResolver>(
         .build();
 
     for entry_result in walker {
+        // Record traversal errors but keep walking.
         let entry = match entry_result {
             Ok(e) => e,
             Err(err) => {
@@ -168,6 +194,7 @@ pub fn glob_files<R: PathResolver>(
             }
         };
 
+        // Skip directories — we only want files.
         if let Some(ft) = entry.file_type() {
             if ft.is_dir() {
                 continue;
@@ -176,6 +203,7 @@ pub fn glob_files<R: PathResolver>(
             continue;
         }
 
+        // Strip the search-root prefix to get a relative path.
         let rel_path = match entry.path().strip_prefix(&path) {
             Ok(p) => p,
             Err(err) => {
@@ -188,29 +216,21 @@ pub fn glob_files<R: PathResolver>(
             }
         };
 
+        // When WalkBuilder yields the search root itself, strip_prefix
+        // produces an empty path - skip it so we only match against files.
         if rel_path.as_os_str().is_empty() {
             continue;
         }
 
-        let rel_str = rel_path.to_string_lossy();
+        // Normalise separators to forward slashes.
+        let rel_str = normalize_path(rel_path);
 
-        // Normalise Windows backslashes to forward slashes for glob pattern matching
-        #[cfg(windows)]
-        let rel_str: std::borrow::Cow<'_, str> = {
-            use std::borrow::Cow;
-            if rel_str.contains('\\') {
-                Cow::Owned(rel_str.replace('\\', "/"))
-            } else {
-                rel_str
-            }
-        };
-
+        // Skip files that don't match the glob pattern.
         if !matcher.is_match(rel_str.as_ref()) {
             continue;
         }
 
-        // If target is in a location it's not allowed to access, it needs
-        // to be filtered out.
+        // Drop files the caller isn't allowed to see.
         if let Some(ruleset) = settings.permission() {
             let entry_subject = entry.path().to_string_lossy();
             if !ruleset.is_allowed(glob_meta::NAME, entry_subject.as_ref()) {
@@ -218,6 +238,7 @@ pub fn glob_files<R: PathResolver>(
             }
         }
 
+        // Read mtime, falling back to epoch when unavailable.
         let mtime = entry
             .metadata()
             .ok()
@@ -230,6 +251,8 @@ pub fn glob_files<R: PathResolver>(
     let total = entries.len();
     let truncated = total > limit;
 
+    // Sort newest-first; break ties by path. Partial-sort when over limit
+    // to avoid ordering entries that will be discarded.
     if total <= limit {
         entries.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
     } else {
@@ -237,14 +260,10 @@ pub fn glob_files<R: PathResolver>(
         entries[..limit].sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
     }
 
+    // Build the final list of normalised relative paths.
     let files: Vec<String> = entries[..limit.min(total)]
         .iter()
-        .map(|(p, _)| {
-            let s = p.to_string_lossy().into_owned();
-            #[cfg(windows)]
-            let s = s.replace('\\', "/");
-            s
-        })
+        .map(|(p, _)| normalize_path(p).into_owned())
         .collect();
 
     Ok(GlobOutput {
@@ -257,17 +276,51 @@ pub fn glob_files<R: PathResolver>(
 
 #[cfg(test)]
 mod tests {
+    //! Tests for the [`glob_files`] operation covering pattern matching, sorting,
+    //! gitignore handling, permission filtering, limit enforcement, and serialization.
     use super::*;
     use crate::path::AbsolutePathResolver;
     use crate::permissions::{ExpandError, PermissionAction, Rule};
     use rstest::rstest;
     use std::fs::{self, File, FileTimes};
     use std::io::Write;
+    use std::path::Path;
     use std::time::{Duration, SystemTime};
     use tempfile::TempDir;
 
     type TestResult = Result<(), ExpandError>;
 
+    fn test_settings() -> GlobSettings {
+        GlobSettings::new().with_limit(1000).unwrap()
+    }
+
+    fn test_settings_with_limit(limit: usize) -> GlobSettings {
+        GlobSettings::new().with_limit(limit).unwrap()
+    }
+
+    fn run_glob(path: &Path, pattern: &str) -> GlobOutput {
+        run_glob_with_settings(path, pattern, &test_settings())
+    }
+
+    fn run_glob_with_limit(path: &Path, pattern: &str, limit: usize) -> GlobOutput {
+        run_glob_with_settings(path, pattern, &test_settings_with_limit(limit))
+    }
+
+    fn run_glob_with_settings(path: &Path, pattern: &str, settings: &GlobSettings) -> GlobOutput {
+        let resolver = AbsolutePathResolver;
+        glob_files(
+            &resolver,
+            GlobRequest {
+                pattern: pattern.to_string(),
+                path: path.to_str().unwrap().to_string(),
+            },
+            settings,
+        )
+        .unwrap()
+    }
+
+    /// Creates a temporary directory tree with `.git`, `src/lib.rs`, `Cargo.toml`,
+    /// and a `target/` directory excluded via `.gitignore`.
     fn create_test_tree() -> TempDir {
         let dir = TempDir::new().unwrap();
         let base = dir.path();
@@ -282,7 +335,6 @@ mod tests {
         dir
     }
 
-    // GlobSettings tests
     #[test]
     fn glob_settings_should_create_standard_defaults() {
         let settings = GlobSettings::new();
@@ -305,17 +357,7 @@ mod tests {
         #[case] should_find: bool,
     ) {
         let dir = create_test_tree();
-        let resolver = AbsolutePathResolver;
-
-        let result = glob_files(
-            &resolver,
-            GlobRequest {
-                pattern: pattern.to_string(),
-                path: dir.path().to_str().unwrap().to_string(),
-            },
-            &GlobSettings::new().with_limit(1000).unwrap(),
-        )
-        .unwrap();
+        let result = run_glob(dir.path(), pattern);
 
         let found = result.files.iter().any(|f| f.contains(needle));
 
@@ -382,7 +424,6 @@ mod tests {
     fn glob_sorts_by_mtime_desc() {
         let dir = TempDir::new().unwrap();
         let base = dir.path();
-        let resolver = AbsolutePathResolver;
 
         let older_path = base.join("older.txt");
         let newer_path = base.join("newer.txt");
@@ -398,15 +439,7 @@ mod tests {
             .set_times(FileTimes::new().set_modified(newer_time))
             .unwrap();
 
-        let result = glob_files(
-            &resolver,
-            GlobRequest {
-                pattern: "**/*.txt".to_string(),
-                path: base.to_str().unwrap().to_string(),
-            },
-            &GlobSettings::new().with_limit(1000).unwrap(),
-        )
-        .unwrap();
+        let result = run_glob(base, "**/*.txt");
 
         let newer_index = result
             .files
@@ -419,7 +452,6 @@ mod tests {
             .position(|path| path.ends_with("older.txt"))
             .unwrap();
 
-        // Newer files should appear before older ones in the results
         assert!(
             newer_index < older_index,
             "expected newer file before older: {:?}",
@@ -448,7 +480,6 @@ mod tests {
     ) {
         let dir = TempDir::new().unwrap();
         let base = dir.path();
-        let resolver = AbsolutePathResolver;
 
         let same_time = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
         for name in files {
@@ -457,15 +488,7 @@ mod tests {
                 .unwrap();
         }
 
-        let result = glob_files(
-            &resolver,
-            GlobRequest {
-                pattern: "**/*.txt".to_string(),
-                path: base.to_str().unwrap().to_string(),
-            },
-            &GlobSettings::new().with_limit(limit).unwrap(),
-        )
-        .unwrap();
+        let result = run_glob_with_limit(base, "**/*.txt", limit);
 
         assert_eq!(
             result.files, expected,
@@ -476,36 +499,26 @@ mod tests {
 
     #[test]
     fn glob_returns_forward_slash_paths() {
-        // Patterns and returned paths use forward slashes on all platforms
         let dir = create_test_tree();
-        let resolver = AbsolutePathResolver;
-        let result = glob_files(
-            &resolver,
-            GlobRequest {
-                pattern: "**/*.rs".to_string(),
-                path: dir.path().to_str().unwrap().to_string(),
-            },
-            &GlobSettings::new().with_limit(1000).unwrap(),
-        )
-        .unwrap();
+        let result = run_glob(dir.path(), "**/*.rs");
 
-        // The only .rs file in our test tree is src/lib.rs
         assert_eq!(result.files.len(), 1);
         assert!(result.files[0].ends_with("lib.rs"));
 
-        // Returned paths must always use forward slashes (important on Windows)
         for path in &result.files {
             assert!(!path.contains('\\'), "expected forward slashes: {path}");
         }
         assert!(result.files.iter().any(|f| f.contains('/')));
     }
 
-    #[test]
-    fn glob_filters_denied_files_before_returning_output() -> TestResult {
+    #[rstest]
+    #[case::txt_files("txt")]
+    #[case::rs_files("rs")]
+    fn glob_permission_filtering_excludes_denied_files(#[case] ext: &str) -> TestResult {
         let dir = TempDir::new().unwrap();
-        let resolver = AbsolutePathResolver;
-        let allowed = dir.path().join("allowed.txt");
-        let denied = dir.path().join("denied.txt");
+        let base = dir.path();
+        let allowed = base.join(format!("allowed.{ext}"));
+        let denied = base.join(format!("denied.{ext}"));
         File::create(&allowed).unwrap();
         File::create(&denied).unwrap();
 
@@ -517,20 +530,21 @@ mod tests {
             PermissionAction::Deny,
         )?);
 
-        let result = glob_files(
-            &resolver,
-            GlobRequest {
-                pattern: "**/*.txt".to_string(),
-                path: dir.path().to_string_lossy().into_owned(),
-            },
-            &GlobSettings::new().with_permission(Some(Arc::new(ruleset))),
-        )
-        .unwrap();
+        let result = run_glob_with_settings(
+            base,
+            &format!("**/*.{ext}"),
+            &GlobSettings::new()
+                .with_limit(1000)
+                .unwrap()
+                .with_permission(Some(Arc::new(ruleset))),
+        );
 
-        assert_eq!(result.files, vec!["allowed.txt".to_string()]);
+        assert_eq!(result.files, vec![format!("allowed.{ext}")]);
         Ok(())
     }
 
+    /// Creates a nested directory tree with root and nested `.gitignore` files
+    /// to verify multi-level ignore rule application.
     fn create_nested_gitignore_tree() -> TempDir {
         let dir = TempDir::new().unwrap();
         let base = dir.path();
@@ -554,20 +568,13 @@ mod tests {
         dir
     }
 
+    /// Verifies that the root `.gitignore` (`build/`) prevents `build/output.rs`
+    /// from appearing in results even when the glob pattern (`**/*.rs`) would
+    /// otherwise match it, while non-ignored `.rs` files remain visible.
     #[test]
     fn glob_root_gitignore_excludes_build_dir_with_rs_pattern() {
         let dir = create_nested_gitignore_tree();
-        let resolver = AbsolutePathResolver;
-
-        let result = glob_files(
-            &resolver,
-            GlobRequest {
-                pattern: "**/*.rs".to_string(),
-                path: dir.path().to_str().unwrap().to_string(),
-            },
-            &GlobSettings::new().with_limit(1000).unwrap(),
-        )
-        .unwrap();
+        let result = run_glob(dir.path(), "**/*.rs");
 
         assert!(
             !result.files.iter().any(|f| f.contains("build")),
@@ -581,20 +588,13 @@ mod tests {
         );
     }
 
+    /// Verifies that a nested `.gitignore` (`src/subdir/.gitignore` with `*.tmp`)
+    /// excludes matching files in that subtree, while sibling files not matching
+    /// the pattern (`keep.rs`) remain in the results.
     #[test]
     fn glob_nested_gitignore_excludes_tmp_files() {
         let dir = create_nested_gitignore_tree();
-        let resolver = AbsolutePathResolver;
-
-        let result = glob_files(
-            &resolver,
-            GlobRequest {
-                pattern: "**/*".to_string(),
-                path: dir.path().to_str().unwrap().to_string(),
-            },
-            &GlobSettings::new().with_limit(1000).unwrap(),
-        )
-        .unwrap();
+        let result = run_glob(dir.path(), "**/*");
 
         assert!(
             !result.files.iter().any(|f| f.contains("test.tmp")),
@@ -611,17 +611,7 @@ mod tests {
     #[test]
     fn glob_handles_empty_directory() {
         let dir = TempDir::new().unwrap();
-        let resolver = AbsolutePathResolver;
-
-        let result = glob_files(
-            &resolver,
-            GlobRequest {
-                pattern: "**/*".to_string(),
-                path: dir.path().to_str().unwrap().to_string(),
-            },
-            &GlobSettings::new().with_limit(1000).unwrap(),
-        )
-        .unwrap();
+        let result = run_glob(dir.path(), "**/*");
 
         assert!(
             result.files.is_empty(),
@@ -635,17 +625,7 @@ mod tests {
     #[test]
     fn glob_handles_pattern_matching_nothing() {
         let dir = create_test_tree();
-        let resolver = AbsolutePathResolver;
-
-        let result = glob_files(
-            &resolver,
-            GlobRequest {
-                pattern: "**/*.xyz".to_string(),
-                path: dir.path().to_str().unwrap().to_string(),
-            },
-            &GlobSettings::new().with_limit(1000).unwrap(),
-        )
-        .unwrap();
+        let result = run_glob(dir.path(), "**/*.xyz");
 
         assert!(
             result.files.is_empty(),
@@ -669,16 +649,7 @@ mod tests {
 
         symlink(base.join("real_dir"), base.join("link_dir")).unwrap();
 
-        let resolver = AbsolutePathResolver;
-        let result = glob_files(
-            &resolver,
-            GlobRequest {
-                pattern: "**/*.txt".to_string(),
-                path: base.to_str().unwrap().to_string(),
-            },
-            &GlobSettings::new().with_limit(1000).unwrap(),
-        )
-        .unwrap();
+        let result = run_glob(base, "**/*.txt");
 
         assert!(
             !result.files.iter().any(|f| f.starts_with("link_dir/")),
@@ -705,16 +676,7 @@ mod tests {
             File::create(base.join(format!("file{i}.txt"))).unwrap();
         }
 
-        let resolver = AbsolutePathResolver;
-        let result = glob_files(
-            &resolver,
-            GlobRequest {
-                pattern: "**/*.txt".to_string(),
-                path: base.to_str().unwrap().to_string(),
-            },
-            &GlobSettings::new().with_limit(3).unwrap(),
-        )
-        .unwrap();
+        let result = run_glob_with_limit(base, "**/*.txt", 3);
 
         assert_eq!(result.files.len(), 3, "should return exactly limit items");
         assert!(result.truncated, "truncated flag should be set");
@@ -727,56 +689,12 @@ mod tests {
         File::create(base.join("a.txt")).unwrap();
         File::create(base.join("b.txt")).unwrap();
 
-        let resolver = AbsolutePathResolver;
-        let result = glob_files(
-            &resolver,
-            GlobRequest {
-                pattern: "**/*.txt".to_string(),
-                path: base.to_str().unwrap().to_string(),
-            },
-            &GlobSettings::new().with_limit(100).unwrap(),
-        )
-        .unwrap();
+        let result = run_glob_with_limit(base, "**/*.txt", 100);
 
         assert!(
             !result.truncated,
             "truncated should be false when files <= limit"
         );
-    }
-
-    #[test]
-    fn glob_permission_filtering_with_override_builder_pattern() -> TestResult {
-        let dir = TempDir::new().unwrap();
-        let base = dir.path();
-        let allowed_path = base.join("allowed.rs");
-        let denied_path = base.join("denied.rs");
-        File::create(&allowed_path).unwrap();
-        File::create(&denied_path).unwrap();
-
-        let mut ruleset = Ruleset::new();
-        ruleset.push(Rule::new(glob_meta::NAME, "*", PermissionAction::Allow)?);
-        ruleset.push(Rule::new(
-            glob_meta::NAME,
-            denied_path.to_string_lossy().into_owned(),
-            PermissionAction::Deny,
-        )?);
-
-        let resolver = AbsolutePathResolver;
-        let result = glob_files(
-            &resolver,
-            GlobRequest {
-                pattern: "**/*.rs".to_string(),
-                path: base.to_str().unwrap().to_string(),
-            },
-            &GlobSettings::new()
-                .with_limit(1000)
-                .unwrap()
-                .with_permission(Some(Arc::new(ruleset))),
-        )
-        .unwrap();
-
-        assert_eq!(result.files, vec!["allowed.rs".to_string()]);
-        Ok(())
     }
 
     #[test]
@@ -793,16 +711,7 @@ mod tests {
         writeln!(subdir_gi, "*.tmp").unwrap();
         File::create(base.join("src/subdir/test.tmp")).unwrap();
 
-        let resolver = AbsolutePathResolver;
-        let result = glob_files(
-            &resolver,
-            GlobRequest {
-                pattern: "**/*".to_string(),
-                path: base.to_str().unwrap().to_string(),
-            },
-            &GlobSettings::new().with_limit(1000).unwrap(),
-        )
-        .unwrap();
+        let result = run_glob(base, "**/*");
 
         assert!(
             !result.files.iter().any(|f| f.contains("test.tmp")),

--- a/src/llm-coding-tools-core/src/tools/grep.rs
+++ b/src/llm-coding-tools-core/src/tools/grep.rs
@@ -13,7 +13,6 @@ use grep_searcher::{BinaryDetection, Searcher, SearcherBuilder};
 use ignore::WalkBuilder;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::fmt::Write;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -241,18 +240,27 @@ impl GrepOutput {
         let estimated_capacity = self.match_count * ESTIMATED_CHARS_PER_MATCH;
         let mut output = String::with_capacity(estimated_capacity);
 
-        let _ = writeln!(&mut output, "Found {} matches", self.match_count);
+        output.push_str("Found ");
+        push_u64(&mut output, self.match_count as u64);
+        output.push_str(" matches\n");
 
         for file in &self.files {
-            let _ = writeln!(&mut output, "\n{}:", file.path);
+            output.push('\n');
+            output.push_str(&file.path);
+            output.push_str(":\n");
+
             for m in &file.matches {
                 let (display_text, was_truncated) =
                     truncate_line_with_ellipsis(&m.line_text, max_line_len);
 
                 if line_numbers {
-                    let _ = write!(&mut output, "  L{}: {}", m.line_num, display_text);
+                    output.push_str("  L");
+                    push_u64(&mut output, m.line_num);
+                    output.push_str(": ");
+                    output.push_str(display_text);
                 } else {
-                    let _ = write!(&mut output, "  {}", display_text);
+                    output.push_str("  ");
+                    output.push_str(display_text);
                 }
 
                 if was_truncated {
@@ -264,19 +272,15 @@ impl GrepOutput {
         }
 
         if self.truncated {
-            let _ = write!(
-                &mut output,
-                "\n(Results truncated at {} matches)",
-                self.effective_limit
-            );
+            output.push_str("\n(Results truncated at ");
+            push_u64(&mut output, self.effective_limit as u64);
+            output.push_str(" matches)");
         }
 
         if self.partial {
-            let _ = write!(
-                &mut output,
-                "\n(Partial results: {} file error(s) encountered)",
-                self.errors.len()
-            );
+            output.push_str("\n(Partial results: ");
+            push_u64(&mut output, self.errors.len() as u64);
+            output.push_str(" file error(s) encountered)");
         }
 
         output
@@ -435,6 +439,28 @@ pub fn grep_search<R: PathResolver>(
         errors,
         effective_limit: limit,
     })
+}
+
+/// Formats a [`u64`] as decimal digits and appends them to `output`.
+///
+/// Writes digits into a fixed-size stack buffer right-to-left, then appends
+/// the resulting slice — no intermediate [`String`] or heap allocation.
+#[inline]
+fn push_u64(output: &mut String, mut n: u64) {
+    if n == 0 {
+        output.push('0');
+        return;
+    }
+    let mut buf = [0u8; 20];
+    let mut pos = 20usize;
+    while n > 0 {
+        pos -= 1;
+        buf[pos] = b'0' + (n % 10) as u8;
+        n /= 10;
+    }
+    unsafe {
+        output.push_str(core::str::from_utf8_unchecked(&buf[pos..]));
+    }
 }
 
 struct FileSearchResult {

--- a/src/llm-coding-tools-core/src/tools/grep.rs
+++ b/src/llm-coding-tools-core/src/tools/grep.rs
@@ -5,7 +5,7 @@ use crate::path::PathResolver;
 use crate::permissions::Ruleset;
 use crate::permissions_ext::OptionRulesetExt;
 use crate::tool_metadata::grep as grep_meta;
-use crate::util::{truncate_line_with_ellipsis, TRUNCATION_ELLIPSIS};
+use crate::util::{push_usize, truncate_line_with_ellipsis, TRUNCATION_ELLIPSIS};
 use globset::Glob;
 use grep_regex::RegexMatcher;
 use grep_searcher::sinks::UTF8;
@@ -241,7 +241,7 @@ impl GrepOutput {
         let mut output = String::with_capacity(estimated_capacity);
 
         output.push_str("Found ");
-        push_u64(&mut output, self.match_count as u64);
+        push_usize(&mut output, self.match_count);
         output.push_str(" matches\n");
 
         for file in &self.files {
@@ -255,7 +255,7 @@ impl GrepOutput {
 
                 if line_numbers {
                     output.push_str("  L");
-                    push_u64(&mut output, m.line_num);
+                    push_usize(&mut output, m.line_num as usize);
                     output.push_str(": ");
                     output.push_str(display_text);
                 } else {
@@ -273,13 +273,13 @@ impl GrepOutput {
 
         if self.truncated {
             output.push_str("\n(Results truncated at ");
-            push_u64(&mut output, self.effective_limit as u64);
+            push_usize(&mut output, self.effective_limit);
             output.push_str(" matches)");
         }
 
         if self.partial {
             output.push_str("\n(Partial results: ");
-            push_u64(&mut output, self.errors.len() as u64);
+            push_usize(&mut output, self.errors.len());
             output.push_str(" file error(s) encountered)");
         }
 
@@ -439,28 +439,6 @@ pub fn grep_search<R: PathResolver>(
         errors,
         effective_limit: limit,
     })
-}
-
-/// Formats a [`u64`] as decimal digits and appends them to `output`.
-///
-/// Writes digits into a fixed-size stack buffer right-to-left, then appends
-/// the resulting slice — no intermediate [`String`] or heap allocation.
-#[inline]
-fn push_u64(output: &mut String, mut n: u64) {
-    if n == 0 {
-        output.push('0');
-        return;
-    }
-    let mut buf = [0u8; 20];
-    let mut pos = 20usize;
-    while n > 0 {
-        pos -= 1;
-        buf[pos] = b'0' + (n % 10) as u8;
-        n /= 10;
-    }
-    unsafe {
-        output.push_str(core::str::from_utf8_unchecked(&buf[pos..]));
-    }
 }
 
 struct FileSearchResult {

--- a/src/llm-coding-tools-core/src/tools/read.rs
+++ b/src/llm-coding-tools-core/src/tools/read.rs
@@ -8,22 +8,90 @@ use crate::permissions::Ruleset;
 use crate::permissions_ext::OptionRulesetExt;
 use crate::tool_metadata::read as read_meta;
 use crate::util::{truncate_line_with_ellipsis, ESTIMATED_CHARS_PER_LINE, TRUNCATION_ELLIPSIS};
-use memchr::memchr;
+use memchr::{memchr, memchr_iter};
 use serde::Deserialize;
 use serde_json::Value;
-use std::borrow::Cow;
-use std::fmt::Write;
 use std::sync::Arc;
 
 /// Strips trailing CR from a line (for CRLF handling).
 #[inline]
 fn strip_cr(line: &[u8]) -> &[u8] {
-    line.strip_suffix(b"\r").unwrap_or(line)
+    if line.last() == Some(&b'\r') {
+        &line[..line.len() - 1]
+    } else {
+        line
+    }
+}
+
+#[inline]
+fn push_usize(output: &mut String, mut n: usize) {
+    if n == 0 {
+        output.push('0');
+        return;
+    }
+    let mut buf = [0u8; 20];
+    let mut pos = 20usize;
+    while n > 0 {
+        pos -= 1;
+        buf[pos] = b'0' + (n % 10) as u8;
+        n /= 10;
+    }
+    unsafe {
+        output.push_str(core::str::from_utf8_unchecked(&buf[pos..]));
+    }
+}
+
+#[inline]
+fn append_line_content(output: &mut String, content: &str, max_line_length: usize) {
+    let (display_content, was_truncated) = truncate_line_with_ellipsis(content, max_line_length);
+    output.push_str(display_content);
+    if was_truncated {
+        output.push_str(TRUNCATION_ELLIPSIS);
+    }
 }
 
 /// Processes a single line, appending it to output with optional line numbers.
+///
+/// Const-generic over `LINE_NUMBERS` so the compiler can eliminate the
+/// branch at compile time and monomorphize two tight loops.
 #[inline]
-fn process_line(
+fn process_line<const LINE_NUMBERS: bool>(
+    line_bytes: &[u8],
+    line_number: usize,
+    output: &mut String,
+    lines_output: &mut usize,
+    max_line_length: usize,
+) {
+    let line_bytes = strip_cr(line_bytes);
+
+    if *lines_output > 0 {
+        output.push('\n');
+    }
+
+    if LINE_NUMBERS {
+        output.push('L');
+        push_usize(output, line_number);
+        output.push_str(": ");
+    }
+
+    // ASCII fast path: SIMD-accelerated check avoids full UTF-8 validation.
+    // SAFETY: ASCII is always valid UTF-8.
+    if line_bytes.is_ascii() {
+        let content = unsafe { core::str::from_utf8_unchecked(line_bytes) };
+        append_line_content(output, content, max_line_length);
+    } else if let Ok(content) = core::str::from_utf8(line_bytes) {
+        append_line_content(output, content, max_line_length);
+    } else {
+        let content = String::from_utf8_lossy(line_bytes);
+        append_line_content(output, &content, max_line_length);
+    }
+
+    *lines_output += 1;
+}
+
+/// Dispatches to the correct const-generic `process_line` monomorphization.
+#[inline(always)]
+fn emit_line(
     line_bytes: &[u8],
     line_number: usize,
     output: &mut String,
@@ -31,25 +99,23 @@ fn process_line(
     max_line_length: usize,
     line_numbers: bool,
 ) {
-    let line_bytes = strip_cr(line_bytes);
-    let content: Cow<'_, str> = String::from_utf8_lossy(line_bytes);
-    let (display_content, was_truncated) = truncate_line_with_ellipsis(&content, max_line_length);
-
-    if *lines_output > 0 {
-        output.push('\n');
-    }
-
     if line_numbers {
-        let _ = write!(output, "L{}: {}", line_number, display_content);
+        process_line::<true>(
+            line_bytes,
+            line_number,
+            output,
+            lines_output,
+            max_line_length,
+        );
     } else {
-        output.push_str(display_content);
+        process_line::<false>(
+            line_bytes,
+            line_number,
+            output,
+            lines_output,
+            max_line_length,
+        );
     }
-
-    if was_truncated {
-        output.push_str(TRUNCATION_ELLIPSIS);
-    }
-
-    *lines_output += 1;
 }
 
 /// Serde-friendly read request owned by the core crate.
@@ -320,15 +386,59 @@ pub async fn read_file<R: PathResolver>(
     settings
         .permission()
         .check(read_meta::NAME, subject.as_ref())?;
-    let buf_capacity = (limit * ESTIMATED_CHARS_PER_LINE).next_power_of_two();
+    let buf_capacity = limit.saturating_mul(ESTIMATED_CHARS_PER_LINE).min(1 << 20);
     let mut reader = fs::open_buffered(&path, buf_capacity).await?;
 
-    let estimated_capacity = limit * ESTIMATED_CHARS_PER_LINE;
+    let line_prefix_len = if line_numbers {
+        let last_line = offset.saturating_add(limit).saturating_sub(1);
+        last_line.checked_ilog10().unwrap_or(0) as usize + 3
+    } else {
+        0
+    };
+    let estimated_capacity = limit.saturating_mul(ESTIMATED_CHARS_PER_LINE + line_prefix_len);
     let mut output = String::with_capacity(estimated_capacity);
     // Holds a partial line that spans multiple buffers.
     let mut overflow: Vec<u8> = Vec::new();
     let mut line_number = 0usize;
     let mut lines_output = 0usize;
+
+    // Fast skip: when offset > 1, count newlines in bulk via SIMD without
+    // processing line content. This avoids the per-line overhead of strip_cr,
+    // UTF-8 validation, and output formatting for skipped lines.
+    if offset > 1 {
+        let skip_target = offset - 1;
+        let mut trailing_content = false;
+        while line_number < skip_target {
+            let consume = {
+                let buf = reader.fill_buf().await?;
+                if buf.is_empty() {
+                    if trailing_content {
+                        line_number += 1;
+                    }
+                    break;
+                }
+                let remaining = skip_target - line_number;
+                let mut count = 0usize;
+                let mut last_pos = 0usize;
+                for pos in memchr_iter(b'\n', buf) {
+                    count += 1;
+                    last_pos = pos;
+                    if count >= remaining {
+                        break;
+                    }
+                }
+                line_number += count;
+                if count >= remaining {
+                    trailing_content = false;
+                    last_pos + 1
+                } else {
+                    trailing_content = buf.last() != Some(&b'\n');
+                    buf.len()
+                }
+            };
+            reader.consume(consume);
+        }
+    }
 
     // Stream buffered chunks, splitting into lines as we go.
     loop {
@@ -338,7 +448,7 @@ pub async fn read_file<R: PathResolver>(
             if !overflow.is_empty() {
                 line_number += 1;
                 if line_number >= offset && lines_output < limit {
-                    process_line(
+                    emit_line(
                         &overflow,
                         line_number,
                         &mut output,
@@ -360,9 +470,9 @@ pub async fn read_file<R: PathResolver>(
 
                 // Only emit lines within the requested window.
                 if line_number >= offset && lines_output < limit {
+                    // Fast path: line is fully in this buffer.
                     if overflow.is_empty() {
-                        // Fast path: line is fully in this buffer.
-                        process_line(
+                        emit_line(
                             &buf[pos..newline_pos],
                             line_number,
                             &mut output,
@@ -373,7 +483,7 @@ pub async fn read_file<R: PathResolver>(
                     } else {
                         // Slow path: prepend buffered fragment.
                         overflow.extend_from_slice(&buf[pos..newline_pos]);
-                        process_line(
+                        emit_line(
                             &overflow,
                             line_number,
                             &mut output,
@@ -519,6 +629,21 @@ mod tests {
     async fn errors_on_offset_zero() {
         let err = read_temp_file(b"test\n", 0, 10, true).await.unwrap_err();
         assert!(matches!(err, ToolError::OutOfBounds(_)));
+    }
+
+    #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]
+    async fn out_of_bounds_reports_correct_line_count_without_trailing_newline() {
+        let err = read_temp_file(b"line1\nline2\nline3", 5, 10, true)
+            .await
+            .unwrap_err();
+        let msg = match &err {
+            ToolError::OutOfBounds(msg) => msg.clone(),
+            other => panic!("expected OutOfBounds, got: {other:?}"),
+        };
+        assert!(
+            msg.contains("3 lines"),
+            "expected '3 lines' in error, got: {msg}"
+        );
     }
 
     #[maybe_async::test(feature = "blocking", async(feature = "tokio", tokio::test))]

--- a/src/llm-coding-tools-core/src/tools/read.rs
+++ b/src/llm-coding-tools-core/src/tools/read.rs
@@ -7,116 +7,13 @@ use crate::path::PathResolver;
 use crate::permissions::Ruleset;
 use crate::permissions_ext::OptionRulesetExt;
 use crate::tool_metadata::read as read_meta;
-use crate::util::{truncate_line_with_ellipsis, ESTIMATED_CHARS_PER_LINE, TRUNCATION_ELLIPSIS};
+use crate::util::{
+    push_usize, truncate_line_with_ellipsis, ESTIMATED_CHARS_PER_LINE, TRUNCATION_ELLIPSIS,
+};
 use memchr::{memchr, memchr_iter};
 use serde::Deserialize;
 use serde_json::Value;
 use std::sync::Arc;
-
-/// Strips trailing CR from a line (for CRLF handling).
-#[inline]
-fn strip_cr(line: &[u8]) -> &[u8] {
-    if line.last() == Some(&b'\r') {
-        &line[..line.len() - 1]
-    } else {
-        line
-    }
-}
-
-#[inline]
-fn push_usize(output: &mut String, mut n: usize) {
-    if n == 0 {
-        output.push('0');
-        return;
-    }
-    let mut buf = [0u8; 20];
-    let mut pos = 20usize;
-    while n > 0 {
-        pos -= 1;
-        buf[pos] = b'0' + (n % 10) as u8;
-        n /= 10;
-    }
-    unsafe {
-        output.push_str(core::str::from_utf8_unchecked(&buf[pos..]));
-    }
-}
-
-#[inline]
-fn append_line_content(output: &mut String, content: &str, max_line_length: usize) {
-    let (display_content, was_truncated) = truncate_line_with_ellipsis(content, max_line_length);
-    output.push_str(display_content);
-    if was_truncated {
-        output.push_str(TRUNCATION_ELLIPSIS);
-    }
-}
-
-/// Processes a single line, appending it to output with optional line numbers.
-///
-/// Const-generic over `LINE_NUMBERS` so the compiler can eliminate the
-/// branch at compile time and monomorphize two tight loops.
-#[inline]
-fn process_line<const LINE_NUMBERS: bool>(
-    line_bytes: &[u8],
-    line_number: usize,
-    output: &mut String,
-    lines_output: &mut usize,
-    max_line_length: usize,
-) {
-    let line_bytes = strip_cr(line_bytes);
-
-    if *lines_output > 0 {
-        output.push('\n');
-    }
-
-    if LINE_NUMBERS {
-        output.push('L');
-        push_usize(output, line_number);
-        output.push_str(": ");
-    }
-
-    // ASCII fast path: SIMD-accelerated check avoids full UTF-8 validation.
-    // SAFETY: ASCII is always valid UTF-8.
-    if line_bytes.is_ascii() {
-        let content = unsafe { core::str::from_utf8_unchecked(line_bytes) };
-        append_line_content(output, content, max_line_length);
-    } else if let Ok(content) = core::str::from_utf8(line_bytes) {
-        append_line_content(output, content, max_line_length);
-    } else {
-        let content = String::from_utf8_lossy(line_bytes);
-        append_line_content(output, &content, max_line_length);
-    }
-
-    *lines_output += 1;
-}
-
-/// Dispatches to the correct const-generic `process_line` monomorphization.
-#[inline(always)]
-fn emit_line(
-    line_bytes: &[u8],
-    line_number: usize,
-    output: &mut String,
-    lines_output: &mut usize,
-    max_line_length: usize,
-    line_numbers: bool,
-) {
-    if line_numbers {
-        process_line::<true>(
-            line_bytes,
-            line_number,
-            output,
-            lines_output,
-            max_line_length,
-        );
-    } else {
-        process_line::<false>(
-            line_bytes,
-            line_number,
-            output,
-            lines_output,
-            max_line_length,
-        );
-    }
-}
 
 /// Serde-friendly read request owned by the core crate.
 #[derive(Debug, Deserialize)]
@@ -170,29 +67,6 @@ impl ReadSettings {
         }
     }
 
-    /// Sets the default and maximum line count for read operations in one
-    /// validated step.
-    ///
-    /// The default limit is used when the caller doesn't specify a line count;
-    /// the max limit caps any explicitly requested count. Both limits must be
-    /// at least [`MIN_LIMIT`], and `default_limit` must not exceed `max_limit`.
-    ///
-    /// # Arguments
-    /// - `default_limit`: Line count used when the request omits `limit`.
-    /// - `max_limit`: Upper bound on lines returned regardless of the request.
-    ///
-    /// # Errors
-    /// - Returns an error when either limit is below [`MIN_LIMIT`] or
-    ///   `default_limit > max_limit`.
-    ///
-    /// [`MIN_LIMIT`]: crate::util::MIN_LIMIT
-    pub fn with_limits(mut self, default_limit: usize, max_limit: usize) -> ToolResult<Self> {
-        ensure_read_limits(default_limit, max_limit)?;
-        self.default_limit = default_limit;
-        self.max_limit = max_limit;
-        Ok(self)
-    }
-
     /// Sets the line count used when the caller doesn't specify one.
     ///
     /// The new value must not exceed the current max limit.
@@ -220,6 +94,29 @@ impl ReadSettings {
     pub fn with_max_limit(self, max_limit: usize) -> ToolResult<Self> {
         let default_limit = self.default_limit;
         self.with_limits(default_limit, max_limit)
+    }
+
+    /// Sets the default and maximum line count for read operations in one
+    /// validated step.
+    ///
+    /// The default limit is used when the caller doesn't specify a line count;
+    /// the max limit caps any explicitly requested count. Both limits must be
+    /// at least [`MIN_LIMIT`], and `default_limit` must not exceed `max_limit`.
+    ///
+    /// # Arguments
+    /// - `default_limit`: Line count used when the request omits `limit`.
+    /// - `max_limit`: Upper bound on lines returned regardless of the request.
+    ///
+    /// # Errors
+    /// - Returns an error when either limit is below [`MIN_LIMIT`] or
+    ///   `default_limit > max_limit`.
+    ///
+    /// [`MIN_LIMIT`]: crate::util::MIN_LIMIT
+    pub fn with_limits(mut self, default_limit: usize, max_limit: usize) -> ToolResult<Self> {
+        ensure_read_limits(default_limit, max_limit)?;
+        self.default_limit = default_limit;
+        self.max_limit = max_limit;
+        Ok(self)
     }
 
     /// Updates the per-line truncation length.
@@ -313,6 +210,349 @@ impl ReadSettings {
     }
 }
 
+#[cfg(feature = "blocking")]
+type BufFile = std::io::BufReader<std::fs::File>;
+#[cfg(feature = "tokio")]
+type BufFile = tokio::io::BufReader<tokio::fs::File>;
+
+/// Reads a range of lines from a file using buffered, streaming I/O with
+/// SIMD-accelerated newline scanning.
+///
+/// The function opens the file at the resolved path, skips to the requested
+/// 1-indexed `offset` via [`skip_to_line`], then streams lines into an output
+/// string. Each line can optionally carry a `L{number}: ` prefix and is
+/// truncated to `max_line_length` when necessary.
+///
+/// # Arguments
+/// - `resolver`: [`PathResolver`] used to resolve `request.file_path` to a filesystem path.
+/// - `request`: [`ReadRequest`] carrying the file path, 1-indexed offset, and optional line limit.
+/// - `settings`: [`ReadSettings`] controlling line numbers, max line length, and permission checks.
+///
+/// # Returns
+/// - [`ToolOutput`] containing the requested line range, each line optionally
+///   prefixed with a line number and truncated to `max_line_length`.
+///
+/// # Errors
+/// - Returns [`ToolError::OutOfBounds`] when `offset` is `0` or exceeds the file's line count.
+/// - Returns [`ToolError::validation_for`] when `limit` resolves to `0`.
+/// - Returns a permission error when the resolved path is denied by the configured [`Ruleset`].
+/// - Returns an I/O error when the file cannot be opened or read.
+#[maybe_async::maybe_async]
+pub async fn read_file<R: PathResolver>(
+    resolver: &R,
+    request: ReadRequest,
+    settings: &ReadSettings,
+) -> ToolResult<ToolOutput> {
+    // Conditional trait import for consume() method
+    #[cfg(feature = "blocking")]
+    use std::io::BufRead as _;
+    #[cfg(feature = "tokio")]
+    use tokio::io::AsyncBufReadExt as _;
+
+    // Resolve the effective line limit: fall back to the configured default,
+    // then clamp to the hard max so callers cannot exceed it.
+    let limit = request
+        .limit
+        .unwrap_or(settings.default_limit())
+        .min(settings.max_limit());
+    if limit == 0 {
+        return Err(ToolError::validation_for("limit", "limit must be >= 1"));
+    }
+
+    let offset = request.offset;
+    let max_line_length = settings.max_line_length();
+    let line_numbers = settings.line_numbers();
+
+    // Reject offset 0 early - the API is 1-indexed.
+    if offset == 0 {
+        return Err(ToolError::OutOfBounds(
+            "offset must be >= 1 (1-indexed)".into(),
+        ));
+    }
+
+    // Resolve the logical path to a filesystem path and check permissions.
+    let path = resolver.resolve(&request.file_path)?;
+    let subject = path.to_string_lossy();
+    settings
+        .permission()
+        .check(read_meta::NAME, subject.as_ref())?;
+
+    // Open the file with a buffered reader sized proportionally to the
+    // expected output, capped at 1 MiB to avoid over-allocating on huge limits.
+    let buf_capacity = limit
+        .saturating_mul(ESTIMATED_CHARS_PER_LINE)
+        .min(1_048_576);
+    let mut reader = fs::open_buffered(&path, buf_capacity).await?;
+
+    // Compute the width of the "L{number}: " prefix so the output buffer can
+    // be pre-sized accurately. Derives digit count from the last line number.
+    let line_prefix_len = if line_numbers {
+        let last_line = offset.saturating_add(limit).saturating_sub(1);
+        last_line.checked_ilog10().unwrap_or(0) as usize + 3
+    } else {
+        0
+    };
+    let estimated_capacity = limit.saturating_mul(ESTIMATED_CHARS_PER_LINE + line_prefix_len);
+    let mut output = String::with_capacity(estimated_capacity);
+    // Holds a partial line that spans multiple buffered chunks.
+    let mut overflow: Vec<u8> = Vec::new();
+    let mut line_number = 0usize;
+    let mut lines_output = 0usize;
+
+    if offset > 1 {
+        line_number = skip_to_line(&mut reader, offset - 1).await?;
+    }
+
+    // Stream buffered chunks, extracting and emitting lines within the
+    // [offset, offset+limit) window until the limit is satisfied or EOF.
+    loop {
+        let buf = reader.fill_buf().await?;
+        // Flush any trailing partial line at EOF.
+        if buf.is_empty() {
+            if !overflow.is_empty() {
+                line_number += 1;
+                if line_number >= offset && lines_output < limit {
+                    emit_line(
+                        &overflow,
+                        line_number,
+                        &mut output,
+                        &mut lines_output,
+                        max_line_length,
+                        line_numbers,
+                    );
+                }
+            }
+            break;
+        }
+
+        let mut pos = 0;
+        while pos < buf.len() {
+            // Find the next newline to delimit the current line.
+            if let Some(newline_offset) = memchr(b'\n', &buf[pos..]) {
+                let newline_pos = pos + newline_offset;
+                line_number += 1;
+
+                // Only format and append lines inside the requested window.
+                if line_number >= offset && lines_output < limit {
+                    if overflow.is_empty() {
+                        // Fast path: entire line lives in this buffer.
+                        emit_line(
+                            &buf[pos..newline_pos],
+                            line_number,
+                            &mut output,
+                            &mut lines_output,
+                            max_line_length,
+                            line_numbers,
+                        );
+                    } else {
+                        // Slow path: assemble the line from the overflow
+                        // fragment buffered across a prior chunk boundary.
+                        overflow.extend_from_slice(&buf[pos..newline_pos]);
+                        emit_line(
+                            &overflow,
+                            line_number,
+                            &mut output,
+                            &mut lines_output,
+                            max_line_length,
+                            line_numbers,
+                        );
+                        overflow.clear();
+                    }
+                } else if !overflow.is_empty() {
+                    // Discard overflow for lines we're skipping past.
+                    overflow.clear();
+                }
+
+                // Advance past the newline character.
+                pos = newline_pos + 1;
+
+                // Stop scanning this buffer once we've output enough lines.
+                if lines_output >= limit {
+                    break;
+                }
+            } else {
+                // No newline in the remainder - buffer the partial line
+                // and wait for the next chunk to complete it.
+                overflow.extend_from_slice(&buf[pos..]);
+                pos = buf.len();
+            }
+        }
+
+        // Tell the buffered reader how much of this chunk we consumed.
+        reader.consume(pos);
+
+        if lines_output >= limit {
+            break;
+        }
+    }
+
+    // If the skip phase consumed the entire file, report the out-of-bounds
+    // offset with the actual line count for a useful error message.
+    if line_number < offset {
+        return Err(ToolError::OutOfBounds(format!(
+            "offset {} exceeds file length of {} lines",
+            offset, line_number
+        )));
+    }
+
+    Ok(ToolOutput::new(output))
+}
+
+/// Advances a buffered reader by counting `skip_target` newline boundaries
+/// using SIMD-accelerated [`memchr_iter`] scanning, without processing line
+/// content.
+///
+/// This avoids the per-line overhead of CR-stripping, UTF-8 validation, and
+/// output formatting for skipped lines. The reader is left positioned at the
+/// start of the next line after the skip target.
+///
+/// # Returns
+/// The number of newline boundaries actually counted (may be less than
+/// `skip_target` if EOF is reached first).
+///
+/// # Errors
+/// Returns an I/O error if reading from the underlying reader fails.
+#[maybe_async::maybe_async]
+pub async fn skip_to_line(reader: &mut BufFile, skip_target: usize) -> ToolResult<usize> {
+    // Import the sync or async `fill_buf`/`consume` trait depending on feature flag.
+    #[cfg(feature = "blocking")]
+    use std::io::BufRead as _;
+    #[cfg(feature = "tokio")]
+    use tokio::io::AsyncBufReadExt as _;
+
+    let mut line_number = 0usize;
+    // Track whether the buffer ended with non-newline bytes so we can count the
+    // last unterminated line when EOF is reached.
+    let mut trailing_content = false;
+    while line_number < skip_target {
+        // Determine how many buffered bytes to consume in this iteration.
+        let consume = {
+            let buf = reader.fill_buf().await?;
+            if buf.is_empty() {
+                // EOF reached - if the file ended without a trailing newline,
+                // count the partial last line.
+                if trailing_content {
+                    line_number += 1;
+                }
+                break;
+            }
+            let remaining = skip_target - line_number;
+            // Scan for newlines in the current buffer using SIMD-accelerated memchr.
+            let mut count = 0usize;
+            let mut last_pos = 0usize;
+            for pos in memchr_iter(b'\n', buf) {
+                count += 1;
+                last_pos = pos;
+                if count >= remaining {
+                    break;
+                }
+            }
+            line_number += count;
+            if count >= remaining {
+                // Found enough newlines - consume up to (and including) the one
+                // that lands us on the target line.
+                trailing_content = false;
+                last_pos + 1
+            } else {
+                // Not enough newlines in this buffer — consume everything and
+                // note whether the buffer ends without a newline.
+                trailing_content = buf.last() != Some(&b'\n');
+                buf.len()
+            }
+        };
+        // Advance the reader past the consumed bytes.
+        reader.consume(consume);
+    }
+    Ok(line_number)
+}
+
+/// Dispatches to the correct const-generic `process_line` monomorphization.
+#[inline(always)]
+fn emit_line(
+    line_bytes: &[u8],
+    line_number: usize,
+    output: &mut String,
+    lines_output: &mut usize,
+    max_line_length: usize,
+    line_numbers: bool,
+) {
+    if line_numbers {
+        process_line::<true>(
+            line_bytes,
+            line_number,
+            output,
+            lines_output,
+            max_line_length,
+        );
+    } else {
+        process_line::<false>(
+            line_bytes,
+            line_number,
+            output,
+            lines_output,
+            max_line_length,
+        );
+    }
+}
+
+/// Processes a single line, appending it to output with optional line numbers.
+///
+/// Const-generic over `LINE_NUMBERS` so the compiler can eliminate the
+/// branch at compile time and monomorphize two tight loops.
+#[inline]
+fn process_line<const LINE_NUMBERS: bool>(
+    line_bytes: &[u8],
+    line_number: usize,
+    output: &mut String,
+    lines_output: &mut usize,
+    max_line_length: usize,
+) {
+    let line_bytes = strip_cr(line_bytes);
+
+    if *lines_output > 0 {
+        output.push('\n');
+    }
+
+    if LINE_NUMBERS {
+        output.push('L');
+        push_usize(output, line_number);
+        output.push_str(": ");
+    }
+
+    // ASCII fast path: SIMD-accelerated check avoids full UTF-8 validation.
+    // SAFETY: ASCII is always valid UTF-8.
+    if line_bytes.is_ascii() {
+        let content = unsafe { core::str::from_utf8_unchecked(line_bytes) };
+        append_line_content(output, content, max_line_length);
+    } else if let Ok(content) = core::str::from_utf8(line_bytes) {
+        append_line_content(output, content, max_line_length);
+    } else {
+        let content = String::from_utf8_lossy(line_bytes);
+        append_line_content(output, &content, max_line_length);
+    }
+
+    *lines_output += 1;
+}
+
+/// Strips trailing CR from a line (for CRLF handling).
+#[inline]
+fn strip_cr(line: &[u8]) -> &[u8] {
+    if line.last() == Some(&b'\r') {
+        &line[..line.len() - 1]
+    } else {
+        line
+    }
+}
+
+#[inline]
+fn append_line_content(output: &mut String, content: &str, max_line_length: usize) {
+    let (display_content, was_truncated) = truncate_line_with_ellipsis(content, max_line_length);
+    output.push_str(display_content);
+    if was_truncated {
+        output.push_str(TRUNCATION_ELLIPSIS);
+    }
+}
+
 fn ensure_read_limits(default_limit: usize, max_limit: usize) -> ToolResult<()> {
     use crate::util::MIN_LIMIT;
     if default_limit < MIN_LIMIT {
@@ -345,184 +585,6 @@ fn ensure_max_line_length(max_line_length: usize) -> ToolResult<()> {
         ));
     }
     Ok(())
-}
-
-/// Reads a file and returns formatted content, optionally with line numbers.
-///
-/// When `line_numbers` is `true`, each line is prefixed with `L{number}: `.
-/// When `false`, raw content is returned without prefixes.
-#[maybe_async::maybe_async]
-pub async fn read_file<R: PathResolver>(
-    resolver: &R,
-    request: ReadRequest,
-    settings: &ReadSettings,
-) -> ToolResult<ToolOutput> {
-    // Conditional trait import for consume() method
-    #[cfg(feature = "blocking")]
-    use std::io::BufRead as _;
-    #[cfg(feature = "tokio")]
-    use tokio::io::AsyncBufReadExt as _;
-
-    let limit = request
-        .limit
-        .unwrap_or(settings.default_limit())
-        .min(settings.max_limit());
-    if limit == 0 {
-        return Err(ToolError::validation_for("limit", "limit must be >= 1"));
-    }
-
-    let offset = request.offset;
-    let max_line_length = settings.max_line_length();
-    let line_numbers = settings.line_numbers();
-
-    if offset == 0 {
-        return Err(ToolError::OutOfBounds(
-            "offset must be >= 1 (1-indexed)".into(),
-        ));
-    }
-
-    let path = resolver.resolve(&request.file_path)?;
-    let subject = path.to_string_lossy();
-    settings
-        .permission()
-        .check(read_meta::NAME, subject.as_ref())?;
-    let buf_capacity = limit.saturating_mul(ESTIMATED_CHARS_PER_LINE).min(1 << 20);
-    let mut reader = fs::open_buffered(&path, buf_capacity).await?;
-
-    let line_prefix_len = if line_numbers {
-        let last_line = offset.saturating_add(limit).saturating_sub(1);
-        last_line.checked_ilog10().unwrap_or(0) as usize + 3
-    } else {
-        0
-    };
-    let estimated_capacity = limit.saturating_mul(ESTIMATED_CHARS_PER_LINE + line_prefix_len);
-    let mut output = String::with_capacity(estimated_capacity);
-    // Holds a partial line that spans multiple buffers.
-    let mut overflow: Vec<u8> = Vec::new();
-    let mut line_number = 0usize;
-    let mut lines_output = 0usize;
-
-    // Fast skip: when offset > 1, count newlines in bulk via SIMD without
-    // processing line content. This avoids the per-line overhead of strip_cr,
-    // UTF-8 validation, and output formatting for skipped lines.
-    if offset > 1 {
-        let skip_target = offset - 1;
-        let mut trailing_content = false;
-        while line_number < skip_target {
-            let consume = {
-                let buf = reader.fill_buf().await?;
-                if buf.is_empty() {
-                    if trailing_content {
-                        line_number += 1;
-                    }
-                    break;
-                }
-                let remaining = skip_target - line_number;
-                let mut count = 0usize;
-                let mut last_pos = 0usize;
-                for pos in memchr_iter(b'\n', buf) {
-                    count += 1;
-                    last_pos = pos;
-                    if count >= remaining {
-                        break;
-                    }
-                }
-                line_number += count;
-                if count >= remaining {
-                    trailing_content = false;
-                    last_pos + 1
-                } else {
-                    trailing_content = buf.last() != Some(&b'\n');
-                    buf.len()
-                }
-            };
-            reader.consume(consume);
-        }
-    }
-
-    // Stream buffered chunks, splitting into lines as we go.
-    loop {
-        let buf = reader.fill_buf().await?;
-        // Flush any trailing partial line at EOF.
-        if buf.is_empty() {
-            if !overflow.is_empty() {
-                line_number += 1;
-                if line_number >= offset && lines_output < limit {
-                    emit_line(
-                        &overflow,
-                        line_number,
-                        &mut output,
-                        &mut lines_output,
-                        max_line_length,
-                        line_numbers,
-                    );
-                }
-            }
-            break;
-        }
-
-        let mut pos = 0;
-        while pos < buf.len() {
-            // Fast newline search to delimit lines.
-            if let Some(newline_offset) = memchr(b'\n', &buf[pos..]) {
-                let newline_pos = pos + newline_offset;
-                line_number += 1;
-
-                // Only emit lines within the requested window.
-                if line_number >= offset && lines_output < limit {
-                    // Fast path: line is fully in this buffer.
-                    if overflow.is_empty() {
-                        emit_line(
-                            &buf[pos..newline_pos],
-                            line_number,
-                            &mut output,
-                            &mut lines_output,
-                            max_line_length,
-                            line_numbers,
-                        );
-                    } else {
-                        // Slow path: prepend buffered fragment.
-                        overflow.extend_from_slice(&buf[pos..newline_pos]);
-                        emit_line(
-                            &overflow,
-                            line_number,
-                            &mut output,
-                            &mut lines_output,
-                            max_line_length,
-                            line_numbers,
-                        );
-                        overflow.clear();
-                    }
-                } else if !overflow.is_empty() {
-                    overflow.clear();
-                }
-
-                pos = newline_pos + 1;
-
-                if lines_output >= limit {
-                    break;
-                }
-            } else {
-                overflow.extend_from_slice(&buf[pos..]);
-                pos = buf.len();
-            }
-        }
-
-        reader.consume(pos);
-
-        if lines_output >= limit {
-            break;
-        }
-    }
-
-    if line_number < offset {
-        return Err(ToolError::OutOfBounds(format!(
-            "offset {} exceeds file length of {} lines",
-            offset, line_number
-        )));
-    }
-
-    Ok(ToolOutput::new(output))
 }
 
 #[cfg(test)]

--- a/src/llm-coding-tools-core/src/tools/write.rs
+++ b/src/llm-coding-tools-core/src/tools/write.rs
@@ -97,14 +97,16 @@ pub async fn write_file<R: PathResolver>(
         }
     }
 
-    let bytes = request.content.as_bytes();
-    fs::write(&path, bytes).await?;
+    fs::write(&path, request.content.as_bytes()).await?;
 
-    Ok(format!(
-        "Successfully wrote {} bytes to {}",
-        bytes.len(),
-        path.display()
-    ))
+    let len = request.content.len();
+    // 32: literal overhead ("Successfully wrote  bytes to "), 20: max usize digits, remainder: path
+    let mut out = String::with_capacity(32 + 20 + path.as_os_str().len());
+    let _ = core::fmt::write(
+        &mut out,
+        core::format_args!("Successfully wrote {} bytes to {}", len, path.display()),
+    );
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/src/llm-coding-tools-core/src/util.rs
+++ b/src/llm-coding-tools-core/src/util.rs
@@ -99,6 +99,28 @@ pub(crate) fn truncate_line_with_ellipsis(line: &str, max_chars: usize) -> (&str
     }
 }
 
+/// Fast integer-to-string conversion for positive integers.
+///
+/// Uses a stack buffer to avoid allocations and converts digit-by-digit
+/// for maximum performance.
+#[inline]
+pub(crate) fn push_usize(output: &mut String, mut n: usize) {
+    if n == 0 {
+        output.push('0');
+        return;
+    }
+    let mut buf = [0u8; 20];
+    let mut pos = 20usize;
+    while n > 0 {
+        pos -= 1;
+        buf[pos] = b'0' + (n % 10) as u8;
+        n /= 10;
+    }
+    unsafe {
+        output.push_str(core::str::from_utf8_unchecked(&buf[pos..]));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- Benchmark all 5 core file I/O tools (read, edit, write, glob, grep) with criterion using **real Rust source files** as test data
- Optimize `read_file` hot path: 35-75% faster across all file sizes
- Optimize `GrepOutput::format()`: 69-76% faster for both line-number modes
- Fix arithmetic overflow in `read_file` capacity estimation
- Edit, write, glob, and grep search are I/O-bound; algorithmic improvements yield 0-4%
- Fixed bug where files over search limits with identical `mtime`(s) are not deterministically returned.

## Commits

Split into two commits:

1. **Add criterion benchmarks** - benchmark suites + corpus data only
2. **Optimize file I/O tools** - source code optimizations

## Realistic benchmark corpus

Benchmark test data is sourced from real Rust files (Apache-2.0, [codex-rs](https://github.com/openai/codex)) selected to match aggregate statistics measured across ~3,300 `.rs` files:

| Metric | Corpus | Measured Average |
|--------|--------|-----------------|
| Non-blank avg line length | 37.7 chars | 37.7 chars |
| Blank line ratio | ~10.5% | ~10.5% |
| Avg bytes/line | 34.7 | 34.7 |

| Size | Source | Lines |
|------|--------|-------|
| Small | `core/src/tools/handlers/plan.rs` | 122 |
| Medium | `mcp-server/src/outgoing_message.rs` | 356 |
| Large | `core/src/unified_exec/session_manager.rs` | 770 |

Shared via `benches/common/mod.rs` with `#[path]` attribute (no Cargo.toml changes needed).

## Key changes

**read.rs** (35-75% faster)
- Replaced `write!` format macro with manual `push_usize` integer formatting
- Added ASCII fast path with `from_utf8_unchecked` (SIMD-accelerated `is_ascii` check)
- Made `process_line` const-generic over `LINE_NUMBERS` to eliminate runtime branch per line
- Added bulk `memchr_iter` newline skip for offset reads
- Used `core::str::from_utf8()` fast path instead of `from_utf8_lossy` Cow wrapper
- Fixed overflow in capacity math with saturating arithmetic + 1 MiB cap

**grep.rs** (format: 69-76% faster)
- Replaced `write!` with `push_str` + `push_u64` transformation in `format()`
- `sort_unstable_by` for equal-element speed
- `to_str()` fast path for file paths
- Pre-allocated matches Vec with capacity 8

**edit.rs** (~0-2% faster, I/O-bound)
- Combined `replace_all` into single-pass `match_indices` loop
- Used `find()` + `contains()` for ambiguity detection
- Pre-allocated result string

**write.rs** (~0% faster, I/O-bound)
- Pre-allocated success message string

**glob.rs** (~0-4% faster, I/O-bound)
- Partial sort via `select_nth_unstable_by` (O(n + k log k) vs O(n log n))
- Deferred `String` conversion: store `PathBuf`, convert only final `limit` items
- OverrideBuilder push-down was tested and reverted due to nested `.gitignore` correctness bug

## Significant improvements

| Tool | Case | Before | After | Change |
|------|------|--------|-------|--------|
| read | small (122 lines, with LN) | 2.2 µs | 1.42 µs | -35% |
| read | medium (356 lines, with LN) | 14.1 µs | 6.6 µs | -53% |
| read | large (770 lines, with LN) | 53.2 µs | 24.9 µs | -53% |
| read | offset_read (with LN) | 2.5 µs | 1.68 µs | -33% |
| read | crlf (356 lines, with LN) | 13.9 µs | 6.58 µs | -53% |
| read | small (122 lines, no LN) | - | 1.25 µs | new |
| read | medium (356 lines, no LN) | - | 4.7 µs | new |
| read | large (770 lines, no LN) | - | 16.7 µs | new |
| read | offset_read (no LN) | - | 1.48 µs | new |
| read | crlf (356 lines, no LN) | - | 4.7 µs | new |
| grep format | with line numbers (~300 matches) | 5.60 µs | 1.49 µs | -73% |
| grep format | without line numbers (~300 matches) | 2.67 µs | 0.83 µs | -69% |

## No significant improvements (I/O-bound)

| Tool | Case | Before | After | Change | Bottleneck |
|------|------|--------|-------|--------|------------|
| edit | rename_string (122 lines) | 19.6 µs | 19.2 µs | -2% | 6 syscalls |
| edit | replace_all (770 lines) | 66.6 µs | 65.4 µs | -2% | 6 syscalls |
| edit | not_found (356 lines) | 13.0 µs | 13.0 µs | ~0% | 6 syscalls |
| edit | update_constant (770 lines) | 14.9 µs | 14.6 µs | -2% | 6 syscalls |
| write | small (~4 KB) | 17 µs | 17 µs | ~0% | mkdir + write |
| write | medium (~12 KB) | 26 µs | 26 µs | ~0% | write syscall |
| write | nested_dirs (a/b/c) | 42 µs | 41 µs | ~0% | mkdir -p |
| glob | small_tree (~10 files) | 104 µs | 102 µs | ~0% | walk + stat |
| glob | large_tree (~300 files) | 944 µs | 950 µs | ~0% | walk + stat |
| glob | no_matches (~300 files) | 578 µs | 555 µs | -4% | walk + stat |
| glob | deep_nesting (10 levels) | 146 µs | 141 µs | -3% | walk + stat |
| grep search | single_file | 58 µs | 58 µs | ~0% | regex + I/O |
| grep search | multi_file (10 files) | 79 µs | 76 µs | -4% | regex + I/O |
| grep search | no_matches | 74 µs | 71 µs | -4% | regex + I/O |
| grep search | regex_pattern (fn\s+\w+) | 2.4 ms | 2.4 ms | ~0% | regex engine |
| grep search | large_tree (30 files) | 241 µs | 236 µs | -2% | regex + I/O |

edit, write, glob, and grep search are dominated by kernel VFS syscall overhead and external crate costs (grep-regex, ignore walker). The algorithmic improvements are real but invisible under I/O noise.

## Bugs fixed

| Tool | Bug | Status |
|------|-----|--------|
| read | Arithmetic overflow in capacity estimation (`limit * 64` could panic/wrap) | Fixed: saturating arithmetic + 1 MiB cap |
| glob | OverrideBuilder bypassed nested `.gitignore` rules | Reverted; kept partial-sort optimizations |

## Benchmark suite overview

### tools_read.rs - 5 cases x 2 modes (with/without line numbers)
| Case | Corpus | What it tests |
|------|--------|---------------|
| small_file | Small (122 lines) | Small file, fits in one read |
| medium_file | Medium (356 lines) | Medium file, buffered reads |
| large_file | Large (770 lines) | Large file, many lines processed |
| offset_read | Medium + offset 50 + limit 50 | Partial read with offset |
| crlf_file | Medium with CRLF endings | CRLF stripping overhead |

### tools_edit.rs - 5 cases
| Case | Corpus | What it tests |
|------|--------|---------------|
| rename_string | Small | Rename `update_plan` -> `update_task_plan` |
| change_type | Medium | Change type `mpsc::UnboundedSender` -> `mpsc::Sender` |
| update_constant | Large | Update `Duration::from_millis(100)` -> `200` |
| replace_all | Large | Bulk rename `process_id` -> `session_id` |
| not_found | Medium | Error path: string not found |

### tools_write.rs - 4 cases
| Case | Content | What it tests |
|------|---------|---------------|
| small_write | Corpus Small (~4 KB) | Write small source file |
| medium_write | Corpus Medium (~12 KB) | Write medium source file |
| large_write | Corpus Large (~26 KB) | Write large source file |
| nested_dirs | Corpus Small + a/b/c/ path | Create nested directories |

### tools_grep.rs - 5 cases x 2 modes + 2 format benchmarks
| Case | Files | Pattern | What it tests |
|------|-------|---------|---------------|
| single_file | 1 | `fn ` | Single file, function definitions |
| multi_file | 10 | `fn ` | Multi-file search |
| no_matches | 10 | `xyznonexistent` | Fast rejection |
| regex_pattern | 10 | `fn\s+\w+` | Complex regex matching |
| large_tree | 30 | `fn ` | Large directory tree traversal |

### tools_glob.rs - 4 cases
| Case | Files | Pattern | What it tests |
|------|-------|---------|---------------|
| small_tree | ~10 | `**/*.rs` | Small project |
| large_tree | ~300 | `**/*.rs` | Large monorepo |
| no_matches | ~300 | `*.xyz` | Full traversal, no matches |
| deep_nesting | ~10 | `**/*.rs` | Deep directory nesting |

## Test plan

- [x] All 357 existing tests pass across all feature flags (tokio, blocking, linux-bubblewrap)
- [x] `.cargo/verify.sh` passes (build, test, clippy, docs, fmt)
- [x] Edge-case tests for all bug fixes
- [x] 5 new benchmark suites compile and produce valid throughput measurements

Closes #96