### PR TITLE
Added: Wire bubblewrap sandbox profiles into agent build pipeline

### DIFF
--- a/src/llm-coding-tools-bubblewrap/ARCHITECTURE.md
+++ b/src/llm-coding-tools-bubblewrap/ARCHITECTURE.md
@@ -17,7 +17,7 @@ llm-coding-tools-bubblewrap
 │   ├── mod.rs              module root; re-exports public API surface
 │   ├── types.rs            Profile, Preset, TmpBacking, Availability, etc.
 │   ├── builder.rs          Builder + build() + static arg precomputation
-│   ├── factory.rs          create_sandbox, create_sandbox_with, TempSandboxDirs (feature "default-sandbox")
+│   ├── factory.rs          create_sandbox, create_sandbox_with, create_temp_sandbox, SandboxDirs, CreateSandboxError, TempSandboxDirs
 │   ├── presets.rs          public_bot() & trusted_maintenance() constructors
 │   ├── validation.rs       path/symlink/env/tmp validators
 │   └── layout.rs           SandboxLayout — "is this host path visible inside?"

--- a/src/llm-coding-tools-bubblewrap/ARCHITECTURE.md
+++ b/src/llm-coding-tools-bubblewrap/ARCHITECTURE.md
@@ -17,6 +17,7 @@ llm-coding-tools-bubblewrap
 │   ├── mod.rs              module root; re-exports public API surface
 │   ├── types.rs            Profile, Preset, TmpBacking, Availability, etc.
 │   ├── builder.rs          Builder + build() + static arg precomputation
+│   ├── factory.rs          create_sandbox, create_sandbox_with, TempSandboxDirs (feature "default-sandbox")
 │   ├── presets.rs          public_bot() & trusted_maintenance() constructors
 │   ├── validation.rs       path/symlink/env/tmp validators
 │   └── layout.rs           SandboxLayout — "is this host path visible inside?"

--- a/src/llm-coding-tools-bubblewrap/Cargo.toml
+++ b/src/llm-coding-tools-bubblewrap/Cargo.toml
@@ -16,7 +16,7 @@ blocking = ["dep:process-wrap", "process-wrap/std", "process-wrap/process-group"
 parking_lot = "0.12"
 thiserror = "2.0"
 process-wrap = { version = "9", default-features = false, optional = true }
-tempfile = "3"
+tempfile = "3.27"
 
 [dev-dependencies]
 rstest = "0.26"

--- a/src/llm-coding-tools-bubblewrap/Cargo.toml
+++ b/src/llm-coding-tools-bubblewrap/Cargo.toml
@@ -12,11 +12,11 @@ readme = "README.md"
 default = ["tokio"]
 tokio = ["dep:process-wrap", "process-wrap/tokio1", "process-wrap/process-group"]
 blocking = ["dep:process-wrap", "process-wrap/std", "process-wrap/process-group"]
-
 [dependencies]
 parking_lot = "0.12"
 thiserror = "2.0"
 process-wrap = { version = "9", default-features = false, optional = true }
+tempfile = "3"
 
 [dev-dependencies]
 rstest = "0.26"

--- a/src/llm-coding-tools-bubblewrap/src/lib.rs
+++ b/src/llm-coding-tools-bubblewrap/src/lib.rs
@@ -14,6 +14,10 @@ mod test_helpers;
 
 pub use error::LinuxBwrapError;
 pub use profile::{
+    create_sandbox, create_sandbox_with, create_temp_sandbox, CreateSandboxError, SandboxDirs,
+    TempSandboxDirs,
+};
+pub use profile::{
     Availability, Builder, EnvVar, FileMount, NetworkPolicy, Preset, Profile, Symlink, TmpBacking,
 };
 pub use wrap::LinuxBwrapWrappedCommand;

--- a/src/llm-coding-tools-bubblewrap/src/profile/factory.rs
+++ b/src/llm-coding-tools-bubblewrap/src/profile/factory.rs
@@ -194,6 +194,7 @@ pub fn create_sandbox(
     preset: Preset,
     dirs: &SandboxDirs<'_>,
 ) -> Result<Arc<Profile>, CreateSandboxError> {
+    let availability = detect_availability()?;
     // Select the builder preset for the desired sandbox policy.
     let builder = match preset {
         Preset::TrustedMaintenance => {
@@ -201,22 +202,7 @@ pub fn create_sandbox(
         }
         Preset::PublicBot => Builder::public_bot(workspace, dirs.home(), dirs.cache(), None),
     };
-    // Verify bubblewrap is present and usable on the host before building.
-    let availability = Availability::detect();
-    if !availability.is_available() {
-        return Err(CreateSandboxError::Unavailable(
-            availability
-                .reason()
-                .unwrap_or("unknown reason")
-                .to_string(),
-        ));
-    }
-    // Assemble and validate the profile, surfacing any structural errors.
-    let profile = builder
-        .with_availability(availability)
-        .build()
-        .map_err(CreateSandboxError::Profile)?;
-    Ok(Arc::new(profile))
+    create_sandbox_inner(builder, availability)
 }
 
 /// Creates a sandbox with a custom builder and a directory spec.
@@ -246,27 +232,15 @@ pub fn create_sandbox_with<F>(
 where
     F: FnOnce(&Path, &SandboxDirs<'_>) -> Builder,
 {
+    let availability = detect_availability()?;
     let builder = f(workspace, dirs);
-    let availability = Availability::detect();
-    if !availability.is_available() {
-        return Err(CreateSandboxError::Unavailable(
-            availability
-                .reason()
-                .unwrap_or("unknown reason")
-                .to_string(),
-        ));
-    }
-    let profile = builder
-        .with_availability(availability)
-        .build()
-        .map_err(CreateSandboxError::Profile)?;
-    Ok(Arc::new(profile))
+    create_sandbox_inner(builder, availability)
 }
 
 /// Creates a sandbox from a preset with auto-managed temp directories.
 ///
-/// Convenience wrapper that creates a [`TempSandboxDirs`] and delegates to
-/// [`create_sandbox`]. The temp directory is wrapped in [`Arc`] so it can be
+/// Convenience wrapper that creates a [`TempSandboxDirs`] and builds a
+/// sandbox profile. The temp directory is wrapped in [`Arc`] so it can be
 /// stored alongside the profile in shared state.
 ///
 /// # Directory layout
@@ -293,7 +267,41 @@ pub fn create_temp_sandbox(
     workspace: &Path,
     preset: Preset,
 ) -> Result<(Arc<Profile>, Arc<TempSandboxDirs>), CreateSandboxError> {
+    let availability = detect_availability()?;
     let dirs = TempSandboxDirs::new().map_err(CreateSandboxError::Dirs)?;
-    let profile = create_sandbox(workspace, preset, &dirs.as_dirs())?;
+    // Select the builder preset for the desired sandbox policy.
+    let builder = match preset {
+        Preset::TrustedMaintenance => {
+            Builder::trusted_maintenance(workspace, dirs.home(), dirs.cache(), dirs.host_tmp())
+        }
+        Preset::PublicBot => Builder::public_bot(workspace, dirs.home(), dirs.cache(), None),
+    };
+    let profile = create_sandbox_inner(builder, availability)?;
     Ok((profile, Arc::new(dirs)))
+}
+
+// Check if bwrap is available on the host.
+fn detect_availability() -> Result<Availability, CreateSandboxError> {
+    let availability = Availability::detect();
+    if !availability.is_available() {
+        return Err(CreateSandboxError::Unavailable(
+            availability
+                .reason()
+                .unwrap_or("unknown reason")
+                .to_string(),
+        ));
+    }
+    Ok(availability)
+}
+
+fn create_sandbox_inner(
+    builder: Builder,
+    availability: Availability,
+) -> Result<Arc<Profile>, CreateSandboxError> {
+    // Assemble and validate the profile, surfacing any structural errors.
+    let profile = builder
+        .with_availability(availability)
+        .build()
+        .map_err(CreateSandboxError::Profile)?;
+    Ok(Arc::new(profile))
 }

--- a/src/llm-coding-tools-bubblewrap/src/profile/factory.rs
+++ b/src/llm-coding-tools-bubblewrap/src/profile/factory.rs
@@ -1,0 +1,299 @@
+//! Convenience constructors for sandbox profiles.
+//!
+//! Use [`create_sandbox`] for preset profiles or [`create_sandbox_with`] for
+//! custom builders, passing a [`SandboxDirs`] that specifies the host
+//! directory paths. Use [`create_temp_sandbox`] for the common case where
+//! all directories are auto-managed temporaries.
+//!
+//! # Directory ownership
+//!
+//! [`SandboxDirs`] borrows its paths, so the backing storage must outlive
+//! the `create_sandbox` / `create_sandbox_with` call. When all directories
+//! are ephemeral, [`TempSandboxDirs`] owns the temp tree and
+//! [`TempSandboxDirs::as_dirs`] provides the borrowed view.
+
+use super::builder::Builder;
+use super::types::{Availability, Preset, Profile};
+use crate::LinuxBwrapError;
+use std::path::Path;
+use std::sync::Arc;
+
+/// Borrowed directory paths for sandbox construction.
+///
+/// Lightweight view over three host directories that a sandbox profile
+/// needs: a synthetic home, a cache root, and a host-tmp directory.
+/// Because the fields are borrowed references, the backing storage must
+/// outlive this value.
+///
+/// Use [`TempSandboxDirs::as_dirs`] when all directories come from an
+/// auto-managed temp tree, or construct this directly when mixing
+/// persisted and ephemeral directories.
+///
+/// # Examples
+///
+/// Mixed persistent cache with ephemeral home and host-tmp:
+///
+/// ```no_run
+/// use llm_coding_tools_bubblewrap::profile::SandboxDirs;
+/// use std::path::Path;
+///
+/// let temp = llm_coding_tools_bubblewrap::TempSandboxDirs::new().unwrap();
+/// let dirs = SandboxDirs::new(
+///     temp.home(),                    // ephemeral
+///     Path::new("/persistent/cache"), // survives across sessions
+///     temp.host_tmp(),               // ephemeral
+/// );
+/// ```
+pub struct SandboxDirs<'a> {
+    home: &'a Path,
+    cache: &'a Path,
+    host_tmp: &'a Path,
+}
+
+impl<'a> SandboxDirs<'a> {
+    /// Creates a new directory spec from borrowed host paths.
+    ///
+    /// # Arguments
+    /// - `home` - Host path to the synthetic home directory.
+    /// - `cache` - Host path to the cache root directory.
+    /// - `host_tmp` - Host path to the host-tmp directory.
+    pub fn new(home: &'a Path, cache: &'a Path, host_tmp: &'a Path) -> Self {
+        Self {
+            home,
+            cache,
+            host_tmp,
+        }
+    }
+
+    /// Returns the host path to the synthetic home directory.
+    pub fn home(&self) -> &'a Path {
+        self.home
+    }
+
+    /// Returns the host path to the cache root directory.
+    pub fn cache(&self) -> &'a Path {
+        self.cache
+    }
+
+    /// Returns the host path to the host-tmp directory.
+    pub fn host_tmp(&self) -> &'a Path {
+        self.host_tmp
+    }
+}
+
+/// Auto-managed temp directory layout for sandbox construction.
+///
+/// Creates a temp directory with `home`, `cache`, and `host-tmp`
+/// subdirectories. The `cache` subdirectory also gets `xdg-cache` and
+/// `xdg-state` sub-subdirectories created by [`Builder::build`].
+///
+/// Wrapped in [`Arc`] when returned from [`create_temp_sandbox`] so it can
+/// be stored alongside the profile in shared state.
+pub struct TempSandboxDirs {
+    tmpdir: tempfile::TempDir,
+    home: Box<Path>,
+    cache: Box<Path>,
+    host_tmp: Box<Path>,
+}
+
+impl TempSandboxDirs {
+    /// Creates a new temp directory layout.
+    ///
+    /// # Returns
+    /// - `Ok(Self)`: A temp directory layout with `home`, `cache`, and
+    ///   `host-tmp` subdirectories created under a system temp directory.
+    ///
+    /// # Errors
+    /// - Returns [`std::io::Error`] when the system temp directory cannot be
+    ///   created (e.g., no writable temp dir, disk full, or permission denied),
+    ///   or when any subdirectory (`home`, `cache`, or `host-tmp`) cannot be
+    ///   created inside the temp directory.
+    pub fn new() -> std::io::Result<Self> {
+        let tmpdir = tempfile::Builder::new()
+            .prefix("llm-coding-tools-sandbox-")
+            .tempdir()?;
+
+        let home = tmpdir.path().join("home").into_boxed_path();
+        let cache = tmpdir.path().join("cache").into_boxed_path();
+        let host_tmp = tmpdir.path().join("host-tmp").into_boxed_path();
+
+        // Builder::build() validates directories exist, so create them first.
+        std::fs::create_dir_all(&home)?;
+        std::fs::create_dir_all(&cache)?;
+        std::fs::create_dir_all(&host_tmp)?;
+
+        Ok(Self {
+            tmpdir,
+            home,
+            cache,
+            host_tmp,
+        })
+    }
+
+    /// Returns a [`SandboxDirs`] view over this temp directory layout.
+    ///
+    /// Useful for passing to [`create_sandbox`] or [`create_sandbox_with`]
+    /// when all directories come from this auto-managed temp tree.
+    pub fn as_dirs(&self) -> SandboxDirs<'_> {
+        SandboxDirs::new(self.home(), self.cache(), self.host_tmp())
+    }
+
+    /// Returns the host path to the synthetic home directory.
+    pub fn home(&self) -> &Path {
+        &self.home
+    }
+
+    /// Returns the host path to the cache root directory.
+    pub fn cache(&self) -> &Path {
+        &self.cache
+    }
+
+    /// Returns the host path to the host-tmp directory.
+    pub fn host_tmp(&self) -> &Path {
+        &self.host_tmp
+    }
+
+    /// Returns a reference to the underlying temp directory.
+    pub fn temp_dir(&self) -> &tempfile::TempDir {
+        &self.tmpdir
+    }
+}
+
+/// Errors that can occur while creating a sandbox profile.
+#[derive(Debug, thiserror::Error)]
+pub enum CreateSandboxError {
+    /// Failed to create the sandbox directory layout.
+    #[error("failed to create sandbox directories: {0}")]
+    Dirs(#[source] std::io::Error),
+    /// Bubblewrap is not available on the host.
+    #[error("bubblewrap is not available: {0}")]
+    Unavailable(String),
+    /// Profile validation or assembly failed.
+    #[error("profile validation failed: {0}")]
+    Profile(#[from] LinuxBwrapError),
+}
+
+/// Creates a sandbox from a preset and a directory spec.
+///
+/// # Arguments
+/// - `workspace`: Host path to the project directory mounted inside the sandbox.
+/// - `preset`: The sandbox preset controlling mount layout and permissions.
+/// - `dirs`: The host directory paths for home, cache, and host-tmp.
+///
+/// # Returns
+/// - `Ok(`[`Arc<Profile>`]`)`: A ready-to-use sandbox profile.
+///
+/// # Errors
+/// - Returns [`CreateSandboxError::Unavailable`] when `bwrap` is not found on
+///   `PATH` or is otherwise unusable on the host (see [`Availability::detect`]).
+/// - Returns [`CreateSandboxError::Profile`] when [`Builder::build`] returns
+///   [`LinuxBwrapError`] (e.g., invalid paths, missing host shell inside the
+///   sandbox).
+pub fn create_sandbox(
+    workspace: &Path,
+    preset: Preset,
+    dirs: &SandboxDirs<'_>,
+) -> Result<Arc<Profile>, CreateSandboxError> {
+    // Select the builder preset for the desired sandbox policy.
+    let builder = match preset {
+        Preset::TrustedMaintenance => {
+            Builder::trusted_maintenance(workspace, dirs.home(), dirs.cache(), dirs.host_tmp())
+        }
+        Preset::PublicBot => Builder::public_bot(workspace, dirs.home(), dirs.cache(), None),
+    };
+    // Verify bubblewrap is present and usable on the host before building.
+    let availability = Availability::detect();
+    if !availability.is_available() {
+        return Err(CreateSandboxError::Unavailable(
+            availability
+                .reason()
+                .unwrap_or("unknown reason")
+                .to_string(),
+        ));
+    }
+    // Assemble and validate the profile, surfacing any structural errors.
+    let profile = builder
+        .with_availability(availability)
+        .build()
+        .map_err(CreateSandboxError::Profile)?;
+    Ok(Arc::new(profile))
+}
+
+/// Creates a sandbox with a custom builder and a directory spec.
+///
+/// Availability detection is handled automatically.
+///
+/// # Arguments
+/// - `workspace`: Host path to the project directory mounted inside the sandbox.
+/// - `dirs`: The host directory paths for home, cache, and host-tmp.
+/// - `f`: Closure receiving the workspace path and a [`SandboxDirs`] view;
+///   must return a configured [`Builder`].
+///
+/// # Returns
+/// - `Ok(`[`Arc<Profile>`]`)`: A ready-to-use sandbox profile.
+///
+/// # Errors
+/// - Returns [`CreateSandboxError::Unavailable`] when `bwrap` is not found on
+///   `PATH` or is otherwise unusable on the host (see [`Availability::detect`]).
+/// - Returns [`CreateSandboxError::Profile`] when [`Builder::build`] returns
+///   [`LinuxBwrapError`] (e.g., invalid paths, missing host shell inside the
+///   sandbox).
+pub fn create_sandbox_with<F>(
+    workspace: &Path,
+    dirs: &SandboxDirs<'_>,
+    f: F,
+) -> Result<Arc<Profile>, CreateSandboxError>
+where
+    F: FnOnce(&Path, &SandboxDirs<'_>) -> Builder,
+{
+    let builder = f(workspace, dirs);
+    let availability = Availability::detect();
+    if !availability.is_available() {
+        return Err(CreateSandboxError::Unavailable(
+            availability
+                .reason()
+                .unwrap_or("unknown reason")
+                .to_string(),
+        ));
+    }
+    let profile = builder
+        .with_availability(availability)
+        .build()
+        .map_err(CreateSandboxError::Profile)?;
+    Ok(Arc::new(profile))
+}
+
+/// Creates a sandbox from a preset with auto-managed temp directories.
+///
+/// Convenience wrapper that creates a [`TempSandboxDirs`] and delegates to
+/// [`create_sandbox`]. The temp directory is wrapped in [`Arc`] so it can be
+/// stored alongside the profile in shared state.
+///
+/// # Directory layout
+///
+/// See [`TempSandboxDirs`].
+///
+/// # Arguments
+/// - `workspace`: Host path to the project directory mounted inside the sandbox.
+/// - `preset`: The sandbox preset controlling mount layout and permissions.
+///
+/// # Returns
+/// - `Ok((`[`Arc<Profile>`]`, `[`Arc<TempSandboxDirs>`]`))`: A ready-to-use
+///   sandbox profile and its owning temp directory layout.
+///
+/// # Errors
+/// - Returns [`CreateSandboxError::Dirs`] when the system temp directory or
+///   any subdirectory cannot be created (see [`TempSandboxDirs::new`]).
+/// - Returns [`CreateSandboxError::Unavailable`] when `bwrap` is not found on
+///   `PATH` or is otherwise unusable on the host (see [`Availability::detect`]).
+/// - Returns [`CreateSandboxError::Profile`] when [`Builder::build`] returns
+///   [`LinuxBwrapError`] (e.g., invalid paths, missing host shell inside the
+///   sandbox).
+pub fn create_temp_sandbox(
+    workspace: &Path,
+    preset: Preset,
+) -> Result<(Arc<Profile>, Arc<TempSandboxDirs>), CreateSandboxError> {
+    let dirs = TempSandboxDirs::new().map_err(CreateSandboxError::Dirs)?;
+    let profile = create_sandbox(workspace, preset, &dirs.as_dirs())?;
+    Ok((profile, Arc::new(dirs)))
+}

--- a/src/llm-coding-tools-bubblewrap/src/profile/factory.rs
+++ b/src/llm-coding-tools-bubblewrap/src/profile/factory.rs
@@ -298,10 +298,43 @@ fn create_sandbox_inner(
     builder: Builder,
     availability: Availability,
 ) -> Result<Arc<Profile>, CreateSandboxError> {
-    // Assemble and validate the profile, surfacing any structural errors.
     let profile = builder
         .with_availability(availability)
         .build()
         .map_err(CreateSandboxError::Profile)?;
     Ok(Arc::new(profile))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn temp_sandbox_dirs_creates_layout_and_as_dirs_returns_matching_view() {
+        let dirs = TempSandboxDirs::new().unwrap();
+
+        assert!(dirs.home().is_dir());
+        assert!(dirs.cache().is_dir());
+        assert!(dirs.host_tmp().is_dir());
+
+        assert!(dirs.home().ends_with("home"));
+        assert!(dirs.cache().ends_with("cache"));
+        assert!(dirs.host_tmp().ends_with("host-tmp"));
+
+        let tmpdir_prefix = dirs
+            .temp_dir()
+            .path()
+            .file_name()
+            .expect("temp dir has a name")
+            .to_string_lossy();
+        assert!(
+            tmpdir_prefix.starts_with("llm-coding-tools-sandbox-"),
+            "unexpected prefix: {tmpdir_prefix}",
+        );
+
+        let view = dirs.as_dirs();
+        assert_eq!(view.home(), dirs.home());
+        assert_eq!(view.cache(), dirs.cache());
+        assert_eq!(view.host_tmp(), dirs.host_tmp());
+    }
 }

--- a/src/llm-coding-tools-bubblewrap/src/profile/mod.rs
+++ b/src/llm-coding-tools-bubblewrap/src/profile/mod.rs
@@ -7,12 +7,17 @@
 //! - [`TmpBacking`] - how sandbox `/tmp` is mounted
 
 mod builder;
+mod factory;
 pub(crate) mod layout;
 mod presets;
 mod types;
 pub(crate) mod validation;
 
 pub use builder::Builder;
+pub use factory::{
+    create_sandbox, create_sandbox_with, create_temp_sandbox, CreateSandboxError, SandboxDirs,
+    TempSandboxDirs,
+};
 pub use types::{
     Availability, EnvVar, FileMount, FileOverlay, NetworkPolicy, Preset, Profile, Symlink,
     TmpBacking,

--- a/src/llm-coding-tools-core/Cargo.toml
+++ b/src/llm-coding-tools-core/Cargo.toml
@@ -103,7 +103,7 @@ process-wrap = { version = "9.1", default-features = false }
 const_format = "0.2.35"
 
 # Linux sandbox types and runtime
-llm-coding-tools-bubblewrap = { version = "0.1.0", path = "../llm-coding-tools-bubblewrap", optional = true, default-features = false }
+llm-coding-tools-bubblewrap = { version = "0.1.0", path = "../llm-coding-tools-bubblewrap", optional = true }
 
 [dev-dependencies]
 serial_test = "3"

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/build.rs
@@ -31,6 +31,13 @@ use serdes_ai_models::BoxedModel;
 use std::path::Path;
 use std::sync::Arc;
 
+#[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+use llm_coding_tools_bubblewrap::Profile;
+
+#[cfg(not(all(feature = "linux-bubblewrap", target_os = "linux")))]
+/// Placeholder type so [`attach_standard_tools`] compiles without the feature.
+pub(super) struct Profile;
+
 /// Error returned when a build cannot produce a SerdesAI agent.
 #[derive(Debug, thiserror::Error)]
 pub enum AgentBuildError {
@@ -151,10 +158,14 @@ pub(super) fn attach_standard_tools<'a, C>(
     prepared: &PreparedBuild<'a>,
     task_handle: Option<&TaskHandle<C>>,
     workspace_root: &Path,
+    bash_sandbox: Option<&Arc<Profile>>,
 ) -> Result<(AgentBuilder<(), String>, SystemPromptBuilder), AgentBuildError>
 where
     C: CredentialLookup + Send + Sync + 'static,
 {
+    // Suppress unused-variable warning for bash_sandbox in non-feature builds.
+    #[cfg(not(all(feature = "linux-bubblewrap", target_os = "linux")))]
+    let _ = bash_sandbox;
     let mut prompt_builder = SystemPromptBuilder::new().system_prompt(prepared.prompt.as_ref());
     let (todo_read, todo_write, _todo_state) = create_todo_tools();
 
@@ -214,13 +225,15 @@ where
             }
             ToolCatalogKind::Bash => {
                 let settings = &prepared.tool_settings.bash;
-                builder = builder.tool(
-                    prompt_builder.track(
-                        BashTool::new()
-                            .with_timeouts(Some(settings.timeout_ms), Some(settings.max_timeout_ms))
-                            .with_permission(permission.clone()),
-                    ),
-                );
+                #[allow(unused_mut)]
+                let mut tool = BashTool::new()
+                    .with_timeouts(Some(settings.timeout_ms), Some(settings.max_timeout_ms))
+                    .with_permission(permission.clone());
+                #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+                if let Some(profile) = bash_sandbox {
+                    tool = tool.with_linux_bwrap(profile.clone());
+                }
+                builder = builder.tool(prompt_builder.track(tool));
             }
             ToolCatalogKind::WebFetch => {
                 let settings = build_webfetch_settings(&prepared.tool_settings.webfetch)?;
@@ -332,6 +345,7 @@ mod tests {
             prepared,
             None,
             &workspace_root,
+            None,
         )
         .expect("build should succeed");
         builder.system_prompt(prompt_builder.build()).build()

--- a/src/llm-coding-tools-serdesai/src/agent_runtime/task.rs
+++ b/src/llm-coding-tools-serdesai/src/agent_runtime/task.rs
@@ -11,6 +11,12 @@ use serdes_ai::{Agent, AgentBuilder};
 use std::path::Path;
 use std::sync::Arc;
 
+#[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+use llm_coding_tools_bubblewrap::{CreateSandboxError, Preset, Profile, TempSandboxDirs};
+
+#[cfg(not(all(feature = "linux-bubblewrap", target_os = "linux")))]
+use super::build::Profile;
+
 /// Reusable shared inputs for building runnable SerdesAI agents.
 ///
 /// Create once and call [`AgentBuildContext::build`] for each catalog agent
@@ -26,9 +32,20 @@ impl<C> AgentBuildContext<C>
 where
     C: CredentialLookup + Send + Sync + 'static,
 {
-    /// Creates a shared build context from runtime state, model catalog, credentials,
-    /// and the workspace root directory.
-    #[inline]
+    /// Creates a shared build context without a sandbox.
+    ///
+    /// [`BashTool`](crate::BashTool) will run commands directly on the host.
+    ///
+    /// # Platform
+    ///
+    /// For sandboxed builds on Linux with the `linux-bubblewrap` feature, use
+    /// `new_with_sandbox` or `new_with_temp_sandbox` instead.
+    ///
+    /// # Arguments
+    /// - `runtime`: Shared agent runtime holding the catalog and defaults.
+    /// - `model_catalog`: Available models for agent resolution.
+    /// - `credentials`: Credential lookup used to authenticate model requests.
+    /// - `workspace_root`: Project directory exposed to tools.
     pub fn new(
         runtime: Arc<AgentRuntime>,
         model_catalog: Arc<ModelCatalog>,
@@ -41,11 +58,120 @@ where
                 model_catalog,
                 credentials,
                 workspace_root,
+                #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+                bash_sandbox: None,
+                #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+                _sandbox_tmpdir: None,
             }),
         }
     }
 
+    /// Creates a shared build context with an explicitly-provided sandbox.
+    ///
+    /// Pass `sandbox_tmpdir` to tie the temp directory lifetime to this
+    /// context; omit it when the backing storage is managed elsewhere.
+    ///
+    /// # Arguments
+    /// - `runtime`: Shared agent runtime holding the catalog and defaults.
+    /// - `model_catalog`: Available models for agent resolution.
+    /// - `credentials`: Credential lookup used to authenticate model requests.
+    /// - `workspace_root`: Project directory exposed to tools.
+    /// - `profile`: Pre-built sandbox profile for [`BashTool`](crate::BashTool).
+    /// - `sandbox_tmpdir`: Optional owning temp directories that keep the
+    ///   profile's backing storage alive for the context's lifetime.
+    ///
+    /// # Platform
+    ///
+    /// Only available on Linux with the `linux-bubblewrap` feature enabled.
+    #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+    pub fn new_with_sandbox(
+        runtime: Arc<AgentRuntime>,
+        model_catalog: Arc<ModelCatalog>,
+        credentials: Arc<C>,
+        workspace_root: Arc<Path>,
+        profile: Arc<Profile>,
+        sandbox_tmpdir: Option<Arc<TempSandboxDirs>>,
+    ) -> Self {
+        Self {
+            context: Arc::new(TaskBuildContext::new_with_sandbox(
+                runtime,
+                model_catalog,
+                credentials,
+                workspace_root,
+                profile,
+                sandbox_tmpdir,
+            )),
+        }
+    }
+
+    /// Creates a shared build context with an auto-managed temp sandbox.
+    ///
+    /// Convenience wrapper that creates a [`TempSandboxDirs`] and builds a
+    /// sandbox profile from the given preset.
+    ///
+    /// # Arguments
+    /// - `runtime`: Shared agent runtime holding the catalog and defaults.
+    /// - `model_catalog`: Available models for agent resolution.
+    /// - `credentials`: Credential lookup used to authenticate model requests.
+    /// - `workspace_root`: Project directory exposed to tools.
+    /// - `preset`: Sandbox preset controlling mount layout and permissions.
+    ///
+    /// # Returns
+    /// - `Ok(`[`AgentBuildContext`]`)`: A shared context backed by the new
+    ///   sandbox.
+    ///
+    /// # Errors
+    /// - Returns [`CreateSandboxError::Dirs`] when the system temp directory or
+    ///   any subdirectory cannot be created.
+    /// - Returns [`CreateSandboxError::Unavailable`] when `bwrap` is not found
+    ///   on `PATH` or is otherwise unusable on the host.
+    /// - Returns [`CreateSandboxError::Profile`] when profile validation or
+    ///   assembly fails (e.g., invalid paths, missing host shell).
+    ///
+    /// # Platform
+    ///
+    /// Only available on Linux with the `linux-bubblewrap` feature enabled.
+    #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+    pub fn new_with_temp_sandbox(
+        runtime: Arc<AgentRuntime>,
+        model_catalog: Arc<ModelCatalog>,
+        credentials: Arc<C>,
+        workspace_root: Arc<Path>,
+        preset: Preset,
+    ) -> Result<Self, CreateSandboxError> {
+        let (profile, sandbox_tmpdir) =
+            llm_coding_tools_bubblewrap::create_temp_sandbox(&workspace_root, preset)?;
+        Ok(Self {
+            context: Arc::new(TaskBuildContext::new_with_sandbox(
+                runtime,
+                model_catalog,
+                credentials,
+                workspace_root,
+                profile,
+                Some(sandbox_tmpdir),
+            )),
+        })
+    }
+
     /// Builds a runnable SerdesAI agent for the named catalog entry.
+    ///
+    /// # Arguments
+    /// - `name`: Catalog entry name to build.
+    ///
+    /// # Returns
+    /// - `Ok(`[`Agent`]`)`: A fully constructed agent ready to run.
+    ///
+    /// # Errors
+    /// - Returns [`AgentBuildError::UnknownAgent`] when `name` is not in the
+    ///   runtime catalog.
+    /// - Returns [`AgentBuildError::ModelResolution`] when model configuration
+    ///   resolution or validation fails.
+    /// - Returns [`AgentBuildError::ModelInit`] when the SerdesAI model fails to
+    ///   initialise.
+    /// - Returns [`AgentBuildError::ToolSettingsValidation`] when tool settings
+    ///   validation fails during the build.
+    /// - Returns [`AgentBuildError::UnsupportedToolKind`] when the runtime
+    ///   contains a tool kind this adapter cannot materialise.
     #[inline]
     pub fn build(&self, name: &str) -> Result<Agent<(), String>, AgentBuildError> {
         build_agent(Arc::clone(&self.context), name, 0)
@@ -78,6 +204,10 @@ pub(crate) struct TaskBuildContext<C: CredentialLookup + Send + Sync + ?Sized = 
     model_catalog: Arc<ModelCatalog>,
     credentials: Arc<C>,
     workspace_root: Arc<Path>,
+    #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+    bash_sandbox: Option<Arc<Profile>>,
+    #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+    _sandbox_tmpdir: Option<Arc<TempSandboxDirs>>,
 }
 
 impl<C> TaskBuildContext<C>
@@ -88,6 +218,38 @@ where
     #[inline]
     pub(crate) fn runtime(&self) -> &AgentRuntime {
         self.runtime.as_ref()
+    }
+
+    /// Creates a task build context with an explicitly-provided sandbox.
+    ///
+    /// Pass `_sandbox_tmpdir` to tie the temp directory lifetime to this
+    /// context; omit it when the backing storage is managed elsewhere.
+    ///
+    /// # Arguments
+    /// - `runtime`: Shared agent runtime holding the catalog and defaults.
+    /// - `model_catalog`: Available models for agent resolution.
+    /// - `credentials`: Credential lookup used to authenticate model requests.
+    /// - `workspace_root`: Project directory exposed to tools.
+    /// - `bash_sandbox`: Pre-built sandbox profile for [`BashTool`](crate::BashTool).
+    /// - `_sandbox_tmpdir`: Optional owning temp directories that keep the
+    ///   profile's backing storage alive.
+    #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+    pub(crate) fn new_with_sandbox(
+        runtime: Arc<AgentRuntime>,
+        model_catalog: Arc<ModelCatalog>,
+        credentials: Arc<C>,
+        workspace_root: Arc<Path>,
+        bash_sandbox: Arc<Profile>,
+        _sandbox_tmpdir: Option<Arc<TempSandboxDirs>>,
+    ) -> Self {
+        Self {
+            runtime,
+            model_catalog,
+            credentials,
+            workspace_root,
+            bash_sandbox: Some(bash_sandbox),
+            _sandbox_tmpdir,
+        }
     }
 }
 
@@ -108,11 +270,36 @@ where
             model_catalog,
             credentials,
             workspace_root,
+            #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+            bash_sandbox: None,
+            #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+            _sandbox_tmpdir: None,
         }
     }
 }
 
 /// Builds one runnable agent using the shared build context.
+///
+/// # Arguments
+/// - `context`: Shared build context holding runtime, model catalog,
+///   credentials, workspace root, and optional sandbox.
+/// - `name`: Catalog entry name to build.
+/// - `current_depth`: Current Task delegation depth (0 for top-level calls).
+///
+/// # Returns
+/// - `Ok(`[`Agent`]`)`: A fully constructed agent ready to run.
+///
+/// # Errors
+/// - Returns [`AgentBuildError::UnknownAgent`] when `name` is not in the
+///   runtime catalog.
+/// - Returns [`AgentBuildError::ModelResolution`] when model configuration
+///   resolution or validation fails.
+/// - Returns [`AgentBuildError::ModelInit`] when the SerdesAI model fails to
+///   initialise.
+/// - Returns [`AgentBuildError::ToolSettingsValidation`] when tool settings
+///   validation fails during the build.
+/// - Returns [`AgentBuildError::UnsupportedToolKind`] when the runtime
+///   contains a tool kind this adapter cannot materialise.
 pub(crate) fn build_agent<C>(
     context: Arc<TaskBuildContext<C>>,
     name: &str,
@@ -121,10 +308,12 @@ pub(crate) fn build_agent<C>(
 where
     C: CredentialLookup + Send + Sync + 'static,
 {
+    // Check whether Task delegation summaries should be included at this depth.
     let with_summaries = context
         .runtime()
         .task_settings()
         .allows_delegation(current_depth);
+    // Resolve model, tools, and prompt from the runtime catalog.
     let prepared = prepare_build(
         context.runtime.as_ref(),
         name,
@@ -132,13 +321,22 @@ where
         context.credentials.as_ref(),
         with_summaries,
     )?;
+    // Create an AgentBuilder pre-loaded with the resolved model.
     let builder = AgentBuilder::<(), String>::from_arc(prepared.model().clone());
+    // Create a TaskHandle for delegation if Task tool is attached later.
     let task_handle = TaskHandle::new(context.clone(), current_depth);
+    // Select the sandbox profile (None on non-Linux or without the feature).
+    #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+    let sandbox_ref = context.bash_sandbox.as_ref();
+    #[cfg(not(all(feature = "linux-bubblewrap", target_os = "linux")))]
+    let sandbox_ref: Option<&Arc<Profile>> = None;
+    // Attach standard tools and build the system prompt.
     let (builder, prompt_builder) = attach_standard_tools(
         builder,
         &prepared,
         Some(&task_handle),
         &context.workspace_root,
+        sandbox_ref,
     )?;
     Ok(builder.system_prompt(prompt_builder.build()).build())
 }
@@ -257,6 +455,10 @@ mod tests {
             model_catalog,
             credentials,
             workspace_root: workspace_root(),
+            #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+            bash_sandbox: None,
+            #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+            _sandbox_tmpdir: None,
         });
 
         let agent = build_agent(context, "caller", 0).expect("build should succeed");
@@ -293,6 +495,10 @@ mod tests {
             model_catalog,
             credentials,
             workspace_root: workspace_root(),
+            #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+            bash_sandbox: None,
+            #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+            _sandbox_tmpdir: None,
         });
 
         let agent = build_agent(context, "caller", 0).expect("build should succeed");
@@ -328,6 +534,10 @@ mod tests {
             model_catalog,
             credentials,
             workspace_root: workspace_root(),
+            #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+            bash_sandbox: None,
+            #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+            _sandbox_tmpdir: None,
         });
 
         let agent = build_agent(context, "caller", 0).expect("build should succeed");
@@ -359,6 +569,10 @@ mod tests {
             model_catalog,
             credentials,
             workspace_root: workspace_root(),
+            #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+            bash_sandbox: None,
+            #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+            _sandbox_tmpdir: None,
         });
 
         let agent = build_agent(context, "caller", 0).expect("build should succeed");
@@ -427,6 +641,10 @@ mod tests {
             model_catalog,
             credentials,
             workspace_root: workspace_root(),
+            #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+            bash_sandbox: None,
+            #[cfg(all(feature = "linux-bubblewrap", target_os = "linux"))]
+            _sandbox_tmpdir: None,
         });
 
         let agent = build_agent(context, "caller", 1).expect("build should succeed");


### PR DESCRIPTION
## Summary

- Add bubblewrap sandbox factory module (`create_sandbox`, `create_sandbox_with`, `create_temp_sandbox`) with `SandboxDirs` (borrowed) and `TempSandboxDirs` (owned) directory layout types
- Wire sandbox profiles into the SerdesAI agent build pipeline so `BashTool` can run commands inside a bubblewrap sandbox when the `linux-bubblewrap` feature is enabled
- Add `AgentBuildContext::new_with_sandbox` and `new_with_temp_sandbox` constructors for creating agents with sandboxing; existing `new()` continues to run commands directly on the host

## Changed

- `llm-coding-tools-bubblewrap`: New `profile::factory` module with convenience constructors, `SandboxDirs<'a>`, `TempSandboxDirs`, and `CreateSandboxError`
- `llm-coding-tools-bubblewrap`: Added `tempfile` dependency; re-exported factory types from `lib.rs` and `profile/mod.rs`
- `llm-coding-tools-core`: Enabled default features on the bubblewrap dependency (so `default-sandbox` feature is available downstream)
- `llm-coding-tools-serdesai`: `attach_standard_tools` now accepts an optional `bash_sandbox` parameter; when provided, `BashTool` is configured with `with_linux_bwrap`
- `llm-coding-tools-serdesai`: `TaskBuildContext` and `AgentBuildContext` carry optional sandbox profile and temp-dir fields; all paths are `#[cfg]`-gated so non-Linux builds are unaffected