### PR TITLE
Changed: Unify dependency versions across workspace

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -9,6 +9,85 @@ members = [
     "llm-coding-tools-bubblewrap",
 ]
 
+[workspace.dependencies]
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = "0.9"
+bitcode = "0.6.9"
+bitflags = "2.11.0"
+
+# Error handling
+thiserror = "2.0"
+
+# Async/Runtime
+tokio = { version = "1.51", features = ["fs", "io-util", "process", "time"] }
+maybe-async = "0.2"
+async-trait = "0.1"
+futures = "0.3"
+
+# HTTP/Network
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "rustls-native-certs"] }
+html-to-markdown-rs = "3.1"
+
+# Filesystem/Path
+shellexpand = "3.1.2"
+soft-canonicalize = "0.5.5"
+dirs = "6"
+tempfile = "3.27"
+ignore = "0.4.25"
+
+# Data structures
+hashbrown = "0.17"
+indexmap = { version = "2", features = ["serde"] }
+tinyvec = { version = "1.11", features = ["alloc"] }
+lite-strtab = "0.2"
+ahash = { version = "0.8", features = ["serde"] }
+parking_lot = "0.12"
+
+# Bit operations
+bitfields = "1.0.3"
+
+# Grep/Glob tools
+globset = "0.4.18"
+grep-regex = "0.1.14"
+grep-searcher = "0.1.16"
+memchr = "2.8.0"
+
+# Process management
+process-wrap = { version = "9.1", default-features = false }
+
+# String formatting
+const_format = "0.2.35"
+crlf-to-lf-inplace = "0.2"
+
+# Schema/Validation
+schemars = "1.2"
+
+# Compression/Encoding
+zstd = "0.13.3"
+endian-writer = "2.2.0"
+endian-writer-derive = "0.1.0"
+
+# serdes-ai ecosystem
+serdes-ai = { version = "0.2.6", default-features = false }
+serdes-ai-models = { version = "0.2.6", default-features = false }
+serdes-ai-streaming = "0.2"
+
+# Internal crates
+llm-coding-tools-core = { version = "0.2.0", path = "llm-coding-tools-core" }
+llm-coding-tools-bubblewrap = { version = "0.1.0", path = "llm-coding-tools-bubblewrap" }
+llm-coding-tools-agents = { version = "0.1.0", path = "llm-coding-tools-agents" }
+llm-coding-tools-models-dev = { version = "0.1.0", path = "llm-coding-tools-models-dev" }
+
+# Dev dependencies
+criterion = "0.8"
+rstest = "0.26"
+serial_test = "3"
+wiremock = "0.6"
+indoc = "2"
+temp-env = "0.3.6"
+
 # Profile Build
 [profile.profile]
 inherits = "release"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -75,7 +75,7 @@ serdes-ai-models = { version = "0.2.6", default-features = false }
 serdes-ai-streaming = "0.2"
 
 # Internal crates
-llm-coding-tools-core = { version = "0.2.0", path = "llm-coding-tools-core" }
+llm-coding-tools-core = { version = "0.2.0", path = "llm-coding-tools-core", default-features = false }
 llm-coding-tools-bubblewrap = { version = "0.1.0", path = "llm-coding-tools-bubblewrap" }
 llm-coding-tools-agents = { version = "0.1.0", path = "llm-coding-tools-agents" }
 llm-coding-tools-models-dev = { version = "0.1.0", path = "llm-coding-tools-models-dev" }

--- a/src/llm-coding-tools-agents/Cargo.toml
+++ b/src/llm-coding-tools-agents/Cargo.toml
@@ -10,37 +10,36 @@ readme = "README.md"
 
 [dependencies]
 # YAML parsing for frontmatter
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
-serde_json = "1.0"
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+serde_json = { workspace = true }
 
 # Preserve insertion order for permission maps
-indexmap = { version = "2", features = ["serde"] }
+indexmap = { workspace = true }
 
 # Error handling
-thiserror = "2.0"
+thiserror = { workspace = true }
 
 # Fast CRLF to LF conversion
-crlf-to-lf-inplace = "0.2"
-
+crlf-to-lf-inplace = { workspace = true }
 
 # Directory scanning with gitignore support
-ignore = "0.4.25"
+ignore = { workspace = true }
 
 # High-performance hashing (sync version with core crate)
-ahash = { version = "0.8", features = ["serde"] }
+ahash = { workspace = true }
 
 # Core library for permissions and tool types
-llm-coding-tools-core = { path = "../llm-coding-tools-core", version = "0.2.0" }
+llm-coding-tools-core = { workspace = true }
 
 # Canonicalizes paths, resolving symlinks without requiring the full path to exist
-soft-canonicalize = "0.5"
+soft-canonicalize = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.27"
-criterion = "0.8"
-indoc = "2"
-rstest = "0.26"
+tempfile = { workspace = true }
+criterion = { workspace = true }
+indoc = { workspace = true }
+rstest = { workspace = true }
 
 [[bench]]
 name = "parser"

--- a/src/llm-coding-tools-agents/Cargo.toml
+++ b/src/llm-coding-tools-agents/Cargo.toml
@@ -30,7 +30,7 @@ ignore = { workspace = true }
 ahash = { workspace = true }
 
 # Core library for permissions and tool types
-llm-coding-tools-core = { workspace = true }
+llm-coding-tools-core = { workspace = true, features = ["tokio"] }
 
 # Canonicalizes paths, resolving symlinks without requiring the full path to exist
 soft-canonicalize = { workspace = true }

--- a/src/llm-coding-tools-agents/src/loader.rs
+++ b/src/llm-coding-tools-agents/src/loader.rs
@@ -82,7 +82,7 @@ impl AgentLoader {
     ///
     /// # Errors
     /// - Returns [`AgentLoadError::Io`] when the path exists but is not a directory.
-    ///   Walk errors (permissions, etc.) may be silently skipped by [`load_directory_with`]
+    ///   Walk errors (permissions, etc.) may be silently skipped by `load_directory_with`
     ///   and are not guaranteed to surface as [`AgentLoadError::Io`].
     pub fn add_directory(
         &self,
@@ -105,7 +105,7 @@ impl AgentLoader {
     ///
     /// # Errors
     /// - Returns [`AgentLoadError::Io`] when the path exists but is not a directory.
-    ///   Walk errors (permissions, etc.) may be silently skipped by [`load_directory_with`]
+    ///   Walk errors (permissions, etc.) may be silently skipped by `load_directory_with`
     ///   and are not guaranteed to surface as [`AgentLoadError::Io`].
     /// - Individual file parse/validation failures are reported via `on_error` and do not fail the operation.
     pub fn add_directory_with_errors(

--- a/src/llm-coding-tools-bubblewrap/Cargo.toml
+++ b/src/llm-coding-tools-bubblewrap/Cargo.toml
@@ -13,13 +13,13 @@ default = ["tokio"]
 tokio = ["dep:process-wrap", "process-wrap/tokio1", "process-wrap/process-group"]
 blocking = ["dep:process-wrap", "process-wrap/std", "process-wrap/process-group"]
 [dependencies]
-parking_lot = "0.12"
-thiserror = "2.0"
-process-wrap = { version = "9", default-features = false, optional = true }
-tempfile = "3.27"
+parking_lot = { workspace = true }
+thiserror = { workspace = true }
+process-wrap = { workspace = true, optional = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
-rstest = "0.26"
-serial_test = "3"
-tempfile = "3.27"
-tokio = { version = "1.51", features = ["rt", "macros"] }
+rstest = { workspace = true }
+serial_test = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/src/llm-coding-tools-bubblewrap/Cargo.toml
+++ b/src/llm-coding-tools-bubblewrap/Cargo.toml
@@ -21,5 +21,4 @@ tempfile = { workspace = true }
 [dev-dependencies]
 rstest = { workspace = true }
 serial_test = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/src/llm-coding-tools-core/Cargo.toml
+++ b/src/llm-coding-tools-core/Cargo.toml
@@ -38,84 +38,81 @@ linux-bubblewrap = ["dep:llm-coding-tools-bubblewrap"]
 
 [dependencies]
 # Tool outputs (BashOutput, GrepOutput, etc.) serialize to JSON for LLM consumption
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Zero overhead compile time bitflag generation
-bitflags = "2.11.0"
+bitflags = { workspace = true }
 
 # Shell-like expansion for home directory paths (~/ and $HOME/)
-shellexpand = "3.1.2"
+shellexpand = { workspace = true }
 
 # Cross-platform canonicalization for non-existent paths
-soft-canonicalize = "0.5.5"
+soft-canonicalize = { workspace = true }
 
 # Fast binary serialization for catalog cache types
-bitcode = "0.6.9"
+bitcode = { workspace = true }
 
 # Compile-time generated packed bitfield structs for model metadata
-bitfields = "1.0.3"
+bitfields = { workspace = true }
 
 # High-performance hashing for permission keys
-ahash = "0.8"
+ahash = { workspace = true }
 
 # Explicit low-level hash table for model catalog lookup
-hashbrown = "0.17"
+hashbrown = { workspace = true }
 
 # Inline vector storage for ProviderEnvVars
-tinyvec = { version = "1.11", features = ["alloc"] }
+tinyvec = { workspace = true }
 
 # Efficient immutable string table for provider URLs and env vars
-lite-strtab = "0.2"
+lite-strtab = { workspace = true }
 
 # ToolError type uses thiserror for ergonomic error definitions
-thiserror = "2.0"
+thiserror = { workspace = true }
 
 # Todo types derive JsonSchema for LLM tool parameter validation
-schemars = "1.2"
+schemars = { workspace = true }
 
 # Sync RwLock for TodoState (no tokio dependency)
-parking_lot = "0.12"
+parking_lot = { workspace = true }
 
 # Glob and grep tool implementations (aligned with ripgrep)
-globset = "0.4.18"       # Glob matching with ripgrep-optimized engine
-grep-regex = "0.1.14"    # Regex matcher for grep_search
-grep-searcher = "0.1.16" # File content searching for grep_search
-ignore = "0.4.25"        # Respects .gitignore when walking directories
-memchr = "2.8.0"         # Fast newline detection in read_file
+globset = { workspace = true }       # Glob matching with ripgrep-optimized engine
+grep-regex = { workspace = true }    # Regex matcher for grep_search
+grep-searcher = { workspace = true } # File content searching for grep_search
+ignore = { workspace = true }        # Respects .gitignore when walking directories
+memchr = { workspace = true }        # Fast newline detection in read_file
 
 # Webfetch tool converts HTML to markdown for LLM-friendly output
-html-to-markdown-rs = "3.1"
-reqwest = { version = "0.13", default-features = false, features = [
-    "rustls",
-    "rustls-native-certs",
-], optional = true }
+html-to-markdown-rs = { workspace = true }
+reqwest = { workspace = true, optional = true }
 
 # Unifies async/sync code via procedural macros
-maybe-async = "0.2"
+maybe-async = { workspace = true }
 
 # Async file I/O, process execution, and timeouts
-tokio = { version = "1.51", features = ["fs", "io-util", "process", "time"], optional = true }
+tokio = { workspace = true, optional = true }
 
 # Cross-platform process tree management (Job Objects on Windows, process groups on Unix)
-process-wrap = { version = "9.1", default-features = false }
+process-wrap = { workspace = true }
 # Compile-time string formatting for prompt text and parameter descriptions
-const_format = "0.2.35"
+const_format = { workspace = true }
 
 # Linux sandbox types and runtime
-llm-coding-tools-bubblewrap = { version = "0.1.0", path = "../llm-coding-tools-bubblewrap", optional = true }
+llm-coding-tools-bubblewrap = { workspace = true, optional = true }
 
 [dev-dependencies]
-serial_test = "3"
-tempfile = "3.27"
-dirs = "6"
+serial_test = { workspace = true }
+tempfile = { workspace = true }
+dirs = { workspace = true }
 # For tests (async and blocking with wiremock)
-tokio = { version = "1.51", features = ["rt-multi-thread", "macros"] }
-wiremock = "0.6"
-indoc = "2"
-criterion = "0.8"
-temp-env = "0.3.6"
-rstest = "0.26"
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+wiremock = { workspace = true }
+indoc = { workspace = true }
+criterion = { workspace = true }
+temp-env = { workspace = true }
+rstest = { workspace = true }
 
 [[bench]]
 name = "model_catalog_builder"

--- a/src/llm-coding-tools-core/src/fs/blocking_impl.rs
+++ b/src/llm-coding-tools-core/src/fs/blocking_impl.rs
@@ -8,6 +8,8 @@ use std::path::Path;
 /// # Errors
 /// - Returns [`ToolError::Io`] when the file cannot be read (e.g., file does not exist,
 ///   permission denied, or other I/O error).
+///
+/// [`ToolError::Io`]: crate::error::ToolError::Io
 pub fn read_to_string(path: impl AsRef<Path>) -> ToolResult<String> {
     Ok(std::fs::read_to_string(path)?)
 }
@@ -17,6 +19,8 @@ pub fn read_to_string(path: impl AsRef<Path>) -> ToolResult<String> {
 /// # Errors
 /// - Returns [`ToolError::Io`] when the file cannot be written (e.g., parent directory
 ///   does not exist, permission denied, or other I/O error).
+///
+/// [`ToolError::Io`]: crate::error::ToolError::Io
 pub fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> ToolResult<()> {
     Ok(std::fs::write(path, contents)?)
 }
@@ -26,6 +30,8 @@ pub fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> ToolResult<(
 /// # Errors
 /// - Returns [`ToolError::Io`] when the directory cannot be created (e.g., permission
 ///   denied or other I/O error).
+///
+/// [`ToolError::Io`]: crate::error::ToolError::Io
 pub fn create_dir_all(path: impl AsRef<Path>) -> ToolResult<()> {
     Ok(std::fs::create_dir_all(path)?)
 }
@@ -35,6 +41,8 @@ pub fn create_dir_all(path: impl AsRef<Path>) -> ToolResult<()> {
 /// # Errors
 /// - Returns [`ToolError::Io`] when the file cannot be opened (e.g., file does not exist,
 ///   permission denied, or other I/O error).
+///
+/// [`ToolError::Io`]: crate::error::ToolError::Io
 pub fn open_buffered(
     path: impl AsRef<Path>,
     capacity: usize,

--- a/src/llm-coding-tools-core/src/fs/tokio_impl.rs
+++ b/src/llm-coding-tools-core/src/fs/tokio_impl.rs
@@ -8,6 +8,8 @@ use std::path::Path;
 /// # Errors
 /// - Returns [`ToolError::Io`] when the file cannot be read (e.g., file does not exist,
 ///   permission denied, or other I/O error).
+///
+/// [`ToolError::Io`]: crate::error::ToolError::Io
 pub async fn read_to_string(path: impl AsRef<Path>) -> ToolResult<String> {
     Ok(tokio::fs::read_to_string(path).await?)
 }
@@ -17,6 +19,8 @@ pub async fn read_to_string(path: impl AsRef<Path>) -> ToolResult<String> {
 /// # Errors
 /// - Returns [`ToolError::Io`] when the file cannot be written (e.g., parent directory
 ///   does not exist, permission denied, or other I/O error).
+///
+/// [`ToolError::Io`]: crate::error::ToolError::Io
 pub async fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> ToolResult<()> {
     Ok(tokio::fs::write(path, contents).await?)
 }
@@ -26,6 +30,8 @@ pub async fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> ToolRe
 /// # Errors
 /// - Returns [`ToolError::Io`] when the directory cannot be created (e.g., permission
 ///   denied or other I/O error).
+///
+/// [`ToolError::Io`]: crate::error::ToolError::Io
 pub async fn create_dir_all(path: impl AsRef<Path>) -> ToolResult<()> {
     Ok(tokio::fs::create_dir_all(path).await?)
 }
@@ -35,6 +41,8 @@ pub async fn create_dir_all(path: impl AsRef<Path>) -> ToolResult<()> {
 /// # Errors
 /// - Returns [`ToolError::Io`] when the file cannot be opened (e.g., file does not exist,
 ///   permission denied, or other I/O error).
+///
+/// [`ToolError::Io`]: crate::error::ToolError::Io
 pub async fn open_buffered(
     path: impl AsRef<Path>,
     capacity: usize,

--- a/src/llm-coding-tools-models-dev/Cargo.toml
+++ b/src/llm-coding-tools-models-dev/Cargo.toml
@@ -24,44 +24,41 @@ blocking = [
 
 [dependencies]
 # Core library for ModelCatalog and related types
-llm-coding-tools-core = { path = "../llm-coding-tools-core", version = "0.2.0", default-features = false }
+llm-coding-tools-core = { workspace = true, default-features = false }
 
 # Cross-platform cache directory detection
-dirs = "6.0.0"
+dirs = { workspace = true }
 
 # HTTP client for conditional GET requests
-reqwest = { version = "0.13", default-features = false, features = [
-    "rustls",
-    "rustls-native-certs",
-], optional = true }
+reqwest = { workspace = true, optional = true }
 
 # Fast binary serialization
-bitcode = "0.6.9"
+bitcode = { workspace = true }
 
 # Compression for cache payload
-zstd = "0.13.3"
+zstd = { workspace = true }
 
 # Shared async/sync implementation for load/cache APIs
-maybe-async = "0.2"
+maybe-async = { workspace = true }
 
 # Endian-aware fixed-header serialization helpers
-endian-writer = "2.2.0"
-endian-writer-derive = "0.1.0"
+endian-writer = { workspace = true }
+endian-writer-derive = { workspace = true }
 
 # JSON parsing for models.dev API responses
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Ergonomic error definitions
-thiserror = "2.0.18"
+thiserror = { workspace = true }
 
 # Temp file with atomic rename support
-tempfile = "3.27"
+tempfile = { workspace = true }
 
 # Async runtime (when tokio feature enabled)
-tokio = { version = "1.51", features = ["fs", "io-util"], optional = true }
+tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.51", features = ["rt", "macros"] }
-serial_test = "3"
-rstest = "0.26"
+tokio = { workspace = true, features = ["rt", "macros"] }
+serial_test = { workspace = true }
+rstest = { workspace = true }

--- a/src/llm-coding-tools-models-dev/README.md
+++ b/src/llm-coding-tools-models-dev/README.md
@@ -8,7 +8,7 @@ for a cached fallback and caching via ETag(s).
 ## Why this exists
 
 If you run coding agents against many providers, you want to have fresh data.
-[models.dev][models.dev] is one such source of data.
+[models.dev][models.dev_link] is one such source of data.
 
 This crate downloads from models.dev, keeps only the fields we need, and
 builds a `llm_coding_tools_core::models::ModelCatalog`.
@@ -150,4 +150,5 @@ Exactly one runtime mode must be enabled.
 
 Apache-2.0
 
+[models.dev_link]: https://models.dev
 [models.dev]: https://models.dev

--- a/src/llm-coding-tools-models-dev/src/api/schema.rs
+++ b/src/llm-coding-tools-models-dev/src/api/schema.rs
@@ -90,6 +90,8 @@ pub(crate) struct ApiModelLimit {
 /// # Errors
 /// - Returns [`CatalogError::Json`] when `json_bytes` is not valid JSON or does not
 ///   match the expected models.dev API schema structure.
+///
+/// [`CatalogError::Json`]: crate::error::CatalogError::Json
 #[inline]
 pub(crate) fn parse_api_json(
     json_bytes: &[u8],

--- a/src/llm-coding-tools-models-dev/src/catalog/mod.rs
+++ b/src/llm-coding-tools-models-dev/src/catalog/mod.rs
@@ -75,6 +75,7 @@ impl ModelsDevCatalog {
     /// # if let Some(entry) = result.catalog.lookup("openai", "gpt-4") {
     /// #     println!("API URL: {}", entry.0.api_url);
     /// # }
+    /// # Ok(())
     /// # }
     /// ```
     ///

--- a/src/llm-coding-tools-serdesai/Cargo.toml
+++ b/src/llm-coding-tools-serdesai/Cargo.toml
@@ -51,50 +51,45 @@ linux-bubblewrap = [
 
 [dependencies]
 # Core tool operations (file read/write/edit, glob, grep, bash, etc.)
-llm-coding-tools-core = { version = "0.2.0", path = "../llm-coding-tools-core", features = [
-    "tokio",
-] }
+llm-coding-tools-core = { workspace = true, features = ["tokio"] }
 
 # Linux sandboxing via bubblewrap.
 # Provides sandbox profiles, presets, and sandbox availability detection.
-llm-coding-tools-bubblewrap = { version = "0.1.0", path = "../llm-coding-tools-bubblewrap", optional = true }
+llm-coding-tools-bubblewrap = { workspace = true, optional = true }
 
 # Generic agent runtime dependencies
-llm-coding-tools-agents = { version = "0.1.0", path = "../llm-coding-tools-agents" }
+llm-coding-tools-agents = { workspace = true }
 
 # serdes-ai provides Tool trait, ToolDefinition, RunContext
-serdes-ai = { version = "0.2.6", default-features = false }
-serdes-ai-models = { version = "0.2.6", default-features = false }
-serdes-ai-streaming = "0.2"
-futures = "0.3"
+serdes-ai = { workspace = true }
+serdes-ai-models = { workspace = true }
+serdes-ai-streaming = { workspace = true }
+futures = { workspace = true }
 
 # Tool trait is async - async-trait is NOT re-exported from serdes-ai
-async-trait = "0.1"
+async-trait = { workspace = true }
 
 # Error derives
-thiserror = "2.0"
+thiserror = { workspace = true }
 
 # Tool parameters use serde for deserialization, serde_json for schema
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # HTTP client for webfetch tool
-reqwest = { version = "0.13", default-features = false, features = [
-    "rustls",
-    "rustls-native-certs",
-] }
+reqwest = { workspace = true }
 
 # Used for IndexMap in build.rs (permission config)
-indexmap = "2"
+indexmap = { workspace = true }
 
 [dev-dependencies]
-serial_test = "3"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-tempfile = "3"
-wiremock = "0.6"
-ahash = "0.8"
-indexmap = "2"
-temp-env = "0.3.6"
-rstest = "0.26"
+serial_test = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tempfile = { workspace = true }
+wiremock = { workspace = true }
+ahash = { workspace = true }
+indexmap = { workspace = true }
+temp-env = { workspace = true }
+rstest = { workspace = true }
 # models.dev catalog loader for examples
-llm-coding-tools-models-dev = { version = "0.1.0", path = "../llm-coding-tools-models-dev" }
+llm-coding-tools-models-dev = { workspace = true }

--- a/src/llm-coding-tools-serdesai/src/convert.rs
+++ b/src/llm-coding-tools-serdesai/src/convert.rs
@@ -50,7 +50,9 @@ fn output_to_return(output: ToolOutput) -> ToolReturn {
 ///
 /// # Errors
 /// - Returns [`SerdesError`] when the core [`ToolResult`] contains a [`ToolError`],
-///   converted via [`core_error_to_serdes`].
+///   converted via `core_error_to_serdes`.
+///
+/// [`ToolError`]: llm_coding_tools_core::ToolError
 #[inline]
 pub fn to_serdes_result(
     tool_name: &str,


### PR DESCRIPTION
### Problem

Dependencies were declared independently in each crate's `Cargo.toml`, leading to version inconsistencies across the workspace:

| Dependency | Versions before |
|---|---|
| serde | `1.0`, `1.0.228` |
| serde_json | `1.0`, `1.0.145` |
| thiserror | `2.0`, `2.0.18` |
| tokio | `1.51`, `1` |
| tempfile | `3.27`, `3` |
| process-wrap | `9.1`, `9` |
| soft-canonicalize | `0.5.5`, `0.5` |
| dirs | `6`, `6.0.0` |

This made it easy for versions to drift apart over time, and required updating multiple files to bump a shared dependency.

### Solution

Add `[workspace.dependencies]` to the root `src/Cargo.toml` and convert all 5 crates to reference workspace deps via `workspace = true`.

**Root Cargo.toml** - 40+ shared dependencies defined once:
- Serialization: `serde`, `serde_json`, `serde_yaml`, `bitcode`, `bitflags`
- Async/Runtime: `tokio`, `maybe-async`, `async-trait`, `futures`
- HTTP: `reqwest`, `html-to-markdown-rs`
- Data structures: `hashbrown`, `indexmap`, `tinyvec`, `lite-strtab`, `ahash`, `parking_lot`
- Grep/Glob: `globset`, `grep-regex`, `grep-searcher`, `memchr`, `ignore`
- Process: `process-wrap`
- Internal crates: `llm-coding-tools-core`, `llm-coding-tools-bubblewrap`, `llm-coding-tools-agents`, `llm-coding-tools-models-dev`
- Dev: `criterion`, `rstest`, `serial_test`, `wiremock`, `indoc`, `temp-env`

**Per-crate Cargo.toml** - all version strings replaced with `workspace = true`; feature overrides preserved locally.

### Remaining duplicates (unavoidable)

Transitive duplicates from external crates (serdes-ai, AWS SDK) still exist in the lockfile — these are outside our control and would require upstream changes:
- `thiserror` v1 (serdes-ai) + v2 (our crates)
- `reqwest` v0.12 (serdes-ai) + v0.13 (our crates)
- `rustls` v0.21 (AWS SDK) + v0.23 (our crates)
- `hashbrown` v0.16 (html-to-markdown-rs) + v0.17 (our crates)

### Files changed

| File | Change |
|---|---|
| `src/Cargo.toml` | +79 lines — add `[workspace.dependencies]` |
| `src/llm-coding-tools-core/Cargo.toml` | Convert 23 deps to workspace |
| `src/llm-coding-tools-agents/Cargo.toml` | Convert 12 deps to workspace |
| `src/llm-coding-tools-models-dev/Cargo.toml` | Convert 14 deps to workspace |
| `src/llm-coding-tools-serdesai/Cargo.toml` | Convert 18 deps to workspace |
| `src/llm-coding-tools-bubblewrap/Cargo.toml` | Convert 6 deps to workspace |