### PR TITLE
fix(ci): remove unsupported docs-directory input from mkdocs workflow

### DIFF
--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Deploy MkDocs
         uses: Reloaded-Project/devops-mkdocs@v1
         with:
+          config-file: docs/mkdocs.yml
           requirements: ./docs/requirements.txt
           publish-to-pages: ${{ github.event_name == 'push' }}
           checkout-current-repo: true
-          docs-directory: docs


### PR DESCRIPTION
The `Reloaded-Project/devops-mkdocs@v1` action no longer accepts `docs-directory` as an input, causing CI to fail with exit code 2.

Changes:
- Remove `docs-directory: docs` (unsupported input)
- Add `config-file: docs/mkdocs.yml` so action finds the config file

The mkdocs config already specifies `docs_dir: src`, which MkDocs reads natively. No separate docs-directory input needed.

Fixes CI failure: https://github.com/Sewer56/llm-coding-tools/actions/runs/24905428630/job/72941300236