### PR TITLE
Bump bitfields from 1.0.3 to 3.0.0

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -582,21 +582,26 @@ dependencies = [
 
 [[package]]
 name = "bitfields"
-version = "1.0.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6e59298da389bc0649c7463856b34c6e17fe542f88939426ede4436c6b1195"
+checksum = "ca5a55e8cbc3b75d1f002a3b62261ab67954755f7e7866f079b8aa63a409b549"
 dependencies = [
  "bitfields-impl",
 ]
 
 [[package]]
 name = "bitfields-impl"
-version = "1.0.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c044f98f86f15414668d6c8187c7e4fadab1ad2b31680f648703e0fe07c555"
+checksum = "797cb6b6e8d5e8c2ecbb5ef52b7c273596d58ce1ab79ef2a6c38fa8dca0817c5"
 dependencies = [
+ "derive_more",
+ "getset",
  "proc-macro2",
  "quote",
+ "rustversion",
+ "strum",
+ "strum_macros",
  "syn",
  "thiserror 2.0.18",
 ]
@@ -849,6 +854,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1099,29 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1403,6 +1440,18 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2474,6 +2523,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3687,6 +3758,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4064,6 +4153,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -47,7 +47,7 @@ ahash = { version = "0.8", features = ["serde"] }
 parking_lot = "0.12"
 
 # Bit operations
-bitfields = "1.0.3"
+bitfields = "3.0.0"
 
 # Grep/Glob tools
 globset = "0.4.18"

--- a/src/reloaded-code-core/src/models/catalog/internal/packed_env_range.rs
+++ b/src/reloaded-code-core/src/models/catalog/internal/packed_env_range.rs
@@ -15,7 +15,7 @@ pub const MAX_ENV_START: u16 = (1u16 << 13) - 1; // 8191
 ///
 /// Stores (start, count) for env keys in the provider_env_keys StringTable.
 #[bitfield(u16)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(PartialEq, Eq, Hash)]
 pub struct PackedEnvRange {
     #[bits(13)]
     start: u16,

--- a/src/reloaded-code-core/src/models/catalog/internal/packed_model_entry.rs
+++ b/src/reloaded-code-core/src/models/catalog/internal/packed_model_entry.rs
@@ -24,7 +24,7 @@ const _: () = assert!(MODALITY_BITS + MAX_OUTPUT_BITS + MAX_INPUT_BITS == 64);
 
 /// Packed model metadata row.
 #[bitfield(u64)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(PartialEq, Eq, Hash)]
 pub struct PackedModelEntry {
     modalities: u8,
     #[bits(27)]

--- a/src/reloaded-code-core/src/models/catalog/internal/packed_provider_model_table_entry.rs
+++ b/src/reloaded-code-core/src/models/catalog/internal/packed_provider_model_table_entry.rs
@@ -21,7 +21,7 @@ const _: () = assert!(PROVIDER_MODEL_TABLE_HASH_BITS + 16 == 64);
 
 /// Packed provider-model-table entry.
 #[bitfield(u64)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(PartialEq, Eq, Hash)]
 pub struct PackedProviderModelTableEntry {
     #[bits(48)]
     hash48: u64,

--- a/src/reloaded-code-core/src/models/catalog/internal/packed_provider_table_entry.rs
+++ b/src/reloaded-code-core/src/models/catalog/internal/packed_provider_table_entry.rs
@@ -21,7 +21,7 @@ const _: () = assert!(PROVIDER_TABLE_HASH_BITS + 16 == 64);
 
 /// Packed provider-table entry.
 #[bitfield(u64)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(PartialEq, Eq, Hash)]
 pub struct PackedProviderTableEntry {
     #[bits(48)]
     hash48: u64,


### PR DESCRIPTION
Migrates the four packed entry structs in `reloaded-code-core` to the bitfields v3 API and closes the equivalent dependabot PR (#133).

`bitfields` v3 auto-derives `Clone` and `Copy` on the generated type, so the manual `#[derive(Clone, Copy, ...)]` lines on the four structs were dropped. `PartialEq`, `Eq`, and `Hash` are still added manually to preserve the public API surface (`PackedModelEntry` is used as an `AHashMap` key in `builder.rs`).

Verified locally with `bash src/.cargo/verify.sh` (build, test, clippy, docs all pass).